### PR TITLE
Tag resource groups with a TTL

### DIFF
--- a/hack/create.sh
+++ b/hack/create.sh
@@ -46,7 +46,11 @@ export RESOURCEGROUP=$1
 rm -rf _data
 mkdir -p _data/_out
 
-az group create -n $RESOURCEGROUP -l eastus --tags now=$(date +%s) >/dev/null
+ttl=76h
+if [[ -n $RESOURCEGROUP_TTL ]]; then
+  ttl=$RESOURCEGROUP_TTL
+fi
+az group create -n $RESOURCEGROUP -l eastus --tags now=$(date +%s) ttl=$ttl >/dev/null
 
 # if AZURE_CLIENT_ID is used as AZURE_AAD_CLIENT_ID, script will reset global team account!
 set +x


### PR DESCRIPTION
@mjudeikis @jim-minter this should allow us to use a tight TTL for resource groups created in CI tests.

/cc mjudeikis