### PR TITLE
Property bag/Context

### DIFF
--- a/cmd/createorupdate/update.go
+++ b/cmd/createorupdate/update.go
@@ -11,8 +11,9 @@ import (
 	"github.com/openshift/openshift-azure/pkg/log"
 )
 
-func update(cs *api.OpenShiftManagedCluster, p api.Plugin) error {
-	authorizer, err := auth.NewAuthorizerFromEnvironment()
+func update(ctx context.Context, cs *api.OpenShiftManagedCluster, p api.Plugin) error {
+	config := auth.NewClientCredentialsConfig(ctx.Value(api.ContextKeyClientID).(string), ctx.Value(api.ContextKeyClientSecret).(string), ctx.Value(api.ContextKeyTennantID).(string))
+	authorizer, err := config.Authorizer()
 	if err != nil {
 		return err
 	}
@@ -21,8 +22,6 @@ func update(cs *api.OpenShiftManagedCluster, p api.Plugin) error {
 	ssc.Authorizer = authorizer
 	vmc := compute.NewVirtualMachineScaleSetVMsClient(cs.Properties.AzProfile.SubscriptionID)
 	vmc.Authorizer = authorizer
-
-	ctx := context.Background()
 
 	err = updateInPlace(ctx, cs, p, ssc, vmc, api.AgentPoolProfileRoleMaster)
 	if err != nil {

--- a/pkg/api/plugin.go
+++ b/pkg/api/plugin.go
@@ -11,7 +11,7 @@ type Plugin interface {
 	// partial user requests to allow reusing the same validation code during
 	// upgrades. This method should be the first one called by the RP, before
 	// validation and generation.
-	MergeConfig(new, old *OpenShiftManagedCluster)
+	MergeConfig(ctx context.Context, new, old *OpenShiftManagedCluster)
 
 	// Validate exists (a) to be able to place validation logic in a
 	// single place in the event of multiple external API versions, and (b) to
@@ -19,13 +19,13 @@ type Plugin interface {
 	// (for update, upgrade, etc.)
 	// externalOnly indicates that fields set by the RP (FQDN and routerProfile.FQDN)
 	// should be excluded.
-	Validate(new, old *OpenShiftManagedCluster, externalOnly bool) []error
+	Validate(ctx context.Context, new, old *OpenShiftManagedCluster, externalOnly bool) []error
 
 	// GenerateConfig ensures all the necessary in-cluster config is generated
 	// for an Openshift cluster.
-	GenerateConfig(cs *OpenShiftManagedCluster) error
+	GenerateConfig(ctx context.Context, cs *OpenShiftManagedCluster) error
 
-	GenerateARM(cs *OpenShiftManagedCluster) ([]byte, error)
+	GenerateARM(ctx context.Context, cs *OpenShiftManagedCluster) ([]byte, error)
 
 	InitializeCluster(ctx context.Context, cs *OpenShiftManagedCluster) error
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1,5 +1,16 @@
 package api
 
+// ContextKey is a type for context property bag payload keys
+type ContextKey string
+
+const (
+	ContextKeyClientID       ContextKey = "ClientID"
+	ContextKeyClientSecret   ContextKey = "ClientSecret"
+	ContextKeyTennantID      ContextKey = "TenantID"
+	ContextKeySubscriptionId ContextKey = "SubscriptionId"
+	ContextKeyResourceGroup  ContextKey = "ResourceGroup"
+)
+
 // TypeMeta describes an individual API model object
 type TypeMeta struct {
 	// APIVersion is on every object

--- a/pkg/arm/arm.go
+++ b/pkg/arm/arm.go
@@ -5,6 +5,7 @@ package arm
 //go:generate gofmt -s -l -w bindata.go
 
 import (
+	"context"
 	"text/template"
 
 	"github.com/sirupsen/logrus"
@@ -15,7 +16,7 @@ import (
 )
 
 type Generator interface {
-	Generate(m *acsapi.OpenShiftManagedCluster) ([]byte, error)
+	Generate(ctx context.Context, m *acsapi.OpenShiftManagedCluster) ([]byte, error)
 }
 
 type simpleGenerator struct{}
@@ -27,7 +28,7 @@ func NewSimpleGenerator(entry *logrus.Entry) Generator {
 	return &simpleGenerator{}
 }
 
-func (*simpleGenerator) Generate(m *acsapi.OpenShiftManagedCluster) ([]byte, error) {
+func (*simpleGenerator) Generate(ctx context.Context, m *acsapi.OpenShiftManagedCluster) ([]byte, error) {
 	masterStartup, err := Asset("master-startup.sh")
 	if err != nil {
 		return nil, err

--- a/pkg/config/upgrade.go
+++ b/pkg/config/upgrade.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"context"
+
 	"github.com/sirupsen/logrus"
 
 	acsapi "github.com/openshift/openshift-azure/pkg/api"
@@ -12,12 +14,10 @@ const (
 )
 
 type Upgrader interface {
-	Upgrade(cs *acsapi.OpenShiftManagedCluster) error
+	Upgrade(ctx context.Context, cs *acsapi.OpenShiftManagedCluster) error
 }
 
-type simpleUpgrader struct {
-	log *logrus.Entry
-}
+type simpleUpgrader struct{}
 
 var _ Upgrader = &simpleUpgrader{}
 
@@ -26,6 +26,6 @@ func NewSimpleUpgrader(entry *logrus.Entry) Upgrader {
 	return &simpleUpgrader{}
 }
 
-func (u *simpleUpgrader) Upgrade(cs *acsapi.OpenShiftManagedCluster) error {
+func (u *simpleUpgrader) Upgrade(ctx context.Context, cs *acsapi.OpenShiftManagedCluster) error {
 	return nil
 }

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -30,7 +30,7 @@ func NewPlugin(entry *logrus.Entry) api.Plugin {
 	}
 }
 
-func (p *plugin) MergeConfig(cs, oldCs *acsapi.OpenShiftManagedCluster) {
+func (p *plugin) MergeConfig(ctx context.Context, cs, oldCs *acsapi.OpenShiftManagedCluster) {
 	if oldCs == nil {
 		return
 	}
@@ -58,12 +58,12 @@ func (p *plugin) MergeConfig(cs, oldCs *acsapi.OpenShiftManagedCluster) {
 	}
 }
 
-func (p *plugin) Validate(new, old *acsapi.OpenShiftManagedCluster, externalOnly bool) []error {
+func (p *plugin) Validate(ctx context.Context, new, old *acsapi.OpenShiftManagedCluster, externalOnly bool) []error {
 	log.Info("validating internal data models")
 	return validate.Validate(new, old, externalOnly)
 }
 
-func (p *plugin) GenerateConfig(cs *acsapi.OpenShiftManagedCluster) error {
+func (p *plugin) GenerateConfig(ctx context.Context, cs *acsapi.OpenShiftManagedCluster) error {
 	log.Info("generating configs")
 	// TODO should we save off the original config here and if there are any errors we can restore it?
 	if cs.Config == nil {
@@ -71,7 +71,7 @@ func (p *plugin) GenerateConfig(cs *acsapi.OpenShiftManagedCluster) error {
 	}
 
 	upgrader := config.NewSimpleUpgrader(p.entry)
-	err := upgrader.Upgrade(cs)
+	err := upgrader.Upgrade(ctx, cs)
 	if err != nil {
 		return err
 	}
@@ -83,10 +83,10 @@ func (p *plugin) GenerateConfig(cs *acsapi.OpenShiftManagedCluster) error {
 	return nil
 }
 
-func (p *plugin) GenerateARM(cs *acsapi.OpenShiftManagedCluster) ([]byte, error) {
+func (p *plugin) GenerateARM(ctx context.Context, cs *acsapi.OpenShiftManagedCluster) ([]byte, error) {
 	log.Info("generating arm templates")
 	generator := arm.NewSimpleGenerator(p.entry)
-	return generator.Generate(cs)
+	return generator.Generate(ctx, cs)
 }
 
 func (p *plugin) InitializeCluster(ctx context.Context, cs *acsapi.OpenShiftManagedCluster) error {

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -1,6 +1,7 @@
 package plugin
 
 import (
+	"context"
 	"testing"
 
 	"github.com/davecgh/go-spew/spew"
@@ -25,7 +26,7 @@ func TestMerge(t *testing.T) {
 
 	// should fix all of the items removed above and we should
 	// be able to run through the entire plugin process.
-	p.MergeConfig(newCluster, oldCluster)
+	p.MergeConfig(context.Background(), newCluster, oldCluster)
 
 	if newCluster.Config == nil {
 		t.Errorf("new cluster config should be merged")
@@ -44,15 +45,15 @@ func TestMerge(t *testing.T) {
 }
 
 func testPluginRun(p api.Plugin, newCluster *api.OpenShiftManagedCluster, oldCluster *api.OpenShiftManagedCluster, t *testing.T) {
-	if errs := p.Validate(newCluster, oldCluster, false); len(errs) != 0 {
+	if errs := p.Validate(context.Background(), newCluster, oldCluster, false); len(errs) != 0 {
 		t.Fatalf("error validating: %s", spew.Sdump(errs))
 	}
 
-	if err := p.GenerateConfig(newCluster); err != nil {
+	if err := p.GenerateConfig(context.Background(), newCluster); err != nil {
 		t.Fatalf("error generating config for arm generate test: %s", spew.Sdump(err))
 	}
 
-	bytes, err := p.GenerateARM(newCluster)
+	bytes, err := p.GenerateARM(context.Background(), newCluster)
 	if err != nil {
 		t.Fatalf("error generating arm: %s", spew.Sdump(err))
 	}


### PR DESCRIPTION
Suggestion to start using Context with all external methods we have. Some of them at the moment does not have use for context,  but I added ctx object too just to keep consistent api. 

The external consumer should not care about how context is being used. And by introducing it early we can use it later. 

At the moment context flow:
`createorUpdate` -> `plugin`-> `GenerateARM` -> `arm.Generator`
`createorUpdate` -> `plugin`-> `MergeConfig` 
`createorUpdate` -> `plugin`-> `Validate` 
`createorUpdate` -> `plugin`-> `GenerateConfig`
`createorUpdate` -> `plugin`-> `InitializeCluster` -> `intitialize.Initializer`
`createorUpdate` -> `plugin`-> `HealthCheck` -> `healthcheck.Healthchecker`
`createorUpdate` -> `plugin`-> `Drain` -> `upgrade.Upgrader`
`createorUpdate` -> `plugin`-> `WaitForReady` -> `upgrade.Upgrader`

I would keep the api consistent state for all plugin methods, and as per needs in secondary packages. 