### PR TITLE
Miscellaneous fixes necessitated by addition of prod subscription

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,8 @@
 /_data
 /createorupdate
 /env
+/env.*
+!/env.example
 /e2e.test
 /logbridge
 /sync

--- a/env.example
+++ b/env.example
@@ -43,5 +43,10 @@ export DEPLOY_VERSION=v3.10
 # If overriding the image used for the sync pod, customise this section.
 #export SYNC_IMAGE=quay.io/openshift-on-azure/sync:v3.10
 
-# If set to true, avoid waiting for the resource group to be cleaned up during deletion.
-# export NO_WAIT=true
+# If set to true, avoid waiting for the resource group to be cleaned up during
+# deletion.
+#export NO_WAIT=true
+
+# If set to true, avoid tagging the resource group to be cleaned up by the
+# pruner.
+#export NOGROUPTAGS=true

--- a/hack/config.sh
+++ b/hack/config.sh
@@ -10,6 +10,10 @@ EOF
     exit 1
 }
 
+if [[ -z "$AZURE_SUBSCRIPTION_ID" ]]; then
+    AZURE_SUBSCRIPTION_ID=$(az account show --query id --output tsv)
+fi
+
 case "$1" in
 get-config)
     if [[ "$#" -ne 2 ]]; then usage; fi
@@ -17,9 +21,9 @@ get-config)
     OSACONFIG=$(mktemp -d)
     trap "rm -rf $OSACONFIG" EXIT
 
-    export AZURE_STORAGE_ACCOUNT=$(az storage account list -g $2 | jq '.[] | select(.tags.type == "config") | .name ' | tr -d '"')
-    export AZURE_STORAGE_KEY=$(az storage account keys list -n $AZURE_STORAGE_ACCOUNT -g $2 --query '[0].value' | tr -d '"')
-    az storage blob download --file $OSACONFIG/config -c config -n config --no-progress >/dev/null
+    export AZURE_STORAGE_ACCOUNT=$(az storage account list --subscription $AZURE_SUBSCRIPTION_ID -g $2 | jq '.[] | select(.tags.type == "config") | .name ' | tr -d '"')
+    export AZURE_STORAGE_KEY=$(az storage account keys list --subscription $AZURE_SUBSCRIPTION_ID -n $AZURE_STORAGE_ACCOUNT -g $2 --query '[0].value' | tr -d '"')
+    az storage blob download --subscription $AZURE_SUBSCRIPTION_ID --file $OSACONFIG/config -c config -n config --no-progress >/dev/null
     cat $OSACONFIG/config
     ;;
 

--- a/hack/create.sh
+++ b/hack/create.sh
@@ -63,11 +63,14 @@ export RESOURCEGROUP=$1
 rm -rf _data
 mkdir -p _data/_out
 
-ttl=76h
-if [[ -n $RESOURCEGROUP_TTL ]]; then
-  ttl=$RESOURCEGROUP_TTL
+if [[ -z "$NOGROUPTAGS" ]]; then
+  ttl=76h
+  if [[ -n "$RESOURCEGROUP_TTL" ]]; then
+    ttl=$RESOURCEGROUP_TTL
+  fi
+  GROUPTAGS=--tags now=$(date +%s) ttl=$ttl
 fi
-az group create -n $RESOURCEGROUP -l $AZURE_REGION --tags now=$(date +%s) ttl=$ttl >/dev/null
+az group create -n $RESOURCEGROUP -l $AZURE_REGION $GROUPTAGS >/dev/null
 
 # if AZURE_CLIENT_ID is used as AZURE_AAD_CLIENT_ID, script will reset global team account!
 set +x

--- a/hack/create.sh
+++ b/hack/create.sh
@@ -70,7 +70,7 @@ if [[ -z "$NOGROUPTAGS" ]]; then
   fi
   GROUPTAGS=--tags now=$(date +%s) ttl=$ttl
 fi
-az group create -n $RESOURCEGROUP -l $AZURE_REGION $GROUPTAGS >/dev/null
+az group create --subscription $AZURE_SUBSCRIPTION_ID -n $RESOURCEGROUP -l $AZURE_REGION $GROUPTAGS >/dev/null
 
 # if AZURE_CLIENT_ID is used as AZURE_AAD_CLIENT_ID, script will reset global team account!
 set +x

--- a/hack/delete.sh
+++ b/hack/delete.sh
@@ -23,6 +23,10 @@ if [[ ! -e _data/containerservice.yaml ]]; then
     exit 1
 fi
 
