### PR TITLE
Remove redundant flag from hack scripts

### DIFF
--- a/hack/create.sh
+++ b/hack/create.sh
@@ -117,7 +117,7 @@ properties:
 EOF
 
 go generate ./...
-go run cmd/createorupdate/createorupdate.go -loglevel=debug
+go run cmd/createorupdate/createorupdate.go
 
 # TODO: This should be configured by MS
 hack/dns.sh zone-create $RESOURCEGROUP

--- a/hack/upgrade.sh
+++ b/hack/upgrade.sh
@@ -44,4 +44,4 @@ fi
 export RESOURCEGROUP=$(awk '/^    resourceGroup:/ { print $2 }' <_data/containerservice.yaml)
 
 go generate ./...
-go run cmd/createorupdate/createorupdate.go -loglevel=debug
+go run cmd/createorupdate/createorupdate.go


### PR DESCRIPTION
The flag was removed in https://github.com/openshift/openshift-azure/pull/572