### PR TITLE
Prod RP requires name to match resource group

### DIFF
--- a/hack/create.sh
+++ b/hack/create.sh
@@ -83,7 +83,7 @@ fi
 set -x
 
 cat >_data/manifest.yaml <<EOF
-name: openshift
+name: $RESOURCEGROUP
 location: $AZURE_REGION
 properties:
   openShiftVersion: "$DEPLOY_VERSION"


### PR DESCRIPTION
When I try to use the OSA sdk and the manifest we currently generate to start a cluster via the prod RP, I get the following error:
```
  containerservice.OpenShiftManagedClustersClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: autorest/azure: Service returned an error. Status=400 Code="MismatchingResourceName" Message="The provided resource name 'openshift' did not match the name in the Url 'kargakisprode2es'."
```
Seems that the prod RP requires name to match the resource group. I can start clusters successfully with this change.