### PR TITLE
Add OWNERS labeling

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -14,3 +14,5 @@ reviewers:
 - pweil-
 - thanasisk
 - thekad
+labels:
+- sig/azure


### PR DESCRIPTION
The OWNERS file in this repo is automatically synced in
openshift/release where we need to use automated labeling
of PRs touching azure-related config. OWNERS files provide
support for automated labeling and this change enables that.

/cc @mjudeikis 