### PR TITLE
Prod cluster test cleanup and createorupdate enhancement

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,9 @@ cover: unit
 e2e: generate
 	./hack/e2e.sh
 
+e2e-prod:
+	go test ./test/e2erp -tags e2erp -test.v -ginkgo.v -ginkgo.randomizeAllSpecs -ginkgo.noColor -ginkgo.focus=Real -timeout 4h
+
 e2e-bin: generate
 	go test -tags e2e -ldflags "-X github.com/openshift/openshift-azure/test/e2e.gitCommit=$(COMMIT)" -i -c -o e2e.test ./test/e2e
 
@@ -67,4 +70,4 @@ e2e-image: e2e-bin
 e2e-push: e2e-image
 	docker push $(E2E_IMAGE)
 
-.PHONY: clean sync-image sync-push verify unit e2e e2e-bin
+.PHONY: clean sync-image sync-push verify unit e2e e2e-bin e2e-prod

--- a/hack/create.sh
+++ b/hack/create.sh
@@ -121,7 +121,7 @@ EOF
 
 go generate ./...
 if [[ -n "$TEST_IN_PRODUCTION" ]]; then
-  go test ./test/e2erp -tags e2erp -test.v -ginkgo.v -ginkgo.randomizeAllSpecs -ginkgo.focus=Real -timeout 4h
+  go run cmd/createorupdate/createorupdate.go -use-prod=true
 else
   go run cmd/createorupdate/createorupdate.go
 

--- a/hack/delete.sh
+++ b/hack/delete.sh
@@ -33,8 +33,11 @@ else
     RESOURCEGROUP=$(awk '/^    resourceGroup:/ { print $2 }' <_data/containerservice.yaml)
 fi
 
-hack/dns.sh zone-delete $RESOURCEGROUP
+USE_PROD_FLAG="-use-prod=true"
+if [[ -z "$TEST_IN_PRODUCTION" ]]; then
+    hack/dns.sh zone-delete $RESOURCEGROUP
+    rm -rf _data
+    USE_PROD_FLAG="-use-prod=false"
+fi
 
-rm -rf _data
-
-go run cmd/createorupdate/createorupdate.go -request DELETE
+go run cmd/createorupdate/createorupdate.go -request=DELETE $USE_PROD_FLAG

--- a/test/e2erp/e2erp_suite_test.go
+++ b/test/e2erp/e2erp_suite_test.go
@@ -20,15 +20,6 @@ var (
 
 var _ = BeforeSuite(func() {
 	c = newTestClient(os.Getenv("RESOURCEGROUP"))
-	if err := c.setup(*manifest); err != nil {
-		panic(err)
-	}
-})
-
-var _ = AfterSuite(func() {
-	if err := c.teardown(); err != nil {
-		panic(err)
-	}
 })
 
 func TestE2eRP(t *testing.T) {


### PR DESCRIPTION
In the first commit, I am separating cluster creation/deletion from the RP test suite to align with what we already do in the openshift e2e suite. An update is required for this in openshift/release to make use of the new make target.

In the second commit, I am enabling updates and cluster cleanups in a single createorupdate run which will potentially simplify our e2e templates and enable us to run upgrade tests locally w/o the need to use our ci-operator templates.

If it's too much to have these in a single PR, I can separate one of the commits to a different PR.