### PR TITLE
fix missing NetworkProfile merge

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -52,6 +52,9 @@ func (p *plugin) MergeConfig(ctx context.Context, cs, oldCs *api.OpenShiftManage
 	if len(cs.Properties.PublicHostname) == 0 {
 		cs.Properties.PublicHostname = oldCs.Properties.PublicHostname
 	}
+	if cs.Properties.NetworkProfile == nil {
+		cs.Properties.NetworkProfile = oldCs.Properties.NetworkProfile
+	}
 	if len(cs.Properties.RouterProfiles) == 0 {
 		cs.Properties.RouterProfiles = oldCs.Properties.RouterProfiles
 	}

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -43,6 +43,9 @@ func TestMerge(t *testing.T) {
 	if len(newCluster.Properties.AgentPoolProfiles) == 0 {
 		t.Errorf("new cluster agent pool profiles should be merged")
 	}
+	if newCluster.Properties.NetworkProfile == nil {
+		t.Errorf("new cluster network profile should be merged")
+	}
 	if len(newCluster.Properties.RouterProfiles) == 0 {
 		t.Errorf("new cluster router profiles should be merged")
 	}


### PR DESCRIPTION
fixes #541 

This should have been caught by a test.  AZURE-135 will rework all of this area, and I have added the requirement for such a test there.