### PR TITLE
add tag for purge jobs

### DIFF
--- a/hack/create.sh
+++ b/hack/create.sh
@@ -34,7 +34,7 @@ export RESOURCEGROUP=$1
 rm -rf _data
 mkdir -p _data/_out
 
-az group create -n $RESOURCEGROUP -l eastus >/dev/null
+az group create -n $RESOURCEGROUP -l eastus --tags now=$(date +%s) >/dev/null
 
 if [[ -z "$AZURE_CLIENT_ID" ]]; then
     set +x


### PR DESCRIPTION
Ci operator uses create.sh to create cluster. 
Purge uses `tag` to clean them. 

I would suggest to add this tag to our projects so we relay under same purge job rules:
`groupTimeout   = 3 * 24 * time.Hour`
This implied each cluster will be deleted after 3 days of creation. If you want cluster for longer time - remote the tag, or change the value.