### PR TITLE
Don't print the diff if the object kind is Secret

### DIFF
--- a/pkg/addons/client.go
+++ b/pkg/addons/client.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"reflect"
+	"strings"
 
 	"github.com/go-test/deep"
 	log "github.com/sirupsen/logrus"
@@ -240,8 +241,13 @@ func needsUpdate(existing, o *unstructured.Unstructured) bool {
 	// TODO: we should have tests that monitor these diffs:
 	// 1) when a cluster is created
 	// 2) when sync is run twice back-to-back on the same cluster
-	for _, diff := range deep.Equal(*existing, *o) {
-		log.Infof("- " + diff)
+
+	// Don't show a diff if kind is Secret
+	oGroupKind := o.GroupVersionKind().GroupKind()
+	if strings.ToLower(oGroupKind.String()) != "secret" {
+		for _, diff := range deep.Equal(*existing, *o) {
+			log.Infof("- " + diff)
+		}
 	}
 
 	return true

--- a/pkg/addons/client.go
+++ b/pkg/addons/client.go
@@ -219,6 +219,7 @@ func write(dyn dynamic.ClientPool, grs []*discovery.APIGroupResources, o *unstru
 		if !needsUpdate(existing, o) {
 			return
 		}
+		printDiff(existing, o)
 
 		o.SetResourceVersion(rv)
 		_, err = dc.Resource(res, o.GetNamespace()).Update(o)
@@ -238,19 +239,24 @@ func needsUpdate(existing, o *unstructured.Unstructured) bool {
 
 	log.Infof("Update " + KeyFunc(o.GroupVersionKind().GroupKind(), o.GetNamespace(), o.GetName()))
 
+	return true
+}
+
+func printDiff(existing, o *unstructured.Unstructured) bool {
 	// TODO: we should have tests that monitor these diffs:
 	// 1) when a cluster is created
 	// 2) when sync is run twice back-to-back on the same cluster
 
 	// Don't show a diff if kind is Secret
 	oGroupKind := o.GroupVersionKind().GroupKind()
+	diffShown := false
 	if strings.ToLower(oGroupKind.String()) != "secret" {
 		for _, diff := range deep.Equal(*existing, *o) {
 			log.Infof("- " + diff)
+			diffShown = true
 		}
 	}
-
-	return true
+	return diffShown
 }
 
 // ServiceCatalogExists returns whether the service catalog API exists.

--- a/pkg/addons/client_test.go
+++ b/pkg/addons/client_test.go
@@ -6,37 +6,48 @@ import (
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
-func TestNeedsUpdate(t *testing.T) {
-	tests := []struct {
-		name     string
-		existing *unstructured.Unstructured
-		updated  *unstructured.Unstructured
-		exp      bool
-	}{
-		{
-			name:     "no need for upgrade",
-			existing: getObjectFromFile("testdata/service1.yaml"),
-			updated:  getObjectFromFile("testdata/service2.yaml"),
-			exp:      false,
-		},
-		{
-			name:     "needs upgrade",
-			existing: getObjectFromFile("testdata/service1.yaml"),
-			updated:  getObjectFromFile("testdata/service3.yaml"),
-			exp:      true,
-		},
-		{
-			name:     "secret diff omitted",
-			existing: getObjectFromFile("testdata/secret2.yaml"),
-			updated:  getObjectFromFile("testdata/secret3.yaml"),
-			exp:      true,
-		},
-	}
+var clientTests = []struct {
+	name     string
+	existing *unstructured.Unstructured
+	updated  *unstructured.Unstructured
+	exp      bool
+	diff     bool
+}{
+	{
+		name:     "no need for upgrade",
+		existing: getObjectFromFile("testdata/service1.yaml"),
+		updated:  getObjectFromFile("testdata/service2.yaml"),
+		exp:      false, // no upgrade expected
+		diff:     false, // no diff expected
+	},
+	{
+		name:     "needs upgrade",
+		existing: getObjectFromFile("testdata/service1.yaml"),
+		updated:  getObjectFromFile("testdata/service3.yaml"),
+		exp:      true, // upgrade expected
+		diff:     true, // diff expected
+	},
+	{
+		name:     "secret diff omitted",
+		existing: getObjectFromFile("testdata/secret2.yaml"),
+		updated:  getObjectFromFile("testdata/secret3.yaml"),
+		exp:      true,  // upgrade expected
+		diff:     false, // no diff expected
+	},
+}
 
-	for _, test := range tests {
+func TestNeedsUpdate(t *testing.T) {
+	for _, test := range clientTests {
 		if got := needsUpdate(test.existing, test.updated); got != test.exp {
 			t.Errorf("%s: expected update %t, got %t", test.name, test.exp, got)
 		}
 	}
+}
 
+func TestShouldPrintDiff(t *testing.T) {
+	for _, test := range clientTests {
+		if got := printDiff(test.existing, test.updated); got != test.diff {
+			t.Errorf("%s: expected to print diff %t, got %t", test.name, test.diff, got)
+		}
+	}
 }

--- a/pkg/addons/client_test.go
+++ b/pkg/addons/client_test.go
@@ -25,6 +25,12 @@ func TestNeedsUpdate(t *testing.T) {
 			updated:  getObjectFromFile("testdata/service3.yaml"),
 			exp:      true,
 		},
+		{
+			name:     "secret diff omitted",
+			existing: getObjectFromFile("testdata/secret2.yaml"),
+			updated:  getObjectFromFile("testdata/secret3.yaml"),
+			exp:      true,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
Fixes #504
We don't want secret values to be logged *anywhere*