+if [[ -z "$AZURE_SUBSCRIPTION_ID" ]]; then
+    AZURE_SUBSCRIPTION_ID=$(az account show --query id --output tsv)
+fi
+
 if [[ $# -eq 1 ]]; then
     export RESOURCEGROUP=$1
 else
@@ -33,4 +37,4 @@ hack/dns.sh zone-delete $RESOURCEGROUP
 
 rm -rf _data
 
-az group delete -n $RESOURCEGROUP -y ${NO_WAIT_FLAG}
+az group delete --subscription $AZURE_SUBSCRIPTION_ID -n $RESOURCEGROUP -y ${NO_WAIT_FLAG}

--- a/hack/dns.sh
+++ b/hack/dns.sh
@@ -10,6 +10,10 @@ if [[ -z "$DNS_RESOURCEGROUP" ]]; then
     exit 1
 fi
 
+if [[ -z "$AZURE_SUBSCRIPTION_ID" ]]; then
+    AZURE_SUBSCRIPTION_ID=$(az account show --query id --output tsv)
+fi
+
 usage() {
     cat <<EOF >&2
 usage:
@@ -28,7 +32,7 @@ $0 a-create testzone '*' 1.2.3.4
 dig +short foo.testzone.$DNS_DOMAIN
 $0 a-delete testzone '*'
 $0 zone-delete testzone
-$0 cname-create testzone '*' app.eastus.cloudapp.azure.com 
+$0 cname-create testzone '*' app.eastus.cloudapp.azure.com
 $0 cname-delete testzone '*'
 
 EOF
@@ -42,46 +46,46 @@ zone-create)
     if [[ "$#" -ne 2 ]]; then usage; fi
 
     # create the new zone
-    az network dns zone create -g "$DNS_RESOURCEGROUP" -n "$2.$DNS_DOMAIN"
-    az network dns record-set soa update -g "$DNS_RESOURCEGROUP" -z "$2.$DNS_DOMAIN" -f 60 -r 60 -x 60 -m 60
-    az network dns record-set ns update -g "$DNS_RESOURCEGROUP" -z "$2.$DNS_DOMAIN" -n @ --set ttl=60
+    az network dns zone create --subscription $AZURE_SUBSCRIPTION_ID -g "$DNS_RESOURCEGROUP" -n "$2.$DNS_DOMAIN"
+    az network dns record-set soa update --subscription $AZURE_SUBSCRIPTION_ID -g "$DNS_RESOURCEGROUP" -z "$2.$DNS_DOMAIN" -f 60 -r 60 -x 60 -m 60
+    az network dns record-set ns update --subscription $AZURE_SUBSCRIPTION_ID -g "$DNS_RESOURCEGROUP" -z "$2.$DNS_DOMAIN" -n @ --set ttl=60
 
     # register the new zone in the "$DNS_DOMAIN" zone
-    NS=$(az network dns zone show -g "$DNS_RESOURCEGROUP" -n "$2.$DNS_DOMAIN" --query 'nameServers[].{nsdname: @}')
-    az network dns record-set ns create -g "$DNS_RESOURCEGROUP" -z "$DNS_DOMAIN" -n "$2" --ttl 60
-    az network dns record-set ns update -g "$DNS_RESOURCEGROUP" -z "$DNS_DOMAIN" -n "$2" --set nsRecords="$NS"
+    NS=$(az network dns zone show --subscription $AZURE_SUBSCRIPTION_ID -g "$DNS_RESOURCEGROUP" -n "$2.$DNS_DOMAIN" --query 'nameServers[].{nsdname: @}')
+    az network dns record-set ns create --subscription $AZURE_SUBSCRIPTION_ID -g "$DNS_RESOURCEGROUP" -z "$DNS_DOMAIN" -n "$2" --ttl 60
+    az network dns record-set ns update --subscription $AZURE_SUBSCRIPTION_ID -g "$DNS_RESOURCEGROUP" -z "$DNS_DOMAIN" -n "$2" --set nsRecords="$NS"
     ;;
 
 zone-delete)
     if [[ "$#" -ne 2 ]]; then usage; fi
 
-    az network dns record-set ns delete -g "$DNS_RESOURCEGROUP" -z "$DNS_DOMAIN" -n "$2" -y
-    az network dns zone delete -g "$DNS_RESOURCEGROUP" -n "$2.$DNS_DOMAIN" -y
+    az network dns record-set ns delete --subscription $AZURE_SUBSCRIPTION_ID -g "$DNS_RESOURCEGROUP" -z "$DNS_DOMAIN" -n "$2" -y
+    az network dns zone delete --subscription $AZURE_SUBSCRIPTION_ID -g "$DNS_RESOURCEGROUP" -n "$2.$DNS_DOMAIN" -y
     ;;
 
 a-create)
     if [[ "$#" -ne 4 ]]; then usage; fi
 
-    az network dns record-set a create -g "$DNS_RESOURCEGROUP" -z "$2.$DNS_DOMAIN" -n "$3" --ttl 60
-    az network dns record-set a update -g "$DNS_RESOURCEGROUP" -z "$2.$DNS_DOMAIN" -n "$3" --set arecords='[{"ipv4Address": "'"$4"'"}]'
+    az network dns record-set a create --subscription $AZURE_SUBSCRIPTION_ID -g "$DNS_RESOURCEGROUP" -z "$2.$DNS_DOMAIN" -n "$3" --ttl 60
+    az network dns record-set a update --subscription $AZURE_SUBSCRIPTION_ID -g "$DNS_RESOURCEGROUP" -z "$2.$DNS_DOMAIN" -n "$3" --set arecords='[{"ipv4Address": "'"$4"'"}]'
     ;;
 
 a-delete)
     if [[ "$#" -ne 3 ]]; then usage; fi
 
-    az network dns record-set a delete -g "$DNS_RESOURCEGROUP" -z "$2.$DNS_DOMAIN" -n "$3" -y
+    az network dns record-set a delete --subscription $AZURE_SUBSCRIPTION_ID -g "$DNS_RESOURCEGROUP" -z "$2.$DNS_DOMAIN" -n "$3" -y
     ;;
 
 cname-create)
     if [[ "$#" -ne 4 ]]; then usage; fi
 
-    az network dns record-set cname set-record -g "$DNS_RESOURCEGROUP" -z "$2.$DNS_DOMAIN" -n "$3" -c "$4"
+    az network dns record-set cname set-record --subscription $AZURE_SUBSCRIPTION_ID -g "$DNS_RESOURCEGROUP" -z "$2.$DNS_DOMAIN" -n "$3" -c "$4"
     ;;
 
 cname-delete)
     if [[ "$#" -ne 3 ]]; then usage; fi
 
-    az network dns record-set cname delete -g "$DNS_RESOURCEGROUP" -z "$2.$DNS_DOMAIN" -n "$3"
+    az network dns record-set cname delete --subscription $AZURE_SUBSCRIPTION_ID -g "$DNS_RESOURCEGROUP" -z "$2.$DNS_DOMAIN" -n "$3"
     ;;
 
 *)

--- a/hack/scp.sh
+++ b/hack/scp.sh
@@ -35,6 +35,10 @@ while getopts :n:s:d: o; do
     esac
 done
 
+if [[ -z "$AZURE_SUBSCRIPTION_ID" ]]; then
+    AZURE_SUBSCRIPTION_ID=$(az account show --query id --output tsv)
+fi
+
 shift $((OPTIND-1))
 RESOURCEGROUP=$1
 
@@ -50,7 +54,7 @@ else
     hack/config.sh get-config $RESOURCEGROUP | jq -r .config.sshKey | base64 -d >$ID_RSA
 fi
 
-IP=$(az vmss list-instance-public-ips -g $RESOURCEGROUP -n ss-master --query "[$ID].ipAddress" | tr -d '"')
+IP=$(az vmss list-instance-public-ips --subscription $AZURE_SUBSCRIPTION_ID -g $RESOURCEGROUP -n ss-master --query "[$ID].ipAddress" | tr -d '"')
 
 eval "$(ssh-agent)"
 ssh-add $ID_RSA 2>/dev/null

--- a/hack/ssh.sh
+++ b/hack/ssh.sh
@@ -32,6 +32,10 @@ while getopts :n:c: o; do
     esac
 done
 
+if [[ -z "$AZURE_SUBSCRIPTION_ID" ]]; then
+    AZURE_SUBSCRIPTION_ID=$(az account show --query id --output tsv)
+fi
+
 shift $((OPTIND-1))
 RESOURCEGROUP=$1
 
@@ -47,7 +51,7 @@ else
     hack/config.sh get-config $RESOURCEGROUP | jq -r .config.sshKey | base64 -d >$ID_RSA
 fi
 
-IP=$(az vmss list-instance-public-ips -g $RESOURCEGROUP -n ss-master --query "[$ID].ipAddress" | tr -d '"')
+IP=$(az vmss list-instance-public-ips --subscription $AZURE_SUBSCRIPTION_ID -g $RESOURCEGROUP -n ss-master --query "[$ID].ipAddress" | tr -d '"')
 
 eval "$(ssh-agent)"
 ssh-add $ID_RSA 2>/dev/null


### PR DESCRIPTION
* add NOGROUPTAGS option to prevent tagging groups with now/ttl (to avoid creating management subscriptions and having them accidentally cleaned up by azure-purge)
* ￼ignore env.* files (to define parameters for management subscriptions in separate env.something files)
* allow overriding of --subscription used by az commands