### PR TITLE
Adding another e2e test

### DIFF
--- a/test/e2e/client_test.go
+++ b/test/e2e/client_test.go
@@ -6,10 +6,7 @@ import (
 	"bytes"
 	"fmt"
 	"io/ioutil"
-	"net/http"
 	"path/filepath"
-	"regexp"
-	"strconv"
 	"time"
 
 	"github.com/ghodss/yaml"
@@ -215,45 +212,4 @@ func (t *testClient) instantiateTemplate(tpl string) error {
 
 	// Return after waiting for instance to complete
 	return wait.PollImmediate(2*time.Second, 10*time.Minute, c.templateInstanceIsReady)
-}
-
-func (t *testClient) loopHTTPGet(url string, regex *regexp.Regexp, times int) func() error {
-
-	httpc := &http.Client{
-		Timeout: 10 * time.Second,
-	}
-	var prevCounter, currCounter int
-
-	return func() error {
-		for i := 0; i < times; i++ {
-			resp, err := httpc.Get(url)
-			if err != nil {
-				return err
-			}
-			defer resp.Body.Close()
-			if resp.StatusCode != http.StatusOK {
-				return fmt.Errorf("unexpected http error returned: %d", resp.StatusCode)
-			}
-
-			contents, err := ioutil.ReadAll(resp.Body)
-			if err != nil {
-				return err
-			}
-			matches := regex.FindStringSubmatch(string(contents))
-			if matches == nil {
-				return fmt.Errorf("no matches found for %s", regex)
-			}
-
-			currCounter, err = strconv.Atoi(matches[1])
-			if err != nil {
-				return err
-			}
-			if currCounter <= prevCounter {
-				return fmt.Errorf("visit counter didn't increment: %d should be > than %d", currCounter, prevCounter)
-			}
-			prevCounter = currCounter
-			time.Sleep(time.Second)
-		}
-		return nil
-	}
 }

--- a/test/e2e/conditions_test.go
+++ b/test/e2e/conditions_test.go
@@ -33,6 +33,22 @@ func (t *testClient) templateInstanceIsReady() (bool, error) {
 	return false, nil
 }
 
+func (t *testClient) deploymentConfigIsReady(name string, replicas int32) func() (bool, error) {
+	return func() (bool, error) {
+		dc, err := c.ac.DeploymentConfigs(c.namespace).Get(name, metav1.GetOptions{})
+		switch {
+		case err == nil:
+			return replicas == dc.Status.Replicas &&
+				replicas == dc.Status.ReadyReplicas &&
+				replicas == dc.Status.AvailableReplicas &&
+				replicas == dc.Status.UpdatedReplicas &&
+				dc.Generation == dc.Status.ObservedGeneration, nil
+		default:
+			return false, err
+		}
+	}
+}
+
 func (t *testClient) projectIsCleanedUp() (bool, error) {
 	_, err := t.pc.Projects().Get(t.namespace, metav1.GetOptions{})
 	if kerrors.IsNotFound(err) {

--- a/test/e2e/end_user_test.go
+++ b/test/e2e/end_user_test.go
@@ -3,6 +3,7 @@
 package e2e
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"net/http"
@@ -12,7 +13,6 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	templatev1 "github.com/openshift/api/template/v1"
 	"github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1beta1"
@@ -21,6 +21,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/intstr"
 	"k8s.io/apimachinery/pkg/util/wait"
+
+	waitutil "github.com/openshift/openshift-azure/pkg/util/wait"
 )
 
 var _ = Describe("Openshift on Azure end user e2e tests [EndUser]", func() {
@@ -59,63 +61,31 @@ var _ = Describe("Openshift on Azure end user e2e tests [EndUser]", func() {
 		Expect(kerrors.IsForbidden(err)).To(Equal(true))
 	})
 
-	It("should deploy a template and check the visit counter increments", func() {
-		const TPL = "cakephp-mysql-example"
-		var regex = regexp.MustCompile(`id="count-value">(\d+)<`)
-
-		// Create the template
-		By(fmt.Sprintf("creating the template (%v)", time.Now()))
-		template, err := c.tc.Templates("openshift").Get(
-			TPL, metav1.GetOptions{})
+	It("should deploy a template and ensure a given text is in the contents", func() {
+		tpl := "nginx-example"
+		By(fmt.Sprintf("instantiating the template and getting the route (%v)", time.Now()))
+		// instantiate the template
+		err := c.instantiateTemplate(tpl)
 		Expect(err).NotTo(HaveOccurred())
-
-		// Instantiate the template
-		_, err = c.tc.TemplateInstances(c.namespace).Create(
-			&templatev1.TemplateInstance{
-				ObjectMeta: metav1.ObjectMeta{
-					Name: c.namespace,
-				},
-				Spec: templatev1.TemplateInstanceSpec{
-					Template: *template,
-				},
-			})
+		route, err := c.rc.Routes(c.namespace).Get(tpl, metav1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
-
-		// Poll for the deployment status
-		By(fmt.Sprintf("waiting for the template instance to turn ready (%v)", time.Now()))
-		err = wait.PollImmediate(2*time.Second, 10*time.Minute, c.templateInstanceIsReady)
-		Expect(err).NotTo(HaveOccurred())
-
-		// Pull the route ingress from the namespace
-		By(fmt.Sprintf("getting the route (%v)", time.Now()))
-		route, err := c.rc.Routes(c.namespace).Get(TPL, metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred())
+		// make sure only 1 ingress point is returned
 		Expect(len(route.Status.Ingress)).To(Equal(1))
 		host := route.Status.Ingress[0].Host
 		url := fmt.Sprintf("http://%s", host)
 
-		prevCounter := 0
-		currCounter := 0
+		// Curl the endpoint and search for a string
 		httpc := &http.Client{
 			Timeout: 10 * time.Second,
 		}
-		By(fmt.Sprintf("hitting the route 3 times to check the counter (%v)", time.Now()))
-		// Hit the ingress 3 times, each time the hit counter should increment
-		for i := 0; i < 3; i++ {
-			resp, err := httpc.Get(url)
-			Expect(err).NotTo(HaveOccurred())
-			defer resp.Body.Close()
-			Expect(resp.StatusCode).Should(Equal(200))
-			contents, err := ioutil.ReadAll(resp.Body)
-			Expect(err).NotTo(HaveOccurred())
-			matches := regex.FindStringSubmatch(string(contents))
-			Expect(matches).NotTo(BeNil())
-			currCounter, err = strconv.Atoi(matches[1])
-			Expect(err).NotTo(HaveOccurred())
-			Expect(currCounter).Should(BeNumerically(">", prevCounter))
-			prevCounter = currCounter
-			time.Sleep(time.Second)
-		}
+		By(fmt.Sprintf("hitting the route and checking the contents (%v)", time.Now()))
+		resp, err := httpc.Get(url)
+		Expect(err).NotTo(HaveOccurred())
+		defer resp.Body.Close()
+		Expect(resp.StatusCode).Should(Equal(http.StatusOK))
+		contents, err := ioutil.ReadAll(resp.Body)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(string(contents)).Should(ContainSubstring("Welcome to your static nginx application on OpenShift"))
 	})
 
 	It("should not crud infra resources", func() {
@@ -162,5 +132,100 @@ var _ = Describe("Openshift on Azure end user e2e tests [EndUser]", func() {
 		result := req.Do()
 		fmt.Println(result.Error().Error())
 		Expect(result.Error().Error()).To(ContainSubstring("pods \"sync-master-000000\" is forbidden: User \"enduser\" cannot get pods/log in the namespace \"kube-system\""))
+	})
+
+	It("should deploy a template with persistent storage and test failure modes", func() {
+		tpl := "django-psql-persistent"
+		By(fmt.Sprintf("instantiating the template and getting the route (%v)", time.Now()))
+		// instantiate the template
+		err := c.instantiateTemplate(tpl)
+		Expect(err).NotTo(HaveOccurred())
+		// Pull the route ingress from the namespace
+		route, err := c.rc.Routes(c.namespace).Get(tpl, metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		// make sure only 1 ingress point is returned
+		Expect(len(route.Status.Ingress)).To(Equal(1))
+		host := route.Status.Ingress[0].Host
+		url := fmt.Sprintf("http://%s", host)
+
+		// Curl the endpoint and search for a string
+		httpc := &http.Client{
+			Timeout: 10 * time.Second,
+		}
+		regex := regexp.MustCompile(`Page views:\s*(\d+)`)
+		By(fmt.Sprintf("hitting the route 3 times, expecting counter to increment (%v)", time.Now()))
+		var prevCounter, currCounter int
+		for i := 0; i < 3; i++ {
+			resp, err := httpc.Get(url)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).Should(Equal(http.StatusOK))
+
+			contents, err := ioutil.ReadAll(resp.Body)
+			Expect(err).NotTo(HaveOccurred())
+			matches := regex.FindStringSubmatch(string(contents))
+			Expect(matches).NotTo(BeNil())
+
+			currCounter, err = strconv.Atoi(matches[1])
+			Expect(err).NotTo(HaveOccurred())
+			Expect(currCounter).Should(BeNumerically(">", prevCounter))
+			prevCounter = currCounter
+			time.Sleep(time.Second)
+		}
+
+		// Find the database deploymentconfig and scale to 0
+		dcName := "postgresql"
+		for i := range []int{0, 1} {
+			By(fmt.Sprintf("searching for the database deploymentconfig (%v)", time.Now()))
+			dbDeploymentConfig, err := c.ac.DeploymentConfigs(c.namespace).Get(dcName, metav1.GetOptions{})
+			Expect(err).NotTo(HaveOccurred())
+			Expect(dbDeploymentConfig).NotTo(BeNil())
+			By(fmt.Sprintf("scaling the database deploymentconfig to %d (%v)", i, time.Now()))
+			dbDeploymentConfig.Spec.Replicas = int32(i)
+			updated, err := c.ac.DeploymentConfigs(c.namespace).Update(dbDeploymentConfig)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(updated).NotTo(BeNil())
+			By(fmt.Sprintf("waiting for database deploymentconfig to reflect %d replicas (%v)", i, time.Now()))
+			waitErr := wait.PollImmediate(2*time.Second, 10*time.Minute, func() (bool, error) {
+				dc, err := c.ac.DeploymentConfigs(c.namespace).Get(dcName, metav1.GetOptions{})
+				i32 := int32(i)
+				switch {
+				case err == nil:
+					return i32 == dc.Status.Replicas &&
+						i32 == dc.Status.ReadyReplicas &&
+						i32 == dc.Status.AvailableReplicas &&
+						i32 == dc.Status.UpdatedReplicas &&
+						dc.Generation == dc.Status.ObservedGeneration, nil
+				default:
+					return false, err
+				}
+			})
+			Expect(waitErr).NotTo(HaveOccurred())
+		}
+
+		// wait for the ingress to return 200 in case healthcheck failed when database got recreated
+		By(fmt.Sprintf("making sure the ingress is healthy (%v)", time.Now()))
+		var rt http.RoundTripper
+		waitErr := waitutil.ForHTTPStatusOk(context.Background(), rt, url)
+		Expect(waitErr).NotTo(HaveOccurred())
+
+		By(fmt.Sprintf("hitting the route again, expecting counter to increment from last=%d (%v)", currCounter, time.Now()))
+		for i := 0; i < 3; i++ {
+			resp, err := httpc.Get(url)
+			Expect(err).NotTo(HaveOccurred())
+			defer resp.Body.Close()
+			Expect(resp.StatusCode).Should(Equal(http.StatusOK))
+
+			contents, err := ioutil.ReadAll(resp.Body)
+			Expect(err).NotTo(HaveOccurred())
+			matches := regex.FindStringSubmatch(string(contents))
+			Expect(matches).NotTo(BeNil())
+
+			currCounter, err = strconv.Atoi(matches[1])
+			Expect(err).NotTo(HaveOccurred())
+			Expect(currCounter).Should(BeNumerically(">", prevCounter))
+			prevCounter = currCounter
+			time.Sleep(time.Second)
+		}
 	})
 })


### PR DESCRIPTION
Fixes #645 

This should:
* Deploy a template with persistent storage
* Get the ingress routes from the deployment
* Hit the routes several times, ensuring the visit counter increments
* Kill the database pod
* Wait for the pod to come back
* Hit the route again a few times
