### PR TITLE
Updating since origin sku was removed.

### DIFF
--- a/pkg/config/generate.go
+++ b/pkg/config/generate.go
@@ -29,7 +29,7 @@ func selectNodeImage(cs *acsapi.ContainerService) {
 	case "":
 		c.ImageSKU = "osa_" + strings.Replace(cs.Properties.OrchestratorProfile.OrchestratorVersion[1:], ".", "", -1)
 	case "centos7":
-		c.ImageSKU = "origin_" + strings.Replace(cs.Properties.OrchestratorProfile.OrchestratorVersion[1:], ".", "", -1)
+		c.ImageSKU = "okd_" + strings.Replace(cs.Properties.OrchestratorProfile.OrchestratorVersion[1:], ".", "", -1)
 	}
 
 	c.ImageResourceGroup = os.Getenv("IMAGE_RESOURCEGROUP")


### PR DESCRIPTION
This modifies the base sku name since origin_ was removed by our automated tools.

I ran into this error until I updated:

```
msrest.http_logger : {"error":{"code":"MarketplacePurchaseEligibilityFailed","message":"Marketplace purchase eligibilty check returned errors. See inner errors for details. ","details":[{"code":"BadRequest","message":"Offer with PublisherId: redhat, OfferId: osa-preview cannot be purchased due to validation errors. See details for more information.
...
```