### PR TITLE
Start using kubeconfig in tests vs cluster config

### DIFF
--- a/test/e2e/extended_suite_test.go
+++ b/test/e2e/extended_suite_test.go
@@ -12,8 +12,8 @@ import (
 )
 
 var (
-	gitCommit = "unknown"
-	config    = flag.String("config", "../../_data/containerservice.yaml", "Location of the config")
+	gitCommit  = "unknown"
+	kubeconfig = flag.String("kubeconfig", "../../_data/_out/admin.kubeconfig", "Location of the kubeconfig")
 )
 
 func TestExtended(t *testing.T) {

--- a/test/e2e/osa_test.go
+++ b/test/e2e/osa_test.go
@@ -13,25 +13,25 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 	"k8s.io/client-go/kubernetes"
-
-	"github.com/openshift/openshift-azure/pkg/api"
-	"github.com/openshift/openshift-azure/pkg/util/managedcluster"
+	"k8s.io/client-go/tools/clientcmd"
 )
 
 type testClient struct {
 	kc *kubernetes.Clientset
-	cs *api.OpenShiftManagedCluster
 }
 
 var c testClient
 
 var _ = BeforeSuite(func() {
-	var err error
-	c.cs, err = managedcluster.ReadConfig(*config)
+
+	// use the current context in kubeconfig
+	config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
 	Expect(err).NotTo(HaveOccurred())
 
-	c.kc, err = managedcluster.ClientsetFromConfig(c.cs)
+	// create the clientset
+	clientset, err := kubernetes.NewForConfig(config)
 	Expect(err).NotTo(HaveOccurred())
+	c.kc = clientset
 })
 
 var _ = Describe("Openshift on Azure e2e tests", func() {


### PR DESCRIPTION
@jim-minter @mjudeikis @kwoodson first step to make our e2e suite run based on the type of the user (end-user, SRE) is to stop accessing the content of the config blob and require only a kubeconfig. In a follow up we should start reading the azure credentials from the environment in order to use the azure SDK for tests that are going to need it.