### PR TITLE
Create a new storage blob to track vm hashes

### DIFF
--- a/pkg/cluster/deploy.go
+++ b/pkg/cluster/deploy.go
@@ -1,9 +1,17 @@
 package cluster
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"strings"
 
 	"github.com/openshift/openshift-azure/pkg/api"
+	"github.com/openshift/openshift-azure/pkg/jsonpath"
+	"github.com/openshift/openshift-azure/pkg/log"
 	"github.com/openshift/openshift-azure/pkg/util/managedcluster"
 )
 
@@ -20,6 +28,10 @@ func (u *simpleUpgrader) Deploy(ctx context.Context, cs *api.OpenShiftManagedClu
 	if err != nil {
 		return &api.PluginError{Err: err, Step: api.PluginStepInitialize}
 	}
+	err = u.initializeUpdateBlob(ctx, cs, azuretemplate)
+	if err != nil {
+		log.Warnf("could not initialize update blob: %v", err)
+	}
 	err = managedcluster.WaitForHealthz(ctx, cs.Config.AdminKubeconfig)
 	if err != nil {
 		return &api.PluginError{Err: err, Step: api.PluginStepWaitForWaitForOpenShiftAPI}
@@ -29,4 +41,72 @@ func (u *simpleUpgrader) Deploy(ctx context.Context, cs *api.OpenShiftManagedClu
 		return &api.PluginError{Err: err, Step: api.PluginStepWaitForNodes}
 	}
 	return nil
+}
+
+func (u *simpleUpgrader) initializeUpdateBlob(ctx context.Context, cs *api.OpenShiftManagedCluster, azuretemplate map[string]interface{}) error {
+	blob := make(map[string]string)
+	for _, r := range jsonpath.MustCompile("$.resources.*").Get(azuretemplate) {
+		resource, ok := r.(map[string]interface{})
+		if !ok {
+			continue
+		}
+		if !isScaleSet(resource) {
+			continue
+		}
+
+		// cleanup capacity so that no unnecessary VM rotations are going
+		// to occur because of a scale up/down.
+		jsonpath.MustCompile("$.sku.capacity").Delete(resource)
+
+		// hash scale set
+		data, err := json.Marshal(resource)
+		if err != nil {
+			return err
+		}
+		hf := sha256.New()
+		fmt.Fprintf(hf, string(data))
+
+		blob[getRole(resource)] = base64.StdEncoding.EncodeToString(hf.Sum(nil))
+	}
+
+	for role, hash := range blob {
+		vms, err := listVMs(ctx, cs, u.vmc, api.AgentPoolProfileRole(role))
+		if err != nil {
+			return err
+		}
+		for _, vm := range vms {
+			blob[*vm.VirtualMachineScaleSetVMProperties.OsProfile.ComputerName] = hash
+		}
+	}
+
+	return u.updateBlob(blob)
+}
+
+func isScaleSet(resource map[string]interface{}) bool {
+	for k, v := range resource {
+		if k == "type" && v.(string) == "Microsoft.Compute/virtualMachineScaleSets" {
+			return true
+		}
+	}
+	return false
+}
+
+func getRole(resource map[string]interface{}) string {
+	for k, v := range resource {
+		if k == "name" && strings.HasPrefix(v.(string), "ss-") {
+			return v.(string)[3:]
+		}
+	}
+	return ""
+}
+
+func (u *simpleUpgrader) updateBlob(blob map[string]string) error {
+	data, err := json.Marshal(blob)
+	if err != nil {
+		return err
+	}
+	bsc := u.storageClient.GetBlobService()
+	c := bsc.GetContainerReference("update")
+	b := c.GetBlobReference("update")
+	return b.CreateBlockBlobFromReader(bytes.NewReader(data), nil)
 }

--- a/pkg/cluster/initialize.go
+++ b/pkg/cluster/initialize.go
@@ -29,6 +29,13 @@ func (u *simpleUpgrader) Initialize(ctx context.Context, cs *api.OpenShiftManage
 		return err
 	}
 
+	// update tracking container
+	c = bsc.GetContainerReference("update")
+	_, err = c.CreateIfNotExists(nil)
+	if err != nil {
+		return err
+	}
+
 	// cluster config container
 	c = bsc.GetContainerReference("config")
 	_, err = c.CreateIfNotExists(nil)

--- a/pkg/cluster/initialize_test.go
+++ b/pkg/cluster/initialize_test.go
@@ -32,6 +32,10 @@ func TestInitialize(t *testing.T) {
 	bsa.EXPECT().GetContainerReference("etcd").Return(etcdCr)
 	etcdCr.EXPECT().CreateIfNotExists(nil).Return(true, nil)
 
+	updateCr := mock_storage.NewMockContainer(gmc)
+	bsa.EXPECT().GetContainerReference("update").Return(updateCr)
+	updateCr.EXPECT().CreateIfNotExists(nil).Return(true, nil)
+
 	configCr := mock_storage.NewMockContainer(gmc)
 	bsa.EXPECT().GetContainerReference("config").Return(configCr)
 	configCr.EXPECT().CreateIfNotExists(nil).Return(true, nil)

--- a/pkg/log/log.go
+++ b/pkg/log/log.go
@@ -64,6 +64,11 @@ func Warn(args ...interface{}) {
 	logger.log.Warn(args...)
 }
 
+// Warnf logs at fatal level
+func Warnf(format string, args ...interface{}) {
+	logger.log.Warnf(format, args...)
+}
+
 // WithFields adds a map of fields to the Entry.
 func WithFields(fields logrus.Fields) *logrus.Entry {
 	return logger.log.WithFields(fields)


### PR DESCRIPTION
Create a storage blob in azure to track vm hashes since we cannot tag VMs individually.

Part of AZURE-199

/cc jim-minter asalkeld  