### PR TITLE
use -X to store sync commit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,4 +5,3 @@
 /sync
 .vscode
 .idea
-COMMIT_ID

--- a/Dockerfile.sync
+++ b/Dockerfile.sync
@@ -1,5 +1,4 @@
 FROM centos:7
 RUN yum -y update
 COPY sync .
-COPY COMMIT_ID .
 ENTRYPOINT [ "/sync" ]

--- a/Makefile
+++ b/Makefile
@@ -5,7 +5,7 @@ build:
 	go build ./...
 
 clean:
-	rm -f sync COMMIT_ID
+	rm -f sync
 
 test: unit e2e
 
@@ -23,8 +23,7 @@ logbridge-push: logbridge-image
 	docker push quay.io/openshift-on-azure/logbridge:latest
 
 sync: clean generate
-	(git rev-parse --short HEAD) > COMMIT_ID
-	CGO_ENABLED=0 go build ./cmd/sync
+	go build -ldflags "-X main.gitCommit=$(shell git rev-parse --short HEAD)" ./cmd/sync
 
 TAG ?= $(shell git rev-parse --short HEAD)
 SYNC_IMAGE ?= quay.io/openshift-on-azure/sync:$(TAG)

--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -21,10 +21,11 @@ import (
 )
 
 var (
-	dryRun   = flag.Bool("dry-run", false, "Print resources to be synced instead of mutating cluster state.")
-	once     = flag.Bool("run-once", false, "If true, run only once then quit.")
-	interval = flag.Duration("interval", 3*time.Minute, "How often the sync process going to be rerun.")
-	logLevel = flag.String("loglevel", "Debug", "valid values are Debug, Info, Warning, Error")
+	dryRun    = flag.Bool("dry-run", false, "Print resources to be synced instead of mutating cluster state.")
+	once      = flag.Bool("run-once", false, "If true, run only once then quit.")
+	interval  = flag.Duration("interval", 3*time.Minute, "How often the sync process going to be rerun.")
+	logLevel  = flag.String("loglevel", "Debug", "valid values are Debug, Info, Warning, Error")
+	gitCommit = "unknown"
 )
 
 type azureStorageClient struct {
@@ -130,6 +131,7 @@ func main() {
 	flag.Parse()
 	logrus.SetLevel(log.SanitizeLogLevel(*logLevel))
 	logrus.SetFormatter(&logrus.TextFormatter{FullTimestamp: true})
+	logrus.Printf("sync pod starting, git commit %s", gitCommit)
 	for {
 		if err := sync(); err != nil {
 			logrus.Printf("Error while syncing: %v", err)


### PR DESCRIPTION
@kargakis @kwoodson I was hoping to do it this way so the commit goes straight into the logging