### PR TITLE
Add external only flag to validation

### DIFF
--- a/cmd/createorupdate/createorupdate.go
+++ b/cmd/createorupdate/createorupdate.go
@@ -55,7 +55,9 @@ func createOrUpdate(oc *v1.OpenShiftManagedCluster, entry *logrus.Entry) (*v1.Op
 
 	// validate the internal API representation (with reference to the previous
 	// internal API representation)
-	errs := p.Validate(cs, oldCs)
+	// we set fqdn during enrichment which is slightly different than what the RP
+	// will do so we are only validating once.
+	errs := p.Validate(cs, oldCs, false)
 	if len(errs) > 0 {
 		return nil, errors.NewAggregate(errs)
 	}

--- a/cmd/createorupdate/createorupdate.go
+++ b/cmd/createorupdate/createorupdate.go
@@ -55,7 +55,7 @@ func createOrUpdate(oc *v1.OpenShiftManagedCluster, entry *logrus.Entry) (*v1.Op
 
 	// validate the internal API representation (with reference to the previous
 	// internal API representation)
-	errs := p.ValidateInternal(cs, oldCs)
+	errs := p.Validate(cs, oldCs)
 	if len(errs) > 0 {
 		return nil, errors.NewAggregate(errs)
 	}

--- a/cmd/healthcheck/healthcheck.go
+++ b/cmd/healthcheck/healthcheck.go
@@ -37,7 +37,7 @@ func healthCheck() error {
 		return errors.Wrap(err, "cannot unmarshal _data/containerservice.yaml")
 	}
 
-	if errs := validate.ContainerService(cs, nil); len(errs) > 0 {
+	if errs := validate.Validate(cs, nil, false); len(errs) > 0 {
 		return errors.Wrap(kerrors.NewAggregate(errs), "cannot validate _data/containerservice.yaml")
 	}
 

--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -34,7 +34,7 @@ func sync() error {
 		return errors.Wrap(err, "cannot unmarshal _data/containerservice.yaml")
 	}
 
-	if errs := validate.ContainerService(cs, nil); len(errs) > 0 {
+	if errs := validate.Validate(cs, nil, false); len(errs) > 0 {
 		return errors.Wrap(kerrors.NewAggregate(errs), "cannot validate _data/manifest.yaml")
 	}
 

--- a/pkg/api/plugin.go
+++ b/pkg/api/plugin.go
@@ -6,14 +6,11 @@ import (
 )
 
 type Plugin interface {
-	// ValidateInternal exists (a) to be able to place validation logic in a
+	// Validate exists (a) to be able to place validation logic in a
 	// single place in the event of multiple external API versions, and (b) to
 	// be able to compare a new API manifest against a pre-existing API manifest
 	// (for update, upgrade, etc.)
-
-	// TODO: confirm with MSFT that they can pass in `old` at the time
-	// ValidateInternal is called and that it makes sense to do this.
-	ValidateInternal(new, old *OpenShiftManagedCluster) []error
+	Validate(new, old *OpenShiftManagedCluster) []error
 
 	GenerateConfig(cs *OpenShiftManagedCluster) error
 

--- a/pkg/api/plugin.go
+++ b/pkg/api/plugin.go
@@ -10,7 +10,9 @@ type Plugin interface {
 	// single place in the event of multiple external API versions, and (b) to
 	// be able to compare a new API manifest against a pre-existing API manifest
 	// (for update, upgrade, etc.)
-	Validate(new, old *OpenShiftManagedCluster) []error
+	// externalOnly indicates that fields set by the RP (FQDN and routerProfile.FQDN)
+	// should be excluded.
+	Validate(new, old *OpenShiftManagedCluster, externalOnly bool) []error
 
 	GenerateConfig(cs *OpenShiftManagedCluster) error
 

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -33,7 +33,7 @@ func NewPlugin(entry *logrus.Entry) api.Plugin {
 	}
 }
 
-func (p *plugin) ValidateInternal(new, old *acsapi.OpenShiftManagedCluster) []error {
+func (p *plugin) Validate(new, old *acsapi.OpenShiftManagedCluster) []error {
 	log.Info("validating internal data models")
 	return validate.ContainerService(new, old)
 }

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -33,9 +33,9 @@ func NewPlugin(entry *logrus.Entry) api.Plugin {
 	}
 }
 
-func (p *plugin) Validate(new, old *acsapi.OpenShiftManagedCluster) []error {
+func (p *plugin) Validate(new, old *acsapi.OpenShiftManagedCluster, externalOnly bool) []error {
 	log.Info("validating internal data models")
-	return validate.ContainerService(new, old)
+	return validate.Validate(new, old, externalOnly)
 }
 
 func (p *plugin) GenerateConfig(cs *acsapi.OpenShiftManagedCluster) error {


### PR DESCRIPTION
Skips validation for post-enrichment items like FQDN and routerProfile.FQDN

Fixes: https://github.com/openshift/openshift-azure/issues/209

@jim-minter  @amanohar @shrutir25