### PR TITLE
Issue/pull request templates

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -1,0 +1,26 @@
+---
+name: Bug report
+about: Create a report to help us improve
+
+---
+
+**Describe the bug**
+A clear and concise description of what the bug is.
+
+**Versions**
+List versions of the components installed. E.g. golang version, git SHA of the repo, etc
+
+**To Reproduce**
+Steps to reproduce the behavior:
+1. Step 1
+2. Step 2
+3. Step N
+
+**Expected behavior**
+A clear and concise description of what you expected to happen.
+
+**Actual behavior**
+Attach any error codes/stack traces that may help troubleshoot this issue. Don't forget to strip out any secrets as necessary.
+
+**Additional context**
+Add any other context about the problem here.

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -1,0 +1,17 @@
+---
+name: Feature request
+about: Suggest an idea for this project
+
+---
+
+**Is your feature request related to a problem? Please describe.**
+A clear and concise description of what the problem is. Ex. I'm always frustrated when [...]
+
+**Indentified workarounds**
+Describe any number of workarounds you've had to follow/you know about to make up for the lack of the proposed feature
+
+**Describe the solution you'd like**
+A clear and concise description of what you want to happen.
+
+**Additional context**
+Add any other context or screenshots about the feature request here.

--- a/.github/ISSUE_TEMPLATE/roadmap-task.md
+++ b/.github/ISSUE_TEMPLATE/roadmap-task.md
@@ -7,6 +7,9 @@ about: Task identified as part of roadmap/sprint
 **Task description**
 Concise description of what the task is about
 
+**References**
+Other issues/stories this task is linked to (href as appropriate)
+
 **Deliverables**
 List of deliverables for this task. Keep it short to 1 or 2 tops (more deliverables are a sign this task should be broken down in more pieces)
 

--- a/.github/ISSUE_TEMPLATE/roadmap-task.md
+++ b/.github/ISSUE_TEMPLATE/roadmap-task.md
@@ -1,0 +1,17 @@
+---
+name: Roadmap task
+about: Task identified as part of roadmap/sprint
+
+---
+
+**Task description**
+Concise description of what the task is about
+
+**Deliverables**
+List of deliverables for this task. Keep it short to 1 or 2 tops (more deliverables are a sign this task should be broken down in more pieces)
+
+1. Deliverable 1: what it is, where it should live, how is it going to be updated in the future
+2. Deliverable 2
+
+**Validation**
+How are the deliverables going to be validated? Examples are: unit test, functional test, SOP review, etc

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -2,7 +2,7 @@ Fixes #.
 (if your pull request doesn't have an issue attached, remove)
 
 **Rationale for this pull request**
-Why is this pull request needed? (could be as easy as "fixes bug #.")
+Why is this pull request needed? (could be as short as "see attached bug #.")
 
 **Changes in this pull request**
 

--- a/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
+++ b/.github/PULL_REQUEST_TEMPLATE/pull_request_template.md
@@ -1,0 +1,17 @@
+Fixes #.
+(if your pull request doesn't have an issue attached, remove)
+
+**Rationale for this pull request**
+Why is this pull request needed? (could be as easy as "fixes bug #.")
+
+**Changes in this pull request**
+
+* Change 1
+* Change 2
+
+(pro tip: `git diff --format="* %s" origin/master..` then paste here and edit)
+
+**Reviewers**
+Ping people here who may be good reviewers for your PR or remove if unsure.
+Please don't ping entire teams unless necessary to lower notification noise.
+


### PR DESCRIPTION
Following https://help.github.com/articles/about-issue-and-pull-request-templates/
Adding templates helps requestors figure out what information to list so reviewers can triage/review faster.