### PR TITLE
allow ssh into arbitrary clusters, stop requiring resourcegroup on delete

### DIFF
--- a/hack/config.sh
+++ b/hack/config.sh
@@ -3,7 +3,9 @@
 usage() {
     cat <<EOF >&2
 usage:
+
 $0 get-config resourcegroup
+
 EOF
     exit 1
 }

--- a/hack/delete.sh
+++ b/hack/delete.sh
@@ -14,18 +14,12 @@ if [[ -z "$DNS_RESOURCEGROUP" ]]; then
     exit 1
 fi
 
-if [[ ! -e _data/manifest.yaml ]]; then
-    echo error: _data/manifest.yaml must exist
+if [[ ! -e _data/containerservice.yaml ]]; then
+    echo error: _data/containerservice.yaml must exist
     exit 1
 fi
 
-if [[ $# -ne 1 ]]; then
-    echo usage: $0 resourcegroup
-    exit 1
-fi
-
-RESOURCEGROUP=$1
-PUBLICHOSTNAME=$(awk '/^  publicHostname:/ { print $2 }' <_data/manifest.yaml)
+RESOURCEGROUP=$(awk '/^    resourceGroup:/ { print $2 }' <_data/containerservice.yaml)
 
 hack/dns.sh zone-delete $RESOURCEGROUP
 

--- a/hack/ssh.sh
+++ b/hack/ssh.sh
@@ -1,24 +1,54 @@
 #!/bin/bash -e
 
-killagent() {
+usage() {
+    cat <<EOF >&2
+usage:
+
+$0 [ resourcegroup ] [ -n {0,1,2} ]
+
+EOF
+    exit 1
+}
+
+cleanup() {
+    [[ -n "$ID_RSA" ]] && rm -f "$ID_RSA"
     [[ -n "$SSH_AGENT_PID" ]] && kill "$SSH_AGENT_PID"
 }
 
-if [[ $# -ne 2 ]]; then
-    echo "usage: $0 resourcegroup {0,1,2}"
-    exit 1
-fi
+ID=0
 
-RESOURCEGROUP="$1"
-ID="$2"
-shift 2
+while getopts :n: o; do
+    case $o in
+        n)
+            ID=$OPTARG
+            if [[ $ID != 0 && $ID != 1 && $ID != 2 ]]; then usage; fi
+            ;;
+        *)
+            usage
+            ;;
+    esac
+done
+
+shift $((OPTIND-1))
+RESOURCEGROUP=$1
+shift
+
+trap cleanup EXIT
+
+ID_RSA=$(mktemp)
+chmod 0600 $ID_RSA
+
+if [[ -z "$RESOURCEGROUP" ]]; then
+    RESOURCEGROUP=$(awk '/^    resourceGroup:/ { print $2 }' <_data/containerservice.yaml)
+    cat _data/_out/id_rsa >$ID_RSA
+else
+    hack/config.sh get-config $RESOURCEGROUP | jq -r .config.SSHKey | base64 -d >$ID_RSA
+fi
 
 IP=$(az vmss list-instance-public-ips -g $RESOURCEGROUP -n ss-master --query "[$ID].ipAddress" | tr -d '"')
 
-trap killagent EXIT
-
 eval "$(ssh-agent)"
-ssh-add _data/_out/id_rsa 2>/dev/null
+ssh-add $ID_RSA 2>/dev/null
 
 ssh -A -o UserKnownHostsFile=/dev/null -o StrictHostKeyChecking=no \
-    "$@" cloud-user@$IP
+    -i $ID_RSA "$@" cloud-user@$IP


### PR DESCRIPTION
@openshift/sig-azure ptal

with this change
* `hack/ssh.sh` takes you straight in to your master-000000. `hack/ssh.sh othercluster` downloads the config for othercluster and takes you in to master-000000 on that cluster. `-n {0,1,2}` allows you to ssh onto a different master
* `hack/delete.sh` no longer requires an argument

shout out to @charlesakalugwu for pointing out the shortcomings of our hack/ scripts and to @mjudeikis for hack/config.sh.  These are your ideas.  @charlesakalugwu this doesn't replace you doing the `env` pieces of issue #399 although hopefully it helps.

fixes #411