### PR TITLE
move config to internal type

### DIFF
--- a/cmd/healthcheck/healthcheck.go
+++ b/cmd/healthcheck/healthcheck.go
@@ -5,14 +5,10 @@ import (
 	"io/ioutil"
 
 	"github.com/ghodss/yaml"
-	"github.com/pkg/errors"
-	kerrors "k8s.io/apimachinery/pkg/util/errors"
-
 	"github.com/openshift/openshift-azure/pkg/api"
 	acsapi "github.com/openshift/openshift-azure/pkg/api"
-	"github.com/openshift/openshift-azure/pkg/api/v1"
 	"github.com/openshift/openshift-azure/pkg/plugin"
-	"github.com/openshift/openshift-azure/pkg/validate"
+	"github.com/pkg/errors"
 )
 
 // healthCheck should get rolled into the end of createorupdate once the sync
@@ -20,26 +16,17 @@ import (
 func healthCheck() error {
 	var p api.Plugin = &plugin.Plugin{}
 
-	b, err := ioutil.ReadFile("_data/manifest.yaml")
+	b, err := ioutil.ReadFile("_data/containerservice.yaml")
 	if err != nil {
 		return err
 	}
-	var ext *v1.OpenShiftCluster
-	err = yaml.Unmarshal(b, &ext)
+	var cs *acsapi.ContainerService
+	err = yaml.Unmarshal(b, &cs)
 	if err != nil {
-		return errors.Wrap(err, "cannot unmarshal _data/manifest.yaml")
-	}
-	if errs := validate.OpenShiftCluster(ext); len(errs) > 0 {
-		return errors.Wrap(kerrors.NewAggregate(errs), "cannot validate _data/manifest.yaml")
-	}
-	cs := acsapi.ConvertVLabsOpenShiftClusterToContainerService(ext)
-
-	configBytes, err := ioutil.ReadFile("_data/config.yaml")
-	if err != nil {
-		return errors.Wrap(err, "cannot read _data/config.yaml")
+		return errors.Wrap(err, "cannot unmarshal _data/containerservice.yaml")
 	}
 
-	return p.HealthCheck(context.Background(), cs, configBytes)
+	return p.HealthCheck(context.Background(), cs)
 }
 
 func main() {

--- a/cmd/healthcheck/healthcheck.go
+++ b/cmd/healthcheck/healthcheck.go
@@ -5,10 +5,11 @@ import (
 	"io/ioutil"
 
 	"github.com/ghodss/yaml"
+	"github.com/pkg/errors"
+
 	"github.com/openshift/openshift-azure/pkg/api"
 	acsapi "github.com/openshift/openshift-azure/pkg/api"
 	"github.com/openshift/openshift-azure/pkg/plugin"
-	"github.com/pkg/errors"
 )
 
 // healthCheck should get rolled into the end of createorupdate once the sync

--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -7,14 +7,9 @@ import (
 	"time"
 
 	"github.com/ghodss/yaml"
-	"github.com/pkg/errors"
-	kerrors "k8s.io/apimachinery/pkg/util/errors"
-
 	"github.com/openshift/openshift-azure/pkg/addons"
 	acsapi "github.com/openshift/openshift-azure/pkg/api"
-	"github.com/openshift/openshift-azure/pkg/api/v1"
-	"github.com/openshift/openshift-azure/pkg/config"
-	"github.com/openshift/openshift-azure/pkg/validate"
+	"github.com/pkg/errors"
 )
 
 var (
@@ -26,30 +21,17 @@ var (
 func sync() error {
 	log.Print("Sync process started!")
 
-	b, err := ioutil.ReadFile("_data/manifest.yaml")
+	b, err := ioutil.ReadFile("_data/containerservice.yaml")
 	if err != nil {
-		return errors.Wrap(err, "cannot read _data/manifest.yaml")
-	}
-	var ext *v1.OpenShiftCluster
-	if err := yaml.Unmarshal(b, &ext); err != nil {
-		return errors.Wrap(err, "cannot unmarshal _data/manifest.yaml")
-	}
-	if errs := validate.OpenShiftCluster(ext); len(errs) > 0 {
-		return errors.Wrap(kerrors.NewAggregate(errs), "cannot validate _data/manifest.yaml")
-	}
-	cs := acsapi.ConvertVLabsOpenShiftClusterToContainerService(ext)
-
-	b, err = ioutil.ReadFile("_data/config.yaml")
-	if err != nil {
-		return errors.Wrap(err, "cannot read _data/config.yaml")
+		return errors.Wrap(err, "cannot read _data/containerservice.yaml")
 	}
 
-	var c *config.Config
-	if err = yaml.Unmarshal(b, &c); err != nil {
-		return errors.Wrap(err, "cannot unmarshal _data/config.yaml")
+	var cs *acsapi.ContainerService
+	if err := yaml.Unmarshal(b, &cs); err != nil {
+		return errors.Wrap(err, "cannot unmarshal _data/containerservice.yaml")
 	}
 
-	if err := addons.Main(cs, c, *dryRun); err != nil {
+	if err := addons.Main(cs, *dryRun); err != nil {
 		return errors.Wrap(err, "cannot sync cluster config")
 	}
 

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -1,4 +1,4 @@
-package config
+package api
 
 import (
 	"crypto/rsa"

--- a/pkg/api/marshal.go
+++ b/pkg/api/marshal.go
@@ -1,4 +1,4 @@
-package config
+package api
 
 import (
 	"bytes"
@@ -138,7 +138,7 @@ func (c *Config) UnmarshalJSON(b []byte) error {
 
 			v.Field(i).Set(reflect.ValueOf(int(ii)))
 
-		case "config.CertificateConfig":
+		case "api.CertificateConfig":
 			// I don't know if this is the most efficient way to do this
 			data, err := yaml.Marshal(m[k])
 			if err != nil {

--- a/pkg/api/plugin.go
+++ b/pkg/api/plugin.go
@@ -19,9 +19,9 @@ type Plugin interface {
 	// ValidateInternal is called and that it makes sense to do this.
 	ValidateInternal(new, old *ContainerService) []error
 
-	GenerateConfig(cs *ContainerService, configBytes []byte) ([]byte, error)
+	GenerateConfig(cs *ContainerService) error
 
-	GenerateARM(cs *ContainerService, configBytes []byte) ([]byte, error)
+	GenerateARM(cs *ContainerService) ([]byte, error)
 
-	HealthCheck(ctx context.Context, cs *ContainerService, configBytes []byte) error
+	HealthCheck(ctx context.Context, cs *ContainerService) error
 }

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -26,6 +26,7 @@ type ContainerService struct {
 	Type     string                `json:"type"`
 
 	Properties *Properties `json:"properties,omitempty"`
+	Config     *Config     `json:config,omitempty`
 }
 
 // Properties represents the ACS cluster definition

--- a/pkg/arm/arm.go
+++ b/pkg/arm/arm.go
@@ -8,11 +8,10 @@ import (
 	"text/template"
 
 	acsapi "github.com/openshift/openshift-azure/pkg/api"
-	"github.com/openshift/openshift-azure/pkg/config"
 	"github.com/openshift/openshift-azure/pkg/util"
 )
 
-func Generate(m *acsapi.ContainerService, c *config.Config) ([]byte, error) {
+func Generate(m *acsapi.ContainerService) ([]byte, error) {
 	masterStartup, err := Asset("master-startup.sh")
 	if err != nil {
 		return nil, err
@@ -30,10 +29,10 @@ func Generate(m *acsapi.ContainerService, c *config.Config) ([]byte, error) {
 	return util.Template(string(tmpl), template.FuncMap{
 		"Startup": func(role acsapi.AgentPoolProfileRole) ([]byte, error) {
 			if role == acsapi.AgentPoolProfileRoleMaster {
-				return util.Template(string(masterStartup), nil, m, c, map[string]interface{}{"Role": role})
+				return util.Template(string(masterStartup), nil, m, map[string]interface{}{"Role": role})
 			} else {
-				return util.Template(string(nodeStartup), nil, m, c, map[string]interface{}{"Role": role})
+				return util.Template(string(nodeStartup), nil, m, map[string]interface{}{"Role": role})
 			}
 		},
-	}, m, c, nil)
+	}, m, nil)
 }

--- a/pkg/config/generate.go
+++ b/pkg/config/generate.go
@@ -19,7 +19,8 @@ import (
 	"github.com/openshift/openshift-azure/pkg/tls"
 )
 
-func selectNodeImage(cs *acsapi.ContainerService, c *Config) {
+func selectNodeImage(cs *acsapi.ContainerService) {
+	c := cs.Config
 	c.ImagePublisher = "redhat"
 	c.ImageOffer = "osa-preview"
 	c.ImageVersion = "latest"
@@ -40,7 +41,8 @@ func image(imageConfigFormat, component, version string) string {
 	return strings.Replace(image, "${version}", version, -1)
 }
 
-func selectContainerImagesOrigin(cs *acsapi.ContainerService, c *Config) {
+func selectContainerImagesOrigin(cs *acsapi.ContainerService) {
+	c := cs.Config
 	c.ImageConfigFormat = os.Getenv("OREG_URL")
 	if c.ImageConfigFormat == "" {
 		c.ImageConfigFormat = "docker.io/openshift/origin-${component}:${version}"
@@ -75,7 +77,8 @@ func selectContainerImagesOrigin(cs *acsapi.ContainerService, c *Config) {
 	}
 }
 
-func selectContainerImagesOSA(cs *acsapi.ContainerService, c *Config) {
+func selectContainerImagesOSA(cs *acsapi.ContainerService) {
+	c := cs.Config
 	c.ImageConfigFormat = os.Getenv("OREG_URL")
 	if c.ImageConfigFormat == "" {
 		c.ImageConfigFormat = "registry.access.redhat.com/openshift3/ose-${component}:${version}"
@@ -110,23 +113,24 @@ func selectContainerImagesOSA(cs *acsapi.ContainerService, c *Config) {
 	}
 }
 
-func selectContainerImages(cs *acsapi.ContainerService, c *Config) {
+func selectContainerImages(cs *acsapi.ContainerService) {
 	switch os.Getenv("DEPLOY_OS") {
 	case "":
-		selectContainerImagesOSA(cs, c)
+		selectContainerImagesOSA(cs)
 	case "centos7":
-		selectContainerImagesOrigin(cs, c)
+		selectContainerImagesOrigin(cs)
 	}
 }
 
-func Generate(cs *acsapi.ContainerService, c *Config) (err error) {
+func Generate(cs *acsapi.ContainerService) (err error) {
+	c := cs.Config
 	c.Version = versionLatest
 
 	// TODO: Need unique name, potentially derivative from PublicHostname
 	c.RouterLBCName = fmt.Sprintf("%s-router", strings.Split(cs.Properties.OrchestratorProfile.OpenShiftConfig.PublicHostname, ".")[1])
-	selectNodeImage(cs, c)
+	selectNodeImage(cs)
 
-	selectContainerImages(cs, c)
+	selectContainerImages(cs)
 
 	// Generate CAs
 	cas := []struct {

--- a/pkg/config/upgrade.go
+++ b/pkg/config/upgrade.go
@@ -8,6 +8,6 @@ const (
 	versionLatest = 1
 )
 
-func Upgrade(cs *acsapi.ContainerService, c *Config) error {
+func Upgrade(cs *acsapi.ContainerService) error {
 	return nil
 }

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -18,7 +18,6 @@ import (
 
 	acsapi "github.com/openshift/openshift-azure/pkg/api"
 	"github.com/openshift/openshift-azure/pkg/checks"
-	"github.com/openshift/openshift-azure/pkg/config"
 )
 
 // GetKubeconfigFromV1Config takes a v1 config and returns a kubeconfig
@@ -35,7 +34,8 @@ func getKubeconfigFromV1Config(kc *v1.Config) (clientcmd.ClientConfig, error) {
 }
 
 // HealthCheck function to verify cluster health
-func HealthCheck(ctx context.Context, cs *acsapi.ContainerService, c *config.Config) error {
+func HealthCheck(ctx context.Context, cs *acsapi.ContainerService) error {
+	c := cs.Config
 	kubeconfig, err := getKubeconfigFromV1Config(c.AdminKubeconfig)
 	if err != nil {
 		return err
@@ -68,10 +68,11 @@ func HealthCheck(ctx context.Context, cs *acsapi.ContainerService, c *config.Con
 	}
 
 	// Wait for the console to be 200 status
-	return waitForConsole(ctx, cs, c)
+	return waitForConsole(ctx, cs)
 }
 
-func waitForConsole(ctx context.Context, cs *acsapi.ContainerService, c *config.Config) error {
+func waitForConsole(ctx context.Context, cs *acsapi.ContainerService) error {
+	c := cs.Config
 	pool := x509.NewCertPool()
 	pool.AddCert(c.Certificates.Ca.Cert)
 

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -9,13 +9,12 @@ import (
 	"github.com/ghodss/yaml"
 
 	acsapi "github.com/openshift/openshift-azure/pkg/api"
-	"github.com/openshift/openshift-azure/pkg/config"
 	"github.com/openshift/openshift-azure/pkg/tls"
 )
 
 // TODO: util packages are an anti-pattern, don't do this
 
-func Template(tmpl string, f template.FuncMap, cs *acsapi.ContainerService, c *config.Config, extra interface{}) ([]byte, error) {
+func Template(tmpl string, f template.FuncMap, cs *acsapi.ContainerService, extra interface{}) ([]byte, error) {
 	t, err := template.New("").Funcs(template.FuncMap{
 		"CertAsBytes":          tls.CertAsBytes,
 		"PrivateKeyAsBytes":    tls.PrivateKeyAsBytes,
@@ -34,9 +33,9 @@ func Template(tmpl string, f template.FuncMap, cs *acsapi.ContainerService, c *c
 
 	err = t.Execute(b, struct {
 		ContainerService *acsapi.ContainerService
-		Config           *config.Config
+		Config           *acsapi.Config
 		Extra            interface{}
-	}{ContainerService: cs, Config: c, Extra: extra})
+	}{ContainerService: cs, Config: cs.Config, Extra: extra})
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Moves the config.Config type to the internal API type.  Persists a copy of the internal model and changes commands that expected an existing cluster (ones that read the manifest AND config) to use the persisted model.

@openshift/sig-azure 
@amanohar
