### PR TITLE
custom logger

### DIFF
--- a/cmd/createorupdate/createorupdate.go
+++ b/cmd/createorupdate/createorupdate.go
@@ -6,10 +6,9 @@ import (
 	"os"
 
 	"github.com/ghodss/yaml"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/errors"
 
-	"github.com/openshift/openshift-azure/pkg/api"
 	acsapi "github.com/openshift/openshift-azure/pkg/api"
 	"github.com/openshift/openshift-azure/pkg/api/v1"
 	"github.com/openshift/openshift-azure/pkg/plugin"
@@ -17,14 +16,13 @@ import (
 )
 
 // createOrUpdate simulates the RP
-func createOrUpdate(oc *v1.OpenShiftCluster) (*v1.OpenShiftCluster, error) {
+func createOrUpdate(oc *v1.OpenShiftCluster, log *logrus.Entry) (*v1.OpenShiftCluster, error) {
 	// instantiate the plugin
-	var p api.Plugin = &plugin.Plugin{}
+	p := plugin.NewPlugin(log)
 
 	// convert the external API manifest into the internal API representation
 	log.Info("convert to internal")
 	cs := acsapi.ConvertVLabsOpenShiftClusterToContainerService(oc)
-	log.Info("done")
 
 	// the RP will enrich the internal API representation with data not included
 	// in the original request
@@ -34,7 +32,6 @@ func createOrUpdate(oc *v1.OpenShiftCluster) (*v1.OpenShiftCluster, error) {
 	if err != nil {
 		return nil, err
 	}
-	log.Info("done")
 
 	// read in the OpenShift config blob if it exists (i.e. we're updating)
 	log.Info("read old config")
@@ -54,24 +51,19 @@ func createOrUpdate(oc *v1.OpenShiftCluster) (*v1.OpenShiftCluster, error) {
 			return nil, err
 		}
 	}
-	log.Info("done")
 
 	// validate the internal API representation (with reference to the previous
 	// internal API representation)
-	log.Info("validate internal")
 	errs := p.ValidateInternal(cs, oldCs)
 	if len(errs) > 0 {
 		return nil, errors.NewAggregate(errs)
 	}
-	log.Info("done")
 
 	// generate or update the OpenShift config blob
-	log.Info("generate config")
 	err = p.GenerateConfig(cs)
 	if err != nil {
 		return nil, err
 	}
-	log.Info("done")
 
 	// persist the OpenShift container service
 	log.Info("persist config")
@@ -83,7 +75,6 @@ func createOrUpdate(oc *v1.OpenShiftCluster) (*v1.OpenShiftCluster, error) {
 	if err != nil {
 		return nil, err
 	}
-	log.Info("done")
 
 	err = os.MkdirAll("_data/_out", 0777)
 	if err != nil {
@@ -91,12 +82,10 @@ func createOrUpdate(oc *v1.OpenShiftCluster) (*v1.OpenShiftCluster, error) {
 	}
 
 	// generate the ARM template
-	log.Info("generate arm")
 	azuredeploy, err := p.GenerateARM(cs)
 	if err != nil {
 		return nil, err
 	}
-	log.Info("done")
 
 	// persist the ARM template
 	log.Info("write arm")
@@ -104,7 +93,6 @@ func createOrUpdate(oc *v1.OpenShiftCluster) (*v1.OpenShiftCluster, error) {
 	if err != nil {
 		return nil, err
 	}
-	log.Info("done")
 
 	// write out development files
 	log.Info("write helpers")
@@ -112,7 +100,6 @@ func createOrUpdate(oc *v1.OpenShiftCluster) (*v1.OpenShiftCluster, error) {
 	if err != nil {
 		return nil, err
 	}
-	log.Info("done")
 
 	// convert our (probably changed) internal API representation back to the
 	// external API manifest to return it to the user
@@ -169,7 +156,9 @@ func writeHelpers(c *acsapi.Config) error {
 }
 
 func main() {
-	log.SetLevel(log.DebugLevel)
+	logger := logrus.New()
+	logger.SetLevel(logrus.DebugLevel)
+	log := logrus.NewEntry(logger)
 
 	// read in the external API manifest.
 	b, err := ioutil.ReadFile("_data/manifest.yaml")
@@ -183,7 +172,7 @@ func main() {
 	}
 
 	// simulate the API call to the RP
-	oc, err = createOrUpdate(oc)
+	oc, err = createOrUpdate(oc, log)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/cmd/healthcheck/healthcheck.go
+++ b/cmd/healthcheck/healthcheck.go
@@ -6,10 +6,9 @@ import (
 
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	kerrors "k8s.io/apimachinery/pkg/util/errors"
 
-	"github.com/openshift/openshift-azure/pkg/api"
 	acsapi "github.com/openshift/openshift-azure/pkg/api"
 	"github.com/openshift/openshift-azure/pkg/plugin"
 	"github.com/openshift/openshift-azure/pkg/validate"
@@ -18,7 +17,12 @@ import (
 // healthCheck should get rolled into the end of createorupdate once the sync
 // pod runs in the cluster
 func healthCheck() error {
-	var p api.Plugin = &plugin.Plugin{}
+	logger := logrus.New()
+	logger.SetLevel(logrus.DebugLevel)
+	log := logrus.NewEntry(logger)
+
+	// instantiate the plugin
+	p := plugin.NewPlugin(log)
 
 	b, err := ioutil.ReadFile("_data/containerservice.yaml")
 	if err != nil {
@@ -38,7 +42,6 @@ func healthCheck() error {
 }
 
 func main() {
-	log.SetLevel(log.DebugLevel)
 	if err := healthCheck(); err != nil {
 		panic(err)
 	}

--- a/pkg/addons/translate.go
+++ b/pkg/addons/translate.go
@@ -4,7 +4,6 @@ import (
 	"encoding/base64"
 
 	"github.com/ghodss/yaml"
-	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	"github.com/openshift/openshift-azure/pkg/jsonpath"
@@ -46,20 +45,20 @@ func Translate(o interface{}, path jsonpath.Path, nestedPath jsonpath.Path, nest
 	var nestedObject interface{}
 	err = yaml.Unmarshal(nestedBytes, &nestedObject)
 	if err != nil {
-		log.Fatal(err)
+		panic(err)
 	}
 
 	nestedPath.Set(nestedObject, v)
 
 	nestedBytes, err = yaml.Marshal(nestedObject)
 	if err != nil {
-		log.Fatal(err)
+		panic(err)
 	}
 
 	if nestedFlags&NestedFlagsBase64 != 0 {
 		nestedBytes = []byte(base64.StdEncoding.EncodeToString(nestedBytes))
 		if err != nil {
-			log.Fatal(err)
+			panic(err)
 		}
 	}
 

--- a/pkg/arm/arm.go
+++ b/pkg/arm/arm.go
@@ -7,11 +7,29 @@ package arm
 import (
 	"text/template"
 
+	"github.com/sirupsen/logrus"
+
 	acsapi "github.com/openshift/openshift-azure/pkg/api"
 	"github.com/openshift/openshift-azure/pkg/util"
 )
 
-func Generate(m *acsapi.ContainerService) ([]byte, error) {
+type Generator interface {
+	Generate(m *acsapi.ContainerService) ([]byte, error)
+}
+
+type simpleGenerator struct {
+	log *logrus.Entry
+}
+
+var _ Generator = &simpleGenerator{}
+
+func NewSimpleGenerator(log *logrus.Entry) Generator {
+	return &simpleGenerator{
+		log: log,
+	}
+}
+
+func (*simpleGenerator) Generate(m *acsapi.ContainerService) ([]byte, error) {
 	masterStartup, err := Asset("master-startup.sh")
 	if err != nil {
 		return nil, err

--- a/pkg/config/upgrade.go
+++ b/pkg/config/upgrade.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"github.com/sirupsen/logrus"
+
 	acsapi "github.com/openshift/openshift-azure/pkg/api"
 )
 
@@ -8,6 +10,22 @@ const (
 	versionLatest = 1
 )
 
-func Upgrade(cs *acsapi.ContainerService) error {
+type Upgrader interface {
+	Upgrade(cs *acsapi.ContainerService) error
+}
+
+type simpleUpgrader struct {
+	log *logrus.Entry
+}
+
+var _ Upgrader = &simpleUpgrader{}
+
+func NewSimpleUpgrader(log *logrus.Entry) Upgrader {
+	return &simpleUpgrader{
+		log: log,
+	}
+}
+
+func (u *simpleUpgrader) Upgrade(cs *acsapi.ContainerService) error {
 	return nil
 }

--- a/pkg/jsonpath/jsonpath.go
+++ b/pkg/jsonpath/jsonpath.go
@@ -6,7 +6,6 @@ package jsonpath
 import (
 	"bufio"
 	"bytes"
-	log "github.com/sirupsen/logrus"
 	"reflect"
 )
 
@@ -34,7 +33,7 @@ func Compile(s string) (Path, error) {
 func MustCompile(s string) Path {
 	p, err := Compile(s)
 	if err != nil {
-		log.Fatal(err)
+		panic(err)
 	}
 
 	return p

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -4,6 +4,8 @@ package plugin
 import (
 	"context"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/openshift/openshift-azure/pkg/api"
 	acsapi "github.com/openshift/openshift-azure/pkg/api"
 	"github.com/openshift/openshift-azure/pkg/arm"
@@ -12,21 +14,38 @@ import (
 	"github.com/openshift/openshift-azure/pkg/validate"
 )
 
-type Plugin struct{}
+type plugin struct {
+	log *logrus.Entry
+}
 
-var _ api.Plugin = &Plugin{}
+var _ api.Plugin = &plugin{}
 
-func (p *Plugin) ValidateInternal(new, old *acsapi.ContainerService) []error {
+func NewPlugin(log *logrus.Entry) api.Plugin {
+	// always have a logger
+	if log == nil {
+		logger := logrus.New()
+		log = logrus.NewEntry(logger)
+	}
+
+	return &plugin{
+		log: log,
+	}
+}
+
+func (p *plugin) ValidateInternal(new, old *acsapi.ContainerService) []error {
+	p.log.Info("validating internal data models")
 	return validate.ContainerService(new, old)
 }
 
-func (p *Plugin) GenerateConfig(cs *acsapi.ContainerService) error {
+func (p *plugin) GenerateConfig(cs *acsapi.ContainerService) error {
+	p.log.Info("generating configs")
 	// TODO should we save off the original config here and if there are any errors we can restore it?
 	if cs.Config == nil {
 		cs.Config = &acsapi.Config{}
 	}
 
-	err := config.Upgrade(cs)
+	upgrader := config.NewSimpleUpgrader(p.log)
+	err := upgrader.Upgrade(cs)
 	if err != nil {
 		return err
 	}
@@ -38,10 +57,14 @@ func (p *Plugin) GenerateConfig(cs *acsapi.ContainerService) error {
 	return nil
 }
 
-func (p *Plugin) GenerateARM(cs *acsapi.ContainerService) ([]byte, error) {
-	return arm.Generate(cs)
+func (p *plugin) GenerateARM(cs *acsapi.ContainerService) ([]byte, error) {
+	p.log.Info("generating arm templates")
+	generator := arm.NewSimpleGenerator(p.log)
+	return generator.Generate(cs)
 }
 
-func (p *Plugin) HealthCheck(ctx context.Context, cs *acsapi.ContainerService) error {
-	return healthcheck.HealthCheck(ctx, cs)
+func (p *plugin) HealthCheck(ctx context.Context, cs *acsapi.ContainerService) error {
+	p.log.Info("starting health check")
+	healthChecker := healthcheck.NewSimpleHealthChecker(p.log)
+	return healthChecker.HealthCheck(ctx, cs)
 }


### PR DESCRIPTION
update plugin to use custom logger, switch add on pieces that were static back to panics (like MustCompile), left other add on statements using logrus but expectation is that it will run in the pod so no custom logger support is there.

~~Not done: passing logger down to static impl methods that the plugin calls (example below).  Right now no logging is done there but we should add that.  When we do we will either pass the logger in the method signature (yuck) or move them to interface (`Generator`, etc) implementations so they can have state like the plugin.  If everyone is good with what is here now I think I'd like to go ahead and take care of moving them to have the logger available now so we don't forget later.~~  Edit: did it


@kargakis @mjudeikis @amanohar

```
func (p *plugin) GenerateARM(cs *acsapi.ContainerService) ([]byte, error) {
	return arm.Generate(cs)
}
```