### PR TITLE
add health check logging

### DIFF
--- a/pkg/checks/checks.go
+++ b/pkg/checks/checks.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/openshift/openshift-azure/pkg/log"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -72,6 +73,7 @@ func checkNamespace(namespace string) bool {
 
 // WaitForInfraServices verify daemonsets, statefulsets
 func WaitForInfraServices(ctx context.Context, appclient *appclient.AppsV1Client) error {
+	log.Info("checking infrastructure service health")
 out:
 	for {
 		_, err := appclient.Deployments("openshift-web-console").Get("webconsole", metav1.GetOptions{})
@@ -99,6 +101,7 @@ out:
 		if !checkNamespace(ds.Namespace) {
 			continue
 		}
+		log.Info(fmt.Sprintf("checking %s %q", ds.Kind, ds.Name))
 		for {
 			ds, err := appclient.DaemonSets(ds.Namespace).Get(ds.Name, metav1.GetOptions{})
 			if err != nil {
@@ -132,6 +135,7 @@ out:
 		if !checkNamespace(ss.Namespace) {
 			continue
 		}
+		log.Info(fmt.Sprintf("checking %s %q", ss.Kind, ss.Name))
 		for {
 			ss, err := appclient.StatefulSets(ss.Namespace).Get(ss.Name, metav1.GetOptions{})
 			if err != nil {
@@ -162,6 +166,7 @@ out:
 		if !checkNamespace(d.Namespace) {
 			continue
 		}
+		log.Info(fmt.Sprintf("checking %s %q", d.Kind, d.Name))
 		for {
 			d, err := appclient.Deployments(d.Namespace).Get(d.Name, metav1.GetOptions{})
 			if err != nil {
@@ -183,5 +188,6 @@ out:
 		}
 	}
 
+	log.Info("done checking infrastructure service health")
 	return nil
 }

--- a/pkg/healthcheck/healthcheck.go
+++ b/pkg/healthcheck/healthcheck.go
@@ -67,6 +67,7 @@ func (hc *simpleHealthChecker) HealthCheck(ctx context.Context, cs *acsapi.OpenS
 }
 
 func (hc *simpleHealthChecker) waitForConsole(ctx context.Context, cs *acsapi.OpenShiftManagedCluster) error {
+	log.Info("checking console health")
 	c := cs.Config
 	pool := x509.NewCertPool()
 	pool.AddCert(c.Certificates.Ca.Cert)
@@ -106,7 +107,6 @@ func (hc *simpleHealthChecker) waitForConsole(ctx context.Context, cs *acsapi.Op
 			return fmt.Errorf("unexpected error code %d from console", resp.StatusCode)
 		}
 	}
-
 }
 
 func newAppClient(ctx context.Context, config *v1.Config) (*appsclient.AppsV1Client, error) {


### PR DESCRIPTION
```
INFO[0000] starting health check                         resourceGroup=pweilosa
INFO[0001] checking infrastructure service health        resourceGroup=pweilosa
INFO[0001] checking  "prometheus-node-exporter"          resourceGroup=pweilosa
INFO[0001] checking  "sync"                              resourceGroup=pweilosa
INFO[0001] checking  "ovs"                               resourceGroup=pweilosa
INFO[0001] checking  "sdn"                               resourceGroup=pweilosa
INFO[0001] checking  "prometheus"                        resourceGroup=pweilosa
INFO[0131] checking  "docker-registry"                   resourceGroup=pweilosa
INFO[0131] checking  "registry-console"                  resourceGroup=pweilosa
INFO[0131] checking  "router"                            resourceGroup=pweilosa
INFO[0131] checking  "apiserver"                         resourceGroup=pweilosa
INFO[0131] checking  "controller-manager"                resourceGroup=pweilosa
INFO[0131] checking  "asb"                               resourceGroup=pweilosa
INFO[0131] checking  "bootstrap-autoapprover"            resourceGroup=pweilosa
INFO[0131] checking  "apiserver"                         resourceGroup=pweilosa
INFO[0131] checking  "webconsole"                        resourceGroup=pweilosa
INFO[0131] done checking infrastructure service health   resourceGroup=pweilosa
INFO[0131] checking console health                       resourceGroup=pweilosa
INFO[0132] OK                                            resourceGroup=pweilosa
```
@amanohar