### PR TITLE
make sync-image: tag sync image with commit id

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -26,7 +26,8 @@ logbridge-push: logbridge-image
 sync: clean generate
 	CGO_ENABLED=0 go build ./cmd/sync
 
-SYNC_IMAGE ?= quay.io/openshift-on-azure/sync:latest
+TAG ?= $(shell git rev-parse --short HEAD)
+SYNC_IMAGE ?= quay.io/openshift-on-azure/sync:$(TAG)
 
 sync-image: sync
 	go get github.com/openshift/imagebuilder/cmd/imagebuilder


### PR DESCRIPTION
Stopgap solution for building and pushing sync using short commit IDs for tags.

@openshift/sig-azure 

```
git checkout commit_id
make sync-push
```
should push a sync image built from commit_id.

Ref https://github.com/openshift/openshift-azure/issues/327