### PR TITLE
[WIP] Rewrite fake RP to be a library and use http

### DIFF
--- a/cmd/createorupdate/createorupdate.go
+++ b/cmd/createorupdate/createorupdate.go
@@ -1,276 +1,174 @@
 package main
 
 import (
+	"bytes"
 	"context"
-	"flag"
-	"fmt"
 	"io/ioutil"
+	"net/http"
 	"os"
 
-	"github.com/Azure/azure-sdk-for-go/services/marketplaceordering/mgmt/2015-06-01/marketplaceordering"
-	"github.com/Azure/go-autorest/autorest/azure/auth"
-	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/ghodss/yaml"
 	"github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/util/errors"
 
-	acsapi "github.com/openshift/openshift-azure/pkg/api"
+	"github.com/openshift/openshift-azure/pkg/api"
 	v20180930preview "github.com/openshift/openshift-azure/pkg/api/2018-09-30-preview/api"
-	"github.com/openshift/openshift-azure/pkg/config"
-	"github.com/openshift/openshift-azure/pkg/log"
-	"github.com/openshift/openshift-azure/pkg/plugin"
-	"github.com/openshift/openshift-azure/pkg/tls"
-	"github.com/openshift/openshift-azure/pkg/upgrade"
-	"github.com/openshift/openshift-azure/pkg/util/managedcluster"
+	"github.com/openshift/openshift-azure/pkg/fakerp"
 )
 
-var logLevel = flag.String("loglevel", "Debug", "valid values are Debug, Info, Warning, Error")
-
-// createOrUpdate simulates the RP
-func createOrUpdate(ctx context.Context, oc *v20180930preview.OpenShiftManagedCluster, entry *logrus.Entry) (*v20180930preview.OpenShiftManagedCluster, error) {
-	// instantiate the plugin
-	p := plugin.NewPlugin(entry, os.Getenv("SYNC_IMAGE"))
-
-	// convert the external API manifest into the internal API representation
-	log.Info("convert to internal")
-	cs := acsapi.ConvertFromV20180930preview(oc)
-
-	// the RP will enrich the internal API representation with data not included
-	// in the original request
-	log.Info("enrich")
-	err := enrich(cs)
-	if err != nil {
-		return nil, err
-	}
-
-	// read in the OpenShift config blob if it exists (i.e. we're updating)
-	// in the update path, the RP should have access to the previous internal
-	// API representation for comparison.
-	var oldCs *acsapi.OpenShiftManagedCluster
-	if _, err := os.Stat("_data/containerservice.yaml"); err == nil {
-		log.Info("read old config")
-		oldCs, err = managedcluster.ReadConfig("_data/containerservice.yaml")
-		if err != nil {
-			return nil, err
-		}
-
-		log.Info("merge old and new config")
-		p.MergeConfig(ctx, cs, oldCs)
-	}
-
-	// validate the internal API representation (with reference to the previous
-	// internal API representation)
-	// we set fqdn during enrichment which is slightly different than what the RP
-	// will do so we are only validating once.
-	errs := p.Validate(ctx, cs, oldCs, false)
-	if len(errs) > 0 {
-		return nil, errors.NewAggregate(errs)
-	}
-
-	// generate or update the OpenShift config blob
-	err = p.GenerateConfig(ctx, cs)
-	if err != nil {
-		return nil, err
-	}
-
-	// persist the OpenShift container service
-	log.Info("persist config")
-	bytes, err := yaml.Marshal(cs)
-	if err != nil {
-		return nil, err
-	}
-	err = ioutil.WriteFile("_data/containerservice.yaml", bytes, 0600)
-	if err != nil {
-		return nil, err
-	}
-
-	err = os.MkdirAll("_data/_out", 0777)
-	if err != nil {
-		return nil, err
-	}
-
-	// generate the ARM template
-	azuredeploy, err := p.GenerateARM(ctx, cs, oldCs != nil)
-	if err != nil {
-		return nil, err
-	}
-
-	// write out development files
-	log.Info("write helpers")
-	err = writeHelpers(cs, azuredeploy)
-	if err != nil {
-		return nil, err
-	}
-
-	err = acceptMarketplaceAgreement(ctx, cs)
-	if err != nil {
-		return nil, err
-	}
-
-	if oldCs != nil {
-		err = p.Update(ctx, cs, azuredeploy)
-		if err != nil {
-			return nil, err
-		}
-	} else {
-		err = upgrade.Deploy(ctx, cs, p, azuredeploy)
-		if err != nil {
-			return nil, err
-		}
-	}
-
-	err = p.HealthCheck(ctx, cs)
-	if err != nil {
-		return nil, err
-	}
-
-	// convert our (probably changed) internal API representation back to the
-	// external API manifest to return it to the user
-	oc = acsapi.ConvertToV20180930preview(cs)
-
-	return oc, nil
+type server struct {
+	// the server will not process more than a single
+	// request at all times.
+	inProgress chan struct{}
+	log        *logrus.Entry
 }
 
-func acceptMarketplaceAgreement(ctx context.Context, cs *acsapi.OpenShiftManagedCluster) error {
-	if config.Derived.ImageResourceName() != "" ||
-		os.Getenv("AUTOACCEPT_MARKETPLACE_AGREEMENT") != "yes" {
-		return nil
-	}
+// ServeHTTP handles an incoming request to the server.
+func (s *server) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	defer r.Body.Close()
 
-	config := auth.NewClientCredentialsConfig(ctx.Value(acsapi.ContextKeyClientID).(string), ctx.Value(acsapi.ContextKeyClientSecret).(string), ctx.Value(acsapi.ContextKeyTenantID).(string))
-	authorizer, err := config.Authorizer()
+	ok := s.validate(w, r, nil)
+	if !ok {
+		return
+	}
+	defer func() {
+		// drain once we are done processing this request
+		<-s.inProgress
+	}()
+
+	b, err := ioutil.ReadAll(r.Body)
 	if err != nil {
-		return err
+		resp := "500 Internal Server Error: Failed to read request body"
+		logrus.Debug(resp, err)
+		http.Error(w, resp, http.StatusInternalServerError)
+		return
 	}
 
-	mpo := marketplaceordering.NewMarketplaceAgreementsClient(cs.Properties.AzProfile.SubscriptionID)
-	mpo.Authorizer = authorizer
+	var oc *v20180930preview.OpenShiftManagedCluster
+	if err := yaml.Unmarshal(b, &oc); err != nil {
+		resp := "500 Internal Server Error: Failed to unmarshal request"
+		logrus.Debug(resp, err)
+		http.Error(w, resp, http.StatusInternalServerError)
+		return
+	}
 
-	log.Info("checking marketplace agreement")
-	terms, err := mpo.Get(ctx, cs.Config.ImagePublisher, cs.Config.ImageOffer, cs.Config.ImageSKU)
+	oc, err = fakerp.CreateOrUpdate(r.Context(), oc, s.log)
 	if err != nil {
-		return err
+		resp := "500 Internal Server Error: Failed to apply request"
+		logrus.Debug(resp, err)
+		http.Error(w, resp, http.StatusInternalServerError)
+		return
 	}
 
-	if *terms.AgreementProperties.Accepted {
-		return nil
+	responce, err := yaml.Marshal(oc)
+	if err != nil {
+		resp := "500 Internal Server Error: Failed to marshal response"
+		logrus.Debug(resp, err)
+		http.Error(w, resp, http.StatusInternalServerError)
+		return
 	}
-
-	terms.AgreementProperties.Accepted = to.BoolPtr(true)
-
-	log.Info("accepting marketplace agreement")
-	_, err = mpo.Create(ctx, cs.Config.ImagePublisher, cs.Config.ImageOffer, cs.Config.ImageSKU, terms)
-	return err
+	w.Write(responce)
 }
 
-func enrich(cs *acsapi.OpenShiftManagedCluster) error {
-	for _, env := range []string{
-		"AZURE_CLIENT_ID",
-		"AZURE_CLIENT_SECRET",
-		"AZURE_SUBSCRIPTION_ID",
-		"AZURE_TENANT_ID",
-		"DNS_DOMAIN",
-		"RESOURCEGROUP",
-	} {
-		if os.Getenv(env) == "" {
-			return fmt.Errorf("must set %s", env)
+func (s *server) ListenAndServe() {
+	http.Handle("/", s)
+	httpServer := &http.Server{Addr: ":8080"}
+	s.log.Info("starting server on :8080")
+	logrus.WithError(httpServer.ListenAndServe()).Warn("Server exited.")
+}
+
+func (s *server) validate(w http.ResponseWriter, r *http.Request, secret []byte) bool {
+	// TODO: Support DELETE
+	if r.Method != http.MethodPut {
+		resp := "405 Method not allowed"
+		logrus.Debug(resp)
+		http.Error(w, resp, http.StatusMethodNotAllowed)
+		return false
+	}
+
+	/*
+		contentType := r.Header.Get("content-type")
+		if contentType != "application/json" {
+			resp := "400 Bad Request: Server only accepts content-type: application/json"
+			logrus.Debug(resp)
+			http.Error(w, resp, http.StatusBadRequest)
+			return false
 		}
+	*/
+
+	if err := validateSecret(r, secret); err != nil {
+		resp := "403 Forbidden: Invalid Signature"
+		logrus.Debug(resp)
+		http.Error(w, resp, http.StatusForbidden)
+		return false
 	}
 
-	cs.Properties.AzProfile = &acsapi.AzProfile{
-		TenantID:       os.Getenv("AZURE_TENANT_ID"),
-		SubscriptionID: os.Getenv("AZURE_SUBSCRIPTION_ID"),
-		ResourceGroup:  os.Getenv("RESOURCEGROUP"),
+	// TODO: Maybe support more than a single request?
+	// For now if the lock is held
+	select {
+	case s.inProgress <- struct{}{}:
+		// continue
+	default:
+		// did not get the lock
+		resp := "423 Locked: Processing another in-flight request"
+		logrus.Debug(resp)
+		http.Error(w, resp, http.StatusLocked)
+		return false
 	}
 
-	cs.Properties.RouterProfiles = []acsapi.RouterProfile{
-		{
-			Name:            "default",
-			PublicSubdomain: fmt.Sprintf("%s.%s", os.Getenv("RESOURCEGROUP"), os.Getenv("DNS_DOMAIN")),
-			FQDN:            fmt.Sprintf("%s-router.%s.cloudapp.azure.com", cs.Properties.AzProfile.ResourceGroup, cs.Location),
-		},
-	}
+	return true
+}
 
-	cs.Properties.ServicePrincipalProfile = &acsapi.ServicePrincipalProfile{
-		ClientID: os.Getenv("AZURE_CLIENT_ID"),
-		Secret:   os.Getenv("AZURE_CLIENT_SECRET"),
-	}
-
+// TODO: Figure out what scheme to use in a request header
+// and compare the secrets here.
+func validateSecret(r *http.Request, secret []byte) error {
 	return nil
 }
 
-func writeHelpers(c *acsapi.OpenShiftManagedCluster, azuredeploy []byte) error {
-	b, err := config.Derived.CloudProviderConf(c)
-	if err != nil {
-		return err
-	}
-
-	err = ioutil.WriteFile("_data/_out/azure.conf", b, 0600)
-	if err != nil {
-		return err
-	}
-
-	err = ioutil.WriteFile("_data/_out/azuredeploy.json", azuredeploy, 0600)
-	if err != nil {
-		return err
-	}
-
-	b, err = tls.PrivateKeyAsBytes(c.Config.SSHKey)
-	if err != nil {
-		return err
-	}
-	err = ioutil.WriteFile("_data/_out/id_rsa", b, 0600)
-	if err != nil {
-		return err
-	}
-
-	b, err = yaml.Marshal(c.Config.AdminKubeconfig)
-	if err != nil {
-		return err
-	}
-	return ioutil.WriteFile("_data/_out/admin.kubeconfig", b, 0600)
-}
-
 func main() {
-	flag.Parse()
-	// mock logger configuration
 	logger := logrus.New()
 	logger.Formatter = &logrus.TextFormatter{FullTimestamp: true}
-	// sanitize input to only accept specific log levels and tolerate junk
-	logger.SetLevel(log.SanitizeLogLevel(*logLevel))
+	logger.SetLevel(logrus.DebugLevel)
 	log := logrus.NewEntry(logger)
+
+	rp := &server{
+		inProgress: make(chan struct{}, 1),
+		log:        log.WithFields(logrus.Fields{"resourceGroup": os.Getenv("RESOURCEGROUP")}),
+	}
+	go rp.ListenAndServe()
 
 	// read in the external API manifest.
 	b, err := ioutil.ReadFile("_data/manifest.yaml")
 	if err != nil {
 		log.Fatal(err)
 	}
-	var oc *v20180930preview.OpenShiftManagedCluster
-	err = yaml.Unmarshal(b, &oc)
+
+	// prepare request to the server
+	req, err := http.NewRequest("PUT", "http://localhost:8080", bytes.NewReader(b))
 	if err != nil {
 		log.Fatal(err)
 	}
-
-	//simulate Context with property bag
 	ctx := context.Background()
-	ctx = context.WithValue(ctx, acsapi.ContextKeyClientID, os.Getenv("AZURE_CLIENT_ID"))
-	ctx = context.WithValue(ctx, acsapi.ContextKeyClientSecret, os.Getenv("AZURE_CLIENT_SECRET"))
-	ctx = context.WithValue(ctx, acsapi.ContextKeyTenantID, os.Getenv("AZURE_TENANT_ID"))
+	ctx = context.WithValue(ctx, api.ContextKeyClientID, os.Getenv("AZURE_CLIENT_ID"))
+	ctx = context.WithValue(ctx, api.ContextKeyClientSecret, os.Getenv("AZURE_CLIENT_SECRET"))
+	ctx = context.WithValue(ctx, api.ContextKeyTenantID, os.Getenv("AZURE_TENANT_ID"))
+	req = req.WithContext(ctx)
 
-	// simulate the API call to the RP
-	entry := logrus.NewEntry(logger).WithFields(logrus.Fields{"resourceGroup": os.Getenv("RESOURCEGROUP")})
-	oc, err = createOrUpdate(ctx, oc, entry)
+	// do request and read response to get the updated API manifest
+	c := &http.Client{}
+	// TODO: Maybe implement retries in case the server is not responding yet
+	resp, err := c.Do(req)
 	if err != nil {
 		log.Fatal(err)
 	}
+	defer resp.Body.Close()
 
-	// persist the returned (updated) external API manifest.
-	b, err = yaml.Marshal(oc)
-	if err != nil {
-		log.Fatal(err)
-	}
-	err = ioutil.WriteFile("_data/manifest.yaml", b, 0666)
-	if err != nil {
-		log.Fatal(err)
+	if resp.StatusCode == http.StatusOK {
+		// persist the returned (updated) external API manifest.
+		if b, err := ioutil.ReadAll(resp.Body); err != nil {
+			err = ioutil.WriteFile("_data/manifest.yaml", b, 0666)
+			if err != nil {
+				log.Fatal(err)
+			}
+		}
 	}
 }

--- a/pkg/fakerp/fakerp.go
+++ b/pkg/fakerp/fakerp.go
@@ -1,0 +1,229 @@
+package fakerp
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"os"
+
+	"github.com/Azure/azure-sdk-for-go/services/marketplaceordering/mgmt/2015-06-01/marketplaceordering"
+	"github.com/Azure/go-autorest/autorest/azure/auth"
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/ghodss/yaml"
+	"github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/util/errors"
+
+	"github.com/openshift/openshift-azure/pkg/api"
+	v20180930preview "github.com/openshift/openshift-azure/pkg/api/2018-09-30-preview/api"
+	"github.com/openshift/openshift-azure/pkg/config"
+	"github.com/openshift/openshift-azure/pkg/log"
+	"github.com/openshift/openshift-azure/pkg/plugin"
+	"github.com/openshift/openshift-azure/pkg/tls"
+	"github.com/openshift/openshift-azure/pkg/upgrade"
+	"github.com/openshift/openshift-azure/pkg/util/managedcluster"
+)
+
+// CreateOrUpdate simulates the RP
+func CreateOrUpdate(ctx context.Context, oc *v20180930preview.OpenShiftManagedCluster, entry *logrus.Entry) (*v20180930preview.OpenShiftManagedCluster, error) {
+	// instantiate the plugin
+	p := plugin.NewPlugin(entry, os.Getenv("SYNC_IMAGE"))
+
+	// convert the external API manifest into the internal API representation
+	log.Info("convert to internal")
+	cs := api.ConvertFromV20180930preview(oc)
+
+	// the RP will enrich the internal API representation with data not included
+	// in the original request
+	log.Info("enrich")
+	err := enrich(cs)
+	if err != nil {
+		return nil, err
+	}
+
+	// read in the OpenShift config blob if it exists (i.e. we're updating)
+	// in the update path, the RP should have access to the previous internal
+	// API representation for comparison.
+	var oldCs *api.OpenShiftManagedCluster
+	if _, err := os.Stat("_data/containerservice.yaml"); err == nil {
+		log.Info("read old config")
+		oldCs, err = managedcluster.ReadConfig("_data/containerservice.yaml")
+		if err != nil {
+			return nil, err
+		}
+
+		log.Info("merge old and new config")
+		p.MergeConfig(ctx, cs, oldCs)
+	}
+
+	// validate the internal API representation (with reference to the previous
+	// internal API representation)
+	// we set fqdn during enrichment which is slightly different than what the RP
+	// will do so we are only validating once.
+	errs := p.Validate(ctx, cs, oldCs, false)
+	if len(errs) > 0 {
+		return nil, errors.NewAggregate(errs)
+	}
+
+	// generate or update the OpenShift config blob
+	err = p.GenerateConfig(ctx, cs)
+	if err != nil {
+		return nil, err
+	}
+
+	// persist the OpenShift container service
+	log.Info("persist config")
+	bytes, err := yaml.Marshal(cs)
+	if err != nil {
+		return nil, err
+	}
+	err = ioutil.WriteFile("_data/containerservice.yaml", bytes, 0600)
+	if err != nil {
+		return nil, err
+	}
+
+	err = os.MkdirAll("_data/_out", 0777)
+	if err != nil {
+		return nil, err
+	}
+
+	// generate the ARM template
+	azuredeploy, err := p.GenerateARM(ctx, cs, oldCs != nil)
+	if err != nil {
+		return nil, err
+	}
+
+	// write out development files
+	log.Info("write helpers")
+	err = writeHelpers(cs, azuredeploy)
+	if err != nil {
+		return nil, err
+	}
+
+	err = acceptMarketplaceAgreement(ctx, cs)
+	if err != nil {
+		return nil, err
+	}
+
+	if oldCs != nil {
+		err = p.Update(ctx, cs, azuredeploy)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		err = upgrade.Deploy(ctx, cs, p, azuredeploy)
+		if err != nil {
+			return nil, err
+		}
+	}
+
+	err = p.HealthCheck(ctx, cs)
+	if err != nil {
+		return nil, err
+	}
+
+	// convert our (probably changed) internal API representation back to the
+	// external API manifest to return it to the user
+	oc = api.ConvertToV20180930preview(cs)
+
+	return oc, nil
+}
+
+func acceptMarketplaceAgreement(ctx context.Context, cs *api.OpenShiftManagedCluster) error {
+	if config.Derived.ImageResourceName() != "" ||
+		os.Getenv("AUTOACCEPT_MARKETPLACE_AGREEMENT") != "yes" {
+		return nil
+	}
+
+	config := auth.NewClientCredentialsConfig(ctx.Value(api.ContextKeyClientID).(string), ctx.Value(api.ContextKeyClientSecret).(string), ctx.Value(api.ContextKeyTenantID).(string))
+	authorizer, err := config.Authorizer()
+	if err != nil {
+		return err
+	}
+
+	mpo := marketplaceordering.NewMarketplaceAgreementsClient(cs.Properties.AzProfile.SubscriptionID)
+	mpo.Authorizer = authorizer
+
+	log.Info("checking marketplace agreement")
+	terms, err := mpo.Get(ctx, cs.Config.ImagePublisher, cs.Config.ImageOffer, cs.Config.ImageSKU)
+	if err != nil {
+		return err
+	}
+
+	if *terms.AgreementProperties.Accepted {
+		return nil
+	}
+
+	terms.AgreementProperties.Accepted = to.BoolPtr(true)
+
+	log.Info("accepting marketplace agreement")
+	_, err = mpo.Create(ctx, cs.Config.ImagePublisher, cs.Config.ImageOffer, cs.Config.ImageSKU, terms)
+	return err
+}
+
+func enrich(cs *api.OpenShiftManagedCluster) error {
+	for _, env := range []string{
+		"AZURE_CLIENT_ID",
+		"AZURE_CLIENT_SECRET",
+		"AZURE_SUBSCRIPTION_ID",
+		"AZURE_TENANT_ID",
+		"DNS_DOMAIN",
+		"RESOURCEGROUP",
+	} {
+		if os.Getenv(env) == "" {
+			return fmt.Errorf("must set %s", env)
+		}
+	}
+
+	cs.Properties.AzProfile = &api.AzProfile{
+		TenantID:       os.Getenv("AZURE_TENANT_ID"),
+		SubscriptionID: os.Getenv("AZURE_SUBSCRIPTION_ID"),
+		ResourceGroup:  os.Getenv("RESOURCEGROUP"),
+	}
+
+	cs.Properties.RouterProfiles = []api.RouterProfile{
+		{
+			Name:            "default",
+			PublicSubdomain: fmt.Sprintf("%s.%s", os.Getenv("RESOURCEGROUP"), os.Getenv("DNS_DOMAIN")),
+			FQDN:            fmt.Sprintf("%s-router.%s.cloudapp.azure.com", cs.Properties.AzProfile.ResourceGroup, cs.Location),
+		},
+	}
+
+	cs.Properties.ServicePrincipalProfile = &api.ServicePrincipalProfile{
+		ClientID: os.Getenv("AZURE_CLIENT_ID"),
+		Secret:   os.Getenv("AZURE_CLIENT_SECRET"),
+	}
+
+	return nil
+}
+
+func writeHelpers(c *api.OpenShiftManagedCluster, azuredeploy []byte) error {
+	b, err := config.Derived.CloudProviderConf(c)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile("_data/_out/azure.conf", b, 0600)
+	if err != nil {
+		return err
+	}
+
+	err = ioutil.WriteFile("_data/_out/azuredeploy.json", azuredeploy, 0600)
+	if err != nil {
+		return err
+	}
+
+	b, err = tls.PrivateKeyAsBytes(c.Config.SSHKey)
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile("_data/_out/id_rsa", b, 0600)
+	if err != nil {
+		return err
+	}
+
+	b, err = yaml.Marshal(c.Config.AdminKubeconfig)
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile("_data/_out/admin.kubeconfig", b, 0600)
+}


### PR DESCRIPTION
Still not ready but pushing this out for early feedback

TODO
- [ ] All the environment variables used in `pkg/fakerp/createorupdate.go` need to be read from the request context or passed down to `createOrUpdate` via other means.
- [ ] writting down files probably needs to be reworked? maybe not
- [x] Expose createOrUpdate to be used by the e2e framework

/cc jim-minter 