### PR TITLE
fix daft mistake in ssh.sh

### DIFF
--- a/hack/ssh.sh
+++ b/hack/ssh.sh
@@ -31,7 +31,7 @@ done
 
 shift $((OPTIND-1))
 RESOURCEGROUP=$1
-shift
+shift || true
 
 trap cleanup EXIT
 


### PR DESCRIPTION
`hack/ssh.sh` on its own doesn't work without this fix.  Not quite sure how I missed that :(