### PR TITLE
Delete provisioningState before an update

### DIFF
--- a/hack/upgrade.sh
+++ b/hack/upgrade.sh
@@ -36,7 +36,7 @@ if [[ -z "$DNS_RESOURCEGROUP" ]]; then
     exit 1
 fi
 
-if [[ ! -e _data/containerservice.yaml ]]; then
+if [[ $# -eq 0 && ! -e _data/containerservice.yaml ]]; then
     echo error: _data/containerservice.yaml must exist
     exit 1
 fi
@@ -46,6 +46,7 @@ if [[ $# -eq 1 ]]; then
 else
     export RESOURCEGROUP=$(awk '/^    resourceGroup:/ { print $2 }' <_data/containerservice.yaml)
 fi
+sed -i '/provisioningState/d' _data/manifest.yaml
 
 go generate ./...
 go run cmd/createorupdate/createorupdate.go


### PR DESCRIPTION
We started using provisioningState in the fake RP to ensure the OSA SDK is working properly when querying the RP (https://github.com/openshift/openshift-azure/pull/592) but since we now write it down in manifest.yaml, upgrade.sh picks it up and fails to validate.

Fixes https://github.com/openshift/openshift-azure/issues/636