### PR TITLE
add flag for delete.sh

### DIFF
--- a/hack/delete.sh
+++ b/hack/delete.sh
@@ -23,7 +23,11 @@ if [[ ! -e _data/containerservice.yaml ]]; then
     exit 1
 fi
 
-RESOURCEGROUP=$(awk '/^    resourceGroup:/ { print $2 }' <_data/containerservice.yaml)
+if [[ $# -eq 1 ]]; then
+    export RESOURCEGROUP=$1
+else
+    RESOURCEGROUP=$(awk '/^    resourceGroup:/ { print $2 }' <_data/containerservice.yaml)
+fi
 
 hack/dns.sh zone-delete $RESOURCEGROUP
 


### PR DESCRIPTION
this got me already few times!

If you have created cluster `cluster-prod` but want to clean old cluster `cluster-dev` and execute:
`./hack/delete.sh cluster-dev` your prod cluster is dead :)