### PR TITLE
refactor config marshalling: it was not honoring the json tag names and had

### DIFF
--- a/pkg/api/marshal.go
+++ b/pkg/api/marshal.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"bytes"
 	"crypto/rsa"
 	"crypto/x509"
 	"encoding/base64"
@@ -9,86 +8,110 @@ import (
 	"fmt"
 	"reflect"
 
-	"github.com/ghodss/yaml"
-	"github.com/satori/go.uuid"
 	"k8s.io/client-go/tools/clientcmd/api/v1"
 
 	"github.com/openshift/openshift-azure/pkg/tls"
 )
 
-func (c Config) MarshalJSON() ([]byte, error) {
-	m := map[string]interface{}{}
-	v := reflect.ValueOf(c)
+// makeShadowStruct returns a pointer to a struct identical in type to the one
+// passed in, but with certain fields types set to json.RawMessage.
+func makeShadowStruct(v reflect.Value) reflect.Value {
+	fields := make([]reflect.StructField, 0, v.NumField())
 	for i := 0; i < v.NumField(); i++ {
-		k := v.Type().Field(i).Name
+		f := v.Type().Field(i)
+		switch f.Type.String() {
+		case "*rsa.PrivateKey", "*v1.Config", "*x509.Certificate":
+			f.Type = reflect.TypeOf(json.RawMessage{})
+		}
+		fields = append(fields, f)
+	}
 
-		switch v.Field(i).Kind() {
-		case reflect.Interface, reflect.Ptr, reflect.Slice:
-			if v.Field(i).IsNil() {
+	return reflect.New(reflect.StructOf(fields))
+}
+
+// marshalJSON marshals a struct, overriding the marshaling used for x509
+// certificates, private keys and kubeconfigs.
+func marshalJSON(v reflect.Value) ([]byte, error) {
+	shadow := makeShadowStruct(v).Elem()
+
+	// copy data into the shadow struct
+	for i := 0; i < v.NumField(); i++ {
+		switch v := v.Field(i).Interface().(type) {
+		case *rsa.PrivateKey:
+			if v == nil {
 				continue
 			}
-		}
 
-		switch v := v.Field(i).Interface().(type) {
-		case *x509.Certificate:
-			b, err := tls.CertAsBytes(v)
-			if err != nil {
-				return nil, err
-			}
-			m[k] = base64.StdEncoding.EncodeToString(b)
-
-		case *rsa.PrivateKey:
 			b, err := tls.PrivateKeyAsBytes(v)
 			if err != nil {
 				return nil, err
 			}
-			m[k] = base64.StdEncoding.EncodeToString(b)
+
+			b, err = json.Marshal(b)
+			if err != nil {
+				return nil, err
+			}
+
+			shadow.Field(i).Set(reflect.ValueOf(b))
 
 		case *v1.Config:
-			b, err := yaml.Marshal(v)
+			if v == nil {
+				continue
+			}
+
+			b, err := json.Marshal(v)
 			if err != nil {
 				return nil, err
 			}
-			m[k] = base64.StdEncoding.EncodeToString(b)
 
-		case []byte:
-			m[k] = base64.StdEncoding.EncodeToString(v)
-
-		case *CertificateConfig:
-			bytes, err := yaml.Marshal(v)
+			b, err = json.Marshal(base64.StdEncoding.EncodeToString(b))
 			if err != nil {
 				return nil, err
 			}
-			m[k] = bytes
+
+			shadow.Field(i).Set(reflect.ValueOf(b))
+
+		case *x509.Certificate:
+			if v == nil {
+				continue
+			}
+
+			b, err := tls.CertAsBytes(v)
+			if err != nil {
+				return nil, err
+			}
+
+			b, err = json.Marshal(b)
+			if err != nil {
+				return nil, err
+			}
+
+			shadow.Field(i).Set(reflect.ValueOf(b))
 
 		default:
-			m[k] = v
+			shadow.Field(i).Set(reflect.ValueOf(v))
 		}
 	}
-	return json.Marshal(m)
+
+	return json.Marshal(shadow.Interface())
 }
 
-func (c *Config) UnmarshalJSON(b []byte) error {
-	d := json.NewDecoder(bytes.NewBuffer(b))
-	d.UseNumber()
-
-	m := map[string]interface{}{}
-	err := d.Decode(&m)
+// unmarshalJSON unmarshals a struct, overriding the unmarshaling used for x509
+// certificates, private keys and kubeconfigs.
+func unmarshalJSON(v reflect.Value, b []byte) error {
+	shadow := makeShadowStruct(v)
+	err := json.Unmarshal(b, shadow.Interface())
 	if err != nil {
 		return err
 	}
+	shadow = shadow.Elem()
 
-	v := reflect.ValueOf(c).Elem()
+	// copy data out of the shadow struct
 	for i := 0; i < v.NumField(); i++ {
-		k := v.Type().Field(i).Name
-
-		if _, exists := m[k]; !exists {
-			continue
-		}
-
-		switch v.Field(i).Type().String() {
-		case "*rsa.PrivateKey":
-			b, err := base64.StdEncoding.DecodeString(m[k].(string))
+		switch v.Field(i).Interface().(type) {
+		case *rsa.PrivateKey:
+			var b []byte
+			err = json.Unmarshal(shadow.Field(i).Bytes(), &b)
 			if err != nil {
 				return err
 			}
@@ -97,31 +120,27 @@ func (c *Config) UnmarshalJSON(b []byte) error {
 			if err != nil {
 				return err
 			}
+
 			v.Field(i).Set(reflect.ValueOf(key))
 
-		case "uuid.UUID":
-			u, err := uuid.FromString(m[k].(string))
-			if err != nil {
-				return err
-			}
-			v.Field(i).Set(reflect.ValueOf(u))
-
-		case "*v1.Config":
-			b, err := base64.StdEncoding.DecodeString(m[k].(string))
+		case *v1.Config:
+			var b []byte
+			err = json.Unmarshal(shadow.Field(i).Bytes(), &b)
 			if err != nil {
 				return err
 			}
 
 			var c v1.Config
-			err = yaml.Unmarshal(b, &c)
+			err = json.Unmarshal(b, &c)
 			if err != nil {
 				return err
 			}
 
 			v.Field(i).Set(reflect.ValueOf(&c))
 
-		case "*x509.Certificate":
-			b, err := base64.StdEncoding.DecodeString(m[k].(string))
+		case *x509.Certificate:
+			var b []byte
+			err = json.Unmarshal(shadow.Field(i).Bytes(), &b)
 			if err != nil {
 				return err
 			}
@@ -130,146 +149,31 @@ func (c *Config) UnmarshalJSON(b []byte) error {
 			if err != nil {
 				return err
 			}
+
 			v.Field(i).Set(reflect.ValueOf(cert))
 
-		case "[]uint8":
-			b, err := base64.StdEncoding.DecodeString(m[k].(string))
-			if err != nil {
-				return err
-			}
-
-			v.Field(i).Set(reflect.ValueOf(b))
-
-		case "int":
-			ii, err := m[k].(json.Number).Int64()
-			if err != nil {
-				return err
-			}
-
-			v.Field(i).Set(reflect.ValueOf(int(ii)))
-
-		case "api.CertificateConfig":
-			// I don't know if this is the most efficient way to do this
-			data, err := yaml.Marshal(m[k])
-			if err != nil {
-				return err
-			}
-
-			var c CertificateConfig
-			err = yaml.Unmarshal(data, &c)
-
-			if err != nil {
-				return err
-			}
-
-			v.Field(i).Set(reflect.ValueOf(c))
-
-		case "api.ImageConfig":
-			data, err := yaml.Marshal(m[k])
-			if err != nil {
-				return err
-			}
-
-			var c ImageConfig
-			err = yaml.Unmarshal(data, &c)
-
-			if err != nil {
-				return err
-			}
-
-			v.Field(i).Set(reflect.ValueOf(c))
 		default:
-			v.Field(i).Set(reflect.ValueOf(m[k]))
+			v.Field(i).Set(shadow.Field(i))
 		}
 	}
 
 	return nil
+}
+
+func (c Config) MarshalJSON() ([]byte, error) {
+	return marshalJSON(reflect.ValueOf(c))
+}
+
+func (c *Config) UnmarshalJSON(b []byte) error {
+	return unmarshalJSON(reflect.ValueOf(c).Elem(), b)
 }
 
 func (c CertKeyPair) MarshalJSON() ([]byte, error) {
-	m := map[string]interface{}{}
-	v := reflect.ValueOf(c)
-	for i := 0; i < v.NumField(); i++ {
-		k := v.Type().Field(i).Name
-
-		switch v.Field(i).Kind() {
-		case reflect.Interface, reflect.Ptr, reflect.Slice:
-			if v.Field(i).IsNil() {
-				continue
-			}
-		}
-
-		switch v := v.Field(i).Interface().(type) {
-		case *x509.Certificate:
-			b, err := tls.CertAsBytes(v)
-			if err != nil {
-				return nil, err
-			}
-			m[k] = base64.StdEncoding.EncodeToString(b)
-
-		case *rsa.PrivateKey:
-			b, err := tls.PrivateKeyAsBytes(v)
-			if err != nil {
-				return nil, err
-			}
-			m[k] = base64.StdEncoding.EncodeToString(b)
-
-		default:
-			m[k] = v
-		}
-	}
-	return json.Marshal(m)
+	return marshalJSON(reflect.ValueOf(c))
 }
 
 func (c *CertKeyPair) UnmarshalJSON(b []byte) error {
-	d := json.NewDecoder(bytes.NewBuffer(b))
-	d.UseNumber()
-
-	m := map[string]interface{}{}
-	err := d.Decode(&m)
-	if err != nil {
-		return err
-	}
-
-	v := reflect.ValueOf(c).Elem()
-	for i := 0; i < v.NumField(); i++ {
-		k := v.Type().Field(i).Name
-
-		if _, exists := m[k]; !exists {
-			continue
-		}
-
-		switch v.Field(i).Type().String() {
-		case "*rsa.PrivateKey":
-			b, err := base64.StdEncoding.DecodeString(m[k].(string))
-			if err != nil {
-				return err
-			}
-
-			key, err := tls.ParsePrivateKey(b)
-			if err != nil {
-				return err
-			}
-			v.Field(i).Set(reflect.ValueOf(key))
-
-		case "*x509.Certificate":
-			b, err := base64.StdEncoding.DecodeString(m[k].(string))
-			if err != nil {
-				return err
-			}
-
-			cert, err := tls.ParseCert(b)
-			if err != nil {
-				return err
-			}
-			v.Field(i).Set(reflect.ValueOf(cert))
-
-		default:
-			v.Field(i).Set(reflect.ValueOf(m[k]))
-		}
-	}
-
-	return nil
+	return unmarshalJSON(reflect.ValueOf(c).Elem(), b)
 }
 
 func (ip *IdentityProvider) UnmarshalJSON(b []byte) error {


### PR DESCRIPTION
grown several unpleasant hacks