### PR TITLE
Record short commit id on every sync build

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 /sync
 .vscode
 .idea
+COMMIT_ID

--- a/Dockerfile.sync
+++ b/Dockerfile.sync
@@ -1,4 +1,5 @@
 FROM centos:7
 RUN yum -y update
 COPY sync .
+COPY COMMIT_ID .
 ENTRYPOINT [ "/sync" ]

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ build:
 	go build ./...
 
 clean:
-	rm -f sync
+	rm -f sync COMMIT_ID
 
 test: unit e2e
 
@@ -23,6 +23,7 @@ logbridge-push: logbridge-image
 	docker push quay.io/openshift-on-azure/logbridge:latest
 
 sync: clean generate
+	(git rev-parse --short HEAD) > COMMIT_ID
 	CGO_ENABLED=0 go build ./cmd/sync
 
 TAG ?= $(shell git rev-parse --short HEAD)


### PR DESCRIPTION
Fixes https://github.com/openshift/openshift-azure/issues/424

A change in release is required to mount the COMMIT_ID correctly in CI images.

@openshift/sig-azure 