### PR TITLE
Make AgentPoolProfile.Count a *int

### DIFF
--- a/pkg/api/2018-09-30-preview/api/types.go
+++ b/pkg/api/2018-09-30-preview/api/types.go
@@ -91,7 +91,7 @@ type RouterProfile struct {
 
 // MasterPoolProfile contains configuration for OpenShift master VMs.
 type MasterPoolProfile struct {
-	Count  int    `json:"count,omitempty"`
+	Count  *int   `json:"count,omitempty"`
 	VMSize VMSize `json:"vmSize,omitempty"`
 
 	// VnetSubnetID is expected to be empty or match
@@ -106,7 +106,7 @@ type MasterPoolProfile struct {
 // AgentPoolProfile represents configuration of OpenShift cluster VMs.
 type AgentPoolProfile struct {
 	Name   string `json:"name,omitempty"`
-	Count  int    `json:"count,omitempty"`
+	Count  *int   `json:"count,omitempty"`
 	VMSize VMSize `json:"vmSize,omitempty"`
 
 	// VnetSubnetID is expected to be empty or match

--- a/pkg/api/2018-09-30-preview/api/types_test.go
+++ b/pkg/api/2018-09-30-preview/api/types_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"reflect"
 	"testing"
+
+	"github.com/Azure/go-autorest/autorest/to"
 )
 
 var unmarshalled = &OpenShiftManagedCluster{
@@ -53,14 +55,14 @@ var unmarshalled = &OpenShiftManagedCluster{
 			},
 		},
 		MasterPoolProfile: &MasterPoolProfile{
-			Count:        1,
+			Count:        to.IntPtr(1),
 			VMSize:       "properties.agentPoolProfiles.0.vmSize",
 			VnetSubnetID: "properties.agentPoolProfiles.0.vnetSubnetID",
 		},
 		AgentPoolProfiles: []AgentPoolProfile{
 			{
 				Name:         "properties.agentPoolProfiles.0.name",
-				Count:        1,
+				Count:        to.IntPtr(1),
 				VMSize:       "properties.agentPoolProfiles.0.vmSize",
 				VnetSubnetID: "properties.agentPoolProfiles.0.vnetSubnetID",
 				OSType:       "properties.agentPoolProfiles.0.osType",
@@ -68,7 +70,7 @@ var unmarshalled = &OpenShiftManagedCluster{
 			},
 			{
 				Name:         "properties.agentPoolProfiles.0.name",
-				Count:        2,
+				Count:        to.IntPtr(2),
 				VMSize:       "properties.agentPoolProfiles.0.vmSize",
 				VnetSubnetID: "properties.agentPoolProfiles.0.vnetSubnetID",
 				OSType:       "properties.agentPoolProfiles.0.osType",

--- a/pkg/api/converterfromv20180930preview.go
+++ b/pkg/api/converterfromv20180930preview.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"github.com/Azure/go-autorest/autorest/to"
+
 	v20180930preview "github.com/openshift/openshift-azure/pkg/api/2018-09-30-preview/api"
 )
 
@@ -43,25 +45,31 @@ func ConvertFromV20180930preview(oc *v20180930preview.OpenShiftManagedCluster) *
 
 		cs.Properties.AgentPoolProfiles = make([]AgentPoolProfile, 0, len(oc.Properties.AgentPoolProfiles)+1)
 		for _, app := range oc.Properties.AgentPoolProfiles {
-			cs.Properties.AgentPoolProfiles = append(cs.Properties.AgentPoolProfiles, AgentPoolProfile{
+			newApp := AgentPoolProfile{
 				Name:         app.Name,
-				Count:        app.Count,
 				VMSize:       VMSize(app.VMSize),
 				OSType:       OSType(app.OSType),
 				VnetSubnetID: app.VnetSubnetID,
 				Role:         AgentPoolProfileRole(app.Role),
-			})
+			}
+			if app.Count != nil {
+				newApp.Count = to.IntPtr(*app.Count)
+			}
+			cs.Properties.AgentPoolProfiles = append(cs.Properties.AgentPoolProfiles, newApp)
 		}
 
 		if oc.Properties.MasterPoolProfile != nil {
-			cs.Properties.AgentPoolProfiles = append(cs.Properties.AgentPoolProfiles, AgentPoolProfile{
+			newApp := AgentPoolProfile{
 				Name:         string(AgentPoolProfileRoleMaster),
-				Count:        oc.Properties.MasterPoolProfile.Count,
 				VMSize:       VMSize(oc.Properties.MasterPoolProfile.VMSize),
 				OSType:       OSTypeLinux,
 				VnetSubnetID: oc.Properties.MasterPoolProfile.VnetSubnetID,
 				Role:         AgentPoolProfileRoleMaster,
-			})
+			}
+			if oc.Properties.MasterPoolProfile.Count != nil {
+				newApp.Count = to.IntPtr(*oc.Properties.MasterPoolProfile.Count)
+			}
+			cs.Properties.AgentPoolProfiles = append(cs.Properties.AgentPoolProfiles, newApp)
 		}
 
 		if oc.Properties.AuthProfile != nil {

--- a/pkg/api/converterfromv20180930preview_test.go
+++ b/pkg/api/converterfromv20180930preview_test.go
@@ -4,6 +4,8 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/Azure/go-autorest/autorest/to"
+
 	v20180930preview "github.com/openshift/openshift-azure/pkg/api/2018-09-30-preview/api"
 )
 
@@ -53,7 +55,7 @@ var v20180930previewManagedCluster = &v20180930preview.OpenShiftManagedCluster{
 			},
 		},
 		MasterPoolProfile: &v20180930preview.MasterPoolProfile{
-			Count:        1,
+			Count:        to.IntPtr(1),
 			VMSize:       "properties.agentPoolProfiles.0.vmSize",
 			VnetSubnetID: "properties.agentPoolProfiles.0.vnetSubnetID",
 		},
@@ -61,7 +63,7 @@ var v20180930previewManagedCluster = &v20180930preview.OpenShiftManagedCluster{
 			{
 				Role:         "properties.agentPoolProfiles.0.role",
 				Name:         "properties.agentPoolProfiles.0.name",
-				Count:        1,
+				Count:        to.IntPtr(1),
 				VMSize:       "properties.agentPoolProfiles.0.vmSize",
 				VnetSubnetID: "properties.agentPoolProfiles.0.vnetSubnetID",
 				OSType:       "properties.agentPoolProfiles.0.osType",
@@ -69,7 +71,7 @@ var v20180930previewManagedCluster = &v20180930preview.OpenShiftManagedCluster{
 			{
 				Role:         "properties.agentPoolProfiles.0.role",
 				Name:         "properties.agentPoolProfiles.0.name",
-				Count:        2,
+				Count:        to.IntPtr(2),
 				VMSize:       "properties.agentPoolProfiles.0.vmSize",
 				VnetSubnetID: "properties.agentPoolProfiles.0.vnetSubnetID",
 				OSType:       "properties.agentPoolProfiles.0.osType",
@@ -126,7 +128,7 @@ var internalManagedCluster = &OpenShiftManagedCluster{
 		AgentPoolProfiles: []AgentPoolProfile{
 			{
 				Name:         "properties.agentPoolProfiles.0.name",
-				Count:        1,
+				Count:        to.IntPtr(1),
 				VMSize:       "properties.agentPoolProfiles.0.vmSize",
 				OSType:       "properties.agentPoolProfiles.0.osType",
 				VnetSubnetID: "properties.agentPoolProfiles.0.vnetSubnetID",
@@ -134,7 +136,7 @@ var internalManagedCluster = &OpenShiftManagedCluster{
 			},
 			{
 				Name:         "properties.agentPoolProfiles.0.name",
-				Count:        2,
+				Count:        to.IntPtr(2),
 				VMSize:       "properties.agentPoolProfiles.0.vmSize",
 				OSType:       "properties.agentPoolProfiles.0.osType",
 				VnetSubnetID: "properties.agentPoolProfiles.0.vnetSubnetID",
@@ -142,7 +144,7 @@ var internalManagedCluster = &OpenShiftManagedCluster{
 			},
 			{
 				Name:         string(AgentPoolProfileRoleMaster),
-				Count:        1,
+				Count:        to.IntPtr(1),
 				VMSize:       "properties.agentPoolProfiles.0.vmSize",
 				OSType:       OSTypeLinux,
 				VnetSubnetID: "properties.agentPoolProfiles.0.vnetSubnetID",

--- a/pkg/api/convertertov20180930preview.go
+++ b/pkg/api/convertertov20180930preview.go
@@ -1,6 +1,8 @@
 package api
 
 import (
+	"github.com/Azure/go-autorest/autorest/to"
+
 	v20180930preview "github.com/openshift/openshift-azure/pkg/api/2018-09-30-preview/api"
 )
 
@@ -45,20 +47,27 @@ func ConvertToV20180930preview(cs *OpenShiftManagedCluster) *v20180930preview.Op
 		for _, app := range cs.Properties.AgentPoolProfiles {
 			if app.Role == AgentPoolProfileRoleMaster {
 				oc.Properties.MasterPoolProfile = &v20180930preview.MasterPoolProfile{
-					Count:        app.Count,
 					VMSize:       v20180930preview.VMSize(app.VMSize),
 					VnetSubnetID: app.VnetSubnetID,
 				}
+				if app.Count != nil {
+					oc.Properties.MasterPoolProfile.Count = to.IntPtr(*app.Count)
+				}
 
 			} else {
-				oc.Properties.AgentPoolProfiles = append(oc.Properties.AgentPoolProfiles, v20180930preview.AgentPoolProfile{
+				newApp := v20180930preview.AgentPoolProfile{
 					Name:         app.Name,
 					Count:        app.Count,
 					VMSize:       v20180930preview.VMSize(app.VMSize),
 					OSType:       v20180930preview.OSType(app.OSType),
 					VnetSubnetID: app.VnetSubnetID,
 					Role:         v20180930preview.AgentPoolProfileRole(app.Role),
-				})
+				}
+				if app.Count != nil {
+					newApp.Count = to.IntPtr(*app.Count)
+				}
+
+				oc.Properties.AgentPoolProfiles = append(oc.Properties.AgentPoolProfiles, newApp)
 			}
 		}
 

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -95,7 +95,7 @@ type RouterProfile struct {
 // AgentPoolProfile represents configuration of OpenShift cluster VMs.
 type AgentPoolProfile struct {
 	Name   string `json:"name,omitempty"`
-	Count  int    `json:"count,omitempty"`
+	Count  *int   `json:"count,omitempty"`
 	VMSize VMSize `json:"vmSize,omitempty"`
 
 	// VnetSubnetID is expected to be empty or match

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -5,6 +5,8 @@ import (
 	"encoding/json"
 	"reflect"
 	"testing"
+
+	"github.com/Azure/go-autorest/autorest/to"
 )
 
 var unmarshalled = &OpenShiftManagedCluster{
@@ -54,14 +56,14 @@ var unmarshalled = &OpenShiftManagedCluster{
 		},
 		AgentPoolProfiles: []AgentPoolProfile{
 			{
-				Count:        1,
+				Count:        to.IntPtr(1),
 				VMSize:       "properties.agentPoolProfiles.0.vmSize",
 				VnetSubnetID: "properties.agentPoolProfiles.0.vnetSubnetID",
 				Role:         "properties.agentPoolProfiles.0.role",
 			},
 			{
 				Name:         "properties.agentPoolProfiles.0.name",
-				Count:        2,
+				Count:        to.IntPtr(2),
 				VMSize:       "properties.agentPoolProfiles.0.vmSize",
 				OSType:       "properties.agentPoolProfiles.0.osType",
 				VnetSubnetID: "properties.agentPoolProfiles.0.vnetSubnetID",
@@ -69,7 +71,7 @@ var unmarshalled = &OpenShiftManagedCluster{
 			},
 			{
 				Name:         "properties.agentPoolProfiles.0.name",
-				Count:        1,
+				Count:        to.IntPtr(1),
 				VMSize:       "properties.agentPoolProfiles.0.vmSize",
 				OSType:       "properties.agentPoolProfiles.0.osType",
 				VnetSubnetID: "properties.agentPoolProfiles.0.vnetSubnetID",

--- a/pkg/util/fixtures/fixtures.go
+++ b/pkg/util/fixtures/fixtures.go
@@ -1,6 +1,9 @@
 package fixtures
 
-import "github.com/openshift/openshift-azure/pkg/api"
+import (
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/openshift/openshift-azure/pkg/api"
+)
 
 // NewTestOpenShiftCluster is a test cluster definition that can be use in unit testing plugin methods.
 func NewTestOpenShiftCluster() *api.OpenShiftManagedCluster {
@@ -37,21 +40,21 @@ func NewTestOpenShiftCluster() *api.OpenShiftManagedCluster {
 				{
 					Name:   "master",
 					Role:   api.AgentPoolProfileRoleMaster,
-					Count:  3,
+					Count:  to.IntPtr(3),
 					VMSize: "Standard_D2s_v3",
 					OSType: "Linux",
 				},
 				{
 					Name:   "infra",
 					Role:   api.AgentPoolProfileRoleInfra,
-					Count:  2,
+					Count:  to.IntPtr(2),
 					VMSize: "Standard_D2s_v3",
 					OSType: "Linux",
 				},
 				{
 					Name:   "compute",
 					Role:   api.AgentPoolProfileRoleCompute,
-					Count:  1,
+					Count:  to.IntPtr(1),
 					VMSize: "Standard_D2s_v3",
 					OSType: "Linux",
 				},

--- a/pkg/validate/validate.go
+++ b/pkg/validate/validate.go
@@ -181,21 +181,21 @@ func validateAgentPoolProfile(app *api.AgentPoolProfile) (errs []error) {
 		if !rxAgentPoolProfileName.MatchString(app.Name) {
 			errs = append(errs, fmt.Errorf("invalid properties.agentPoolProfiles[%q].name %q", app.Name, app.Name))
 		}
-		if app.Count < 1 || app.Count > 5 {
-			errs = append(errs, fmt.Errorf("invalid properties.agentPoolProfiles[%q].count %d", app.Name, app.Count))
+		if app.Count == nil || *app.Count < 1 || *app.Count > 5 {
+			errs = append(errs, fmt.Errorf("invalid properties.agentPoolProfiles[%q].count", app.Name))
 		}
 
 	case api.AgentPoolProfileRoleInfra:
 		if app.Name != string(app.Role) {
 			errs = append(errs, fmt.Errorf("invalid properties.agentPoolProfiles[%q].name %q", app.Name, app.Name))
 		}
-		if app.Count != 2 {
-			errs = append(errs, fmt.Errorf("invalid properties.agentPoolProfiles[%q].count %d", app.Name, app.Count))
+		if app.Count == nil || *app.Count != 2 {
+			errs = append(errs, fmt.Errorf("invalid properties.agentPoolProfiles[%q].count", app.Name))
 		}
 
 	case api.AgentPoolProfileRoleMaster:
-		if app.Count != 3 {
-			errs = append(errs, fmt.Errorf("invalid masterPoolProfile.count %d", app.Count))
+		if app.Count == nil || *app.Count != 3 {
+			errs = append(errs, fmt.Errorf("invalid masterPoolProfile.count"))
 		}
 	}
 

--- a/pkg/validate/validate_test.go
+++ b/pkg/validate/validate_test.go
@@ -5,6 +5,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/davecgh/go-spew/spew"
 	"github.com/ghodss/yaml"
 
@@ -254,11 +255,11 @@ func TestValidate(t *testing.T) {
 			f: func(oc *api.OpenShiftManagedCluster) {
 				for i, app := range oc.Properties.AgentPoolProfiles {
 					if app.Role == api.AgentPoolProfileRoleMaster {
-						oc.Properties.AgentPoolProfiles[i].Count = 1
+						oc.Properties.AgentPoolProfiles[i].Count = to.IntPtr(1)
 					}
 				}
 			},
-			expectedErrs: []error{errors.New(`invalid masterPoolProfile.count 1`)},
+			expectedErrs: []error{errors.New(`invalid masterPoolProfile.count`)},
 		},
 		//we dont check authProfile because it is non pointer struct. Which is all zero values.
 		"authProfile.identityProviders empty": {


### PR DESCRIPTION
This is not pleasant, but the least worst mechanism to leave open the
possibility of being able to scale APPs down to 0 at the same time as
being able to specify a partial manifest on PUT.