### PR TITLE
Merge old and new config + validate updates

### DIFF
--- a/cmd/createorupdate/createorupdate.go
+++ b/cmd/createorupdate/createorupdate.go
@@ -74,6 +74,9 @@ func createOrUpdate(oc *v1.OpenShiftManagedCluster, entry *logrus.Entry) (*v1.Op
 		}
 	}
 
+	log.Info("merge old and new config")
+	p.MergeConfig(cs, oldCs)
+
 	// validate the internal API representation (with reference to the previous
 	// internal API representation)
 	// we set fqdn during enrichment which is slightly different than what the RP

--- a/pkg/api/plugin.go
+++ b/pkg/api/plugin.go
@@ -6,6 +6,13 @@ import (
 )
 
 type Plugin interface {
+	// MergeConfig merges new and old config so that no unnecessary config
+	// is going to get regenerated during generation. It also handles merging
+	// partial user requests to allow reusing the same validation code during
+	// upgrades. This method should be the first one called by the RP, before
+	// validation and generation.
+	MergeConfig(new, old *OpenShiftManagedCluster)
+
 	// Validate exists (a) to be able to place validation logic in a
 	// single place in the event of multiple external API versions, and (b) to
 	// be able to compare a new API manifest against a pre-existing API manifest
@@ -14,6 +21,8 @@ type Plugin interface {
 	// should be excluded.
 	Validate(new, old *OpenShiftManagedCluster, externalOnly bool) []error
 
+	// GenerateConfig ensures all the necessary in-cluster config is generated
+	// for an Openshift cluster.
 	GenerateConfig(cs *OpenShiftManagedCluster) error
 
 	GenerateARM(cs *OpenShiftManagedCluster) ([]byte, error)

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -33,6 +33,34 @@ func NewPlugin(entry *logrus.Entry) api.Plugin {
 	}
 }
 
+func (p *plugin) MergeConfig(cs, oldCs *acsapi.OpenShiftManagedCluster) {
+	if oldCs == nil {
+		return
+	}
+	log.Info("merging internal data models")
+
+	// generated config should be copied as is
+	cs.Config = oldCs.Config
+
+	// user request data
+	// need to merge partial requests
+	if len(cs.Properties.AgentPoolProfiles) == 0 {
+		cs.Properties.AgentPoolProfiles = oldCs.Properties.AgentPoolProfiles
+	}
+	if cs.Properties.OrchestratorProfile == nil {
+		cs.Properties.OrchestratorProfile = oldCs.Properties.OrchestratorProfile
+	}
+	if len(cs.Properties.OrchestratorProfile.OrchestratorVersion) == 0 {
+		cs.Properties.OrchestratorProfile.OrchestratorVersion = oldCs.Properties.OrchestratorProfile.OrchestratorVersion
+	}
+	if cs.Properties.OrchestratorProfile.OpenShiftConfig == nil {
+		cs.Properties.OrchestratorProfile.OpenShiftConfig = oldCs.Properties.OrchestratorProfile.OpenShiftConfig
+	}
+	if len(cs.Properties.FQDN) == 0 {
+		cs.Properties.FQDN = oldCs.Properties.FQDN
+	}
+}
+
 func (p *plugin) Validate(new, old *acsapi.OpenShiftManagedCluster, externalOnly bool) []error {
 	log.Info("validating internal data models")
 	return validate.Validate(new, old, externalOnly)


### PR DESCRIPTION
@openshift/sig-azure ptal

@pweil- comments on the merging<->validation order: 
1. we need to merge the old cs.Config into the new and hand that over to GenerateConfig (so there is no merging of the user request but of the generated config). 
2. validation only happens on the user request and not on generated config. 
3. In the close future, we probably want to add validation for updates and likely invalidate every request that causes a difference in fqdn, resourceGroup, and location. If we are going to merge user requests prior to validation, we will not be able to validate updates.  

Based on the above I don't see what merging gives us prior to validation (since the merged part is unaffected by validation) and I prefer to avoid the extra method in the plugin interface so I just opted on extending GenerateConfig. Thoughts?

cc @amanohar 