### PR TITLE
Configure sync image pullspec in plugin init 

### DIFF
--- a/cmd/createorupdate/createorupdate.go
+++ b/cmd/createorupdate/createorupdate.go
@@ -23,7 +23,7 @@ var logLevel = flag.String("loglevel", "Debug", "valid values are Debug, Info, W
 // createOrUpdate simulates the RP
 func createOrUpdate(ctx context.Context, oc *v20180930preview.OpenShiftManagedCluster, entry *logrus.Entry) (*v20180930preview.OpenShiftManagedCluster, error) {
 	// instantiate the plugin
-	p := plugin.NewPlugin(entry)
+	p := plugin.NewPlugin(entry, os.Getenv("SYNC_IMAGE"))
 
 	// convert the external API manifest into the internal API representation
 	log.Info("convert to internal")

--- a/pkg/config/images.go
+++ b/pkg/config/images.go
@@ -61,7 +61,6 @@ func selectContainerImagesOrigin(cs *acsapi.OpenShiftManagedCluster) {
 
 		c.AzureCLIImage = "docker.io/microsoft/azure-cli:latest"
 
-		c.SyncImage = os.Getenv("SYNC_IMAGE")
 		if c.SyncImage == "" {
 			c.SyncImage = "quay.io/openshift-on-azure/sync:v3.10"
 		}
@@ -102,7 +101,6 @@ func selectContainerImagesOSA(cs *acsapi.OpenShiftManagedCluster) {
 
 		c.AzureCLIImage = "docker.io/microsoft/azure-cli:latest" //TODO: create mapping for OSA release to any other image we use
 
-		c.SyncImage = os.Getenv("SYNC_IMAGE")
 		if c.SyncImage == "" {
 			c.SyncImage = "quay.io/openshift-on-azure/sync:v3.10"
 		}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -17,15 +17,17 @@ import (
 )
 
 type plugin struct {
-	entry *logrus.Entry
+	entry     *logrus.Entry
+	syncImage string
 }
 
 var _ api.Plugin = &plugin{}
 
-func NewPlugin(entry *logrus.Entry) api.Plugin {
+func NewPlugin(entry *logrus.Entry, syncImage string) api.Plugin {
 	log.New(entry)
 	return &plugin{
-		entry: entry,
+		entry:     entry,
+		syncImage: syncImage,
 	}
 }
 
@@ -82,6 +84,9 @@ func (p *plugin) GenerateConfig(ctx context.Context, cs *api.OpenShiftManagedClu
 	err = config.Generate(cs)
 	if err != nil {
 		return err
+	}
+	if p.syncImage != "" {
+		cs.Config.SyncImage = p.syncImage
 	}
 	return nil
 }

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -13,7 +13,7 @@ import (
 )
 
 func TestMerge(t *testing.T) {
-	p := NewPlugin(logrus.NewEntry(logrus.New()))
+	p := NewPlugin(logrus.NewEntry(logrus.New()), "sync:latest")
 	newCluster := fixtures.NewTestOpenShiftCluster()
 	oldCluster := fixtures.NewTestOpenShiftCluster()
 


### PR DESCRIPTION
Fixes https://github.com/openshift/openshift-azure/issues/327

@openshift/sig-azure this PR moves `SYNC_IMAGE` out of the plugin code and uses the plugin struct to hold the sync image.