### PR TITLE
Define APIVersion in the api packages

### DIFF
--- a/pkg/api/2018-09-30-preview/api/types.go
+++ b/pkg/api/2018-09-30-preview/api/types.go
@@ -1,5 +1,10 @@
 package api
 
+const (
+	// APIVersion is the version of this API
+	APIVersion = "2018-09-30-preview"
+)
+
 // OpenShiftManagedCluster complies with the ARM model of resource definition in
 // a JSON template.
 type OpenShiftManagedCluster struct {

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -1,5 +1,10 @@
 package api
 
+const (
+	// APIVersion is the version of this API
+	APIVersion = "internal"
+)
+
 // OpenShiftManagedCluster complies with the ARM model of resource definition in
 // a JSON template.
 type OpenShiftManagedCluster struct {


### PR DESCRIPTION
closes #433 

@amanohar can you let me know if this is what you are after?
I was unsure what we should put into the unversioned api, maybe "unversioned" instead of "master"..