### PR TITLE
Split e2e framework to run different suites based on provided kubeconfig 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -51,7 +51,7 @@ cover:
 	go tool cover -html=coverage.out
 
 e2e: generate
-	go test ./test/e2e -tags e2e
+	./hack/e2e.sh
 
 e2e-bin: generate
 	go test -tags e2e -ldflags "-X github.com/openshift/openshift-azure/test/e2e.gitCommit=$(shell git rev-parse --short HEAD)" -i -c -o e2e.test ./test/e2e

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -1,0 +1,22 @@
+#!/bin/bash -e
+
+if [[ -z "$RESOURCEGROUP" ]]; then
+    RESOURCEGROUP=$(awk '/^    resourceGroup:/ { print $2 }' <_data/containerservice.yaml)
+fi
+
+echo "Running end user e2e tests"
+# Login as osadmin to simulate a regural user
+password=$(hack/config.sh get-config $RESOURCEGROUP | jq -r .config.adminPasswd)
+fqdn=$(hack/config.sh get-config $RESOURCEGROUP | jq -r .properties.fqdn)
+oc login $fqdn --username osadmin --password $password --insecure-skip-tls-verify=true
+oc new-project e2e-end-user-test-root
+# TODO: Run the e2e image inside a job. Figure out whether we run as part of ci-operator
+# or it's just a local run.
+
+# TODO: Wait for the job to finish, report results
+oc delete project e2e-end-user-test-root
+oc logout
+
+echo "Running azure cluster reader e2e tests"
+(hack/config.sh get-config $RESOURCEGROUP | jq -r .config.azureClusterReaderKubeconfig | base64 -d) > _data/_out/azure-cluster-reader.kubeconfig
+go test ./test/e2e -ginkgo.focus="\[AzureClusterReader\]" -tags e2e -kubeconfig ../../_data/_out/azure-cluster-reader.kubeconfig

--- a/test/e2e/admin_test.go
+++ b/test/e2e/admin_test.go
@@ -7,38 +7,22 @@ import (
 	"time"
 
 	"github.com/ghodss/yaml"
-
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
-	"k8s.io/client-go/kubernetes"
-	"k8s.io/client-go/tools/clientcmd"
 
 	"github.com/openshift/openshift-azure/pkg/jsonpath"
 )
 
-type testClient struct {
-	kc *kubernetes.Clientset
-}
-
-var c testClient
-
 var _ = BeforeSuite(func() {
-
-	// use the current context in kubeconfig
-	config, err := clientcmd.BuildConfigFromFlags("", *kubeconfig)
-	Expect(err).NotTo(HaveOccurred())
-
-	// create the clientset
-	clientset, err := kubernetes.NewForConfig(config)
-	Expect(err).NotTo(HaveOccurred())
-	c.kc = clientset
+	c = newTestClient(*kubeconfig)
 })
 
-var _ = Describe("Openshift on Azure e2e tests", func() {
+var _ = Describe("Openshift on Azure admin e2e tests [AzureClusterReader]", func() {
+	defer GinkgoRecover()
+
 	It("should label nodes correctly", func() {
 		labels := map[string]map[string]string{
 			"master": {

--- a/test/e2e/client_test.go
+++ b/test/e2e/client_test.go
@@ -1,0 +1,60 @@
+//+build e2e
+
+package e2e
+
+import (
+	"time"
+
+	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/rest"
+	"k8s.io/client-go/tools/clientcmd"
+)
+
+var c *testClient
+
+type testClient struct {
+	kc        *kubernetes.Clientset
+	namespace string
+}
+
+func newTestClient(kubeconfig string) *testClient {
+	var err error
+	var config *rest.Config
+
+	if kubeconfig != "" {
+		config, err = clientcmd.BuildConfigFromFlags("", kubeconfig)
+		if err != nil {
+			panic(err)
+		}
+	} else {
+		// use in-cluster config if no kubeconfig has been specified
+		config, err = rest.InClusterConfig()
+		if err != nil {
+			panic(err.Error())
+		}
+	}
+
+	// create the clientset
+	kc, err := kubernetes.NewForConfig(config)
+	if err != nil {
+		panic(err)
+	}
+
+	return &testClient{
+		kc: kc,
+	}
+}
+
+func (t *testClient) createNamespace(namespace string) {
+	// TODO: Create a project request
+	t.namespace = namespace
+	// TODO: Wait for a successful SAR check
+}
+
+func (t *testClient) cleanupNamespace(timeout time.Duration) {
+	if t.namespace == "" {
+		return
+	}
+
+	// TODO: Do a project delete and wait for the namespace to cleanup
+}

--- a/test/e2e/end_user_test.go
+++ b/test/e2e/end_user_test.go
@@ -1,0 +1,35 @@
+//+build e2e
+
+package e2e
+
+import (
+	"time"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+)
+
+var _ = Describe("Openshift on Azure end user e2e tests [EndUser]", func() {
+	defer GinkgoRecover()
+
+	BeforeEach(func() {
+		// TODO: Use a generator here
+		namespace := "generateme"
+		// TODO: The namespace is cached in the client so this will not
+		// work with parallel tests.
+		c.createNamespace(namespace)
+	})
+
+	AfterEach(func() {
+		if CurrentGinkgoTestDescription().Failed {
+			// TODO: Dump info from namespace
+		}
+		c.cleanupNamespace(10 * time.Minute)
+	})
+
+	// TODO: Add tests
+	It("dummy test", func() {
+		var err error
+		Expect(err).NotTo(HaveOccurred())
+	})
+})


### PR DESCRIPTION
Split out of https://github.com/openshift/openshift-azure/pull/428

@jim-minter @mjudeikis the idea here is to run all e2e suites as part of our merge queue (hence `hack/e2e.sh`) while allowing to run tests both inside a cluster and given a kubeconfig. For now I am assuming that if the provided kubeconfig is not system:admin or the azure cluster reader, it's an end user. PTAL, I think we can get this merged as is and iterate on the e2e user tests with the addition of openshift client-go.