### PR TITLE
createorupdate: env checks and random region selection

### DIFF
--- a/cmd/createorupdate/createorupdate.go
+++ b/cmd/createorupdate/createorupdate.go
@@ -118,7 +118,7 @@ func (s *server) handleDelete(w http.ResponseWriter, req *http.Request) {
 	authorizer, err := azureclient.NewAuthorizer(conf.ClientID, conf.ClientSecret, conf.TenantID)
 	if err != nil {
 		resp := "500 Internal Error: Failed to determine request credentials"
-		s.log.Debug(resp, err)
+		s.log.Debugf("%s: %v", resp, err)
 		http.Error(w, resp, http.StatusInternalServerError)
 		return
 	}
@@ -134,20 +134,20 @@ func (s *server) handleDelete(w http.ResponseWriter, req *http.Request) {
 	future, err := gc.Delete(ctx, resourceGroup)
 	if err != nil {
 		resp := "500 Internal Error: Failed to delete resource group"
-		s.log.Debug(resp, err)
+		s.log.Debugf("%s: %v", resp, err)
 		http.Error(w, resp, http.StatusInternalServerError)
 		return
 	}
 	if err := future.WaitForCompletionRef(ctx, gc.Client); err != nil {
 		resp := "500 Internal Error: Failed to wait for resource group deletion"
-		s.log.Debug(resp, err)
+		s.log.Debugf("%s: %v", resp, err)
 		http.Error(w, resp, http.StatusInternalServerError)
 		return
 	}
 	resp, err := future.Result(gc)
 	if err != nil {
 		resp := "500 Internal Error: Failed to get resource group deletion response"
-		s.log.Debug(resp, err)
+		s.log.Debugf("%s: %v", resp, err)
 		http.Error(w, resp, http.StatusInternalServerError)
 		return
 	}
@@ -168,7 +168,7 @@ func (s *server) handlePut(w http.ResponseWriter, req *http.Request) {
 	b, err := ioutil.ReadAll(req.Body)
 	if err != nil {
 		resp := "400 Bad Request: Failed to read request body"
-		s.log.Debug(resp, err)
+		s.log.Debugf("%s: %v", resp, err)
 		http.Error(w, resp, http.StatusBadRequest)
 		return
 	}
@@ -176,7 +176,7 @@ func (s *server) handlePut(w http.ResponseWriter, req *http.Request) {
 	var oc *v20180930preview.OpenShiftManagedCluster
 	if err := yaml.Unmarshal(b, &oc); err != nil {
 		resp := "400 Bad Request: Failed to unmarshal request"
-		s.log.Debug(resp, err)
+		s.log.Debugf("%s: %v", resp, err)
 		http.Error(w, resp, http.StatusBadRequest)
 		return
 	}
@@ -217,7 +217,7 @@ func (s *server) handlePut(w http.ResponseWriter, req *http.Request) {
 	if _, err := fakerp.CreateOrUpdate(ctx, oc, s.log, config); err != nil {
 		s.writeState(v20180930preview.Failed)
 		resp := "400 Bad Request: Failed to apply request"
-		s.log.Debug(resp, err)
+		s.log.Debugf("%s: %v", resp, err)
 		http.Error(w, resp, http.StatusBadRequest)
 		return
 	}
@@ -260,7 +260,7 @@ func (s *server) reply(w http.ResponseWriter, req *http.Request) {
 	res, err := json.Marshal(azureclient.ExternalToSdk(oc))
 	if err != nil {
 		resp := "500 Internal Server Error: Failed to marshal response"
-		s.log.Debug(resp, err)
+		s.log.Debugf("%s: %v", resp, err)
 		http.Error(w, resp, http.StatusInternalServerError)
 		return
 	}

--- a/cmd/createorupdate/createorupdate.go
+++ b/cmd/createorupdate/createorupdate.go
@@ -8,6 +8,7 @@ import (
 	"flag"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"net"
 	"net/http"
 	"net/url"
@@ -22,6 +23,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/ghodss/yaml"
+	"github.com/kelseyhightower/envconfig"
 	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/wait"
 
@@ -112,15 +114,16 @@ func (s *server) validate(w http.ResponseWriter, r *http.Request) bool {
 }
 
 func (s *server) handleDelete(w http.ResponseWriter, req *http.Request) {
-	authorizer, err := azureclient.NewAuthorizer(os.Getenv("AZURE_CLIENT_ID"), os.Getenv("AZURE_CLIENT_SECRET"), os.Getenv("AZURE_TENANT_ID"))
+	// TODO: Get the azure credentials from the request headers
+	authorizer, err := azureclient.NewAuthorizer(conf.ClientID, conf.ClientSecret, conf.TenantID)
 	if err != nil {
 		resp := "500 Internal Error: Failed to determine request credentials"
 		s.log.Debug(resp, err)
 		http.Error(w, resp, http.StatusInternalServerError)
 		return
 	}
-	subID := os.Getenv("AZURE_SUBSCRIPTION_ID")
-	gc := resources.NewGroupsClient(subID)
+	// TODO: Determine subscription ID from the request path
+	gc := resources.NewGroupsClient(conf.SubscriptionID)
 	gc.Authorizer = authorizer
 
 	resourceGroup := filepath.Base(req.URL.Path)
@@ -182,9 +185,10 @@ func (s *server) handlePut(w http.ResponseWriter, req *http.Request) {
 	// simulate Context with property bag
 	ctx, cancel := context.WithTimeout(context.Background(), 1*time.Hour)
 	defer cancel()
-	ctx = context.WithValue(ctx, api.ContextKeyClientID, os.Getenv("AZURE_CLIENT_ID"))
-	ctx = context.WithValue(ctx, api.ContextKeyClientSecret, os.Getenv("AZURE_CLIENT_SECRET"))
-	ctx = context.WithValue(ctx, api.ContextKeyTenantID, os.Getenv("AZURE_TENANT_ID"))
+	// TODO: Get the azure credentials from the request headers
+	ctx = context.WithValue(ctx, api.ContextKeyClientID, conf.ClientID)
+	ctx = context.WithValue(ctx, api.ContextKeyClientSecret, conf.ClientSecret)
+	ctx = context.WithValue(ctx, api.ContextKeyTenantID, conf.TenantID)
 
 	tc := api.TestConfig{
 		RunningUnderTest:   os.Getenv("RUNNING_UNDER_TEST") != "",
@@ -263,6 +267,44 @@ func (s *server) reply(w http.ResponseWriter, req *http.Request) {
 	w.Write(res)
 }
 
+var conf config
+
+type config struct {
+	SubscriptionID   string `envconfig:"AZURE_SUBSCRIPTION_ID" required:"true"`
+	TenantID         string `envconfig:"AZURE_TENANT_ID" required:"true"`
+	ClientID         string `envconfig:"AZURE_CLIENT_ID" required:"true"`
+	ClientSecret     string `envconfig:"AZURE_CLIENT_SECRET" required:"true"`
+	AADClientID      string `envconfig:"AZURE_AAD_CLIENT_ID"`
+	Region           string `envconfig:"AZURE_REGION"`
+	DnsDomain        string `envconfig:"DNS_DOMAIN" required:"true"`
+	DnsResourceGroup string `envconfig:"DNS_RESOURCEGROUP" required:"true"`
+	ResourceGroup    string `envconfig:"RESOURCEGROUP" required:"true"`
+
+	NoGroupTags      bool   `envconfig:"NOGROUPTAGS"`
+	ResourceGroupTTL string `envconfig:"RESOURCEGROUP_TTL"`
+}
+
+func (c *config) init() error {
+	supportedRegions := []string{"eastus", "westeurope", "australiasoutheast"}
+	if c.Region == "" {
+		// Randomly assign a supported region
+		rand.Seed(time.Now().UTC().UnixNano())
+		c.Region = supportedRegions[rand.Intn(3)]
+		logrus.Infof("using randomly selected region %q", c.Region)
+	}
+
+	var supported bool
+	for _, region := range supportedRegions {
+		if c.Region == region {
+			supported = true
+		}
+	}
+	if !supported {
+		return fmt.Errorf("%q is not a supported region (supported regions: %v)", c.Region, supportedRegions)
+	}
+	return nil
+}
+
 var (
 	method   = flag.String("request", http.MethodPut, "Specify request to send to the OpenShift resource provider. Supported methods are PUT and DELETE.")
 	useProd  = flag.Bool("use-prod", false, "If true, send the request to the production OpenShift resource provider.")
@@ -305,7 +347,7 @@ func validate() error {
 
 func delete(ctx context.Context, log *logrus.Entry, rpc sdk.OpenShiftManagedClustersClient) error {
 	log.Info("deleting cluster")
-	future, err := rpc.Delete(ctx, os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
+	future, err := rpc.Delete(ctx, conf.ResourceGroup, conf.ResourceGroup)
 	if err != nil {
 		return err
 	}
@@ -333,7 +375,7 @@ func createOrUpdate(ctx context.Context, log *logrus.Entry, rpc sdk.OpenShiftMan
 	if err := yaml.Unmarshal(in, &oc); err != nil {
 		return err
 	}
-	future, err := rpc.CreateOrUpdate(ctx, os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"), oc)
+	future, err := rpc.CreateOrUpdate(ctx, conf.ResourceGroup, conf.ResourceGroup, oc)
 	if err != nil {
 		return err
 	}
@@ -367,20 +409,67 @@ func execCommand(c string) error {
 	return nil
 }
 
+func createResourceGroup(log *logrus.Entry) error {
+	authorizer, err := azureclient.NewAuthorizer(conf.ClientID, conf.ClientSecret, conf.TenantID)
+	if err != nil {
+		return err
+	}
+	gc := resources.NewGroupsClient(conf.SubscriptionID)
+	gc.Authorizer = authorizer
+
+	if _, err := gc.Get(context.Background(), conf.ResourceGroup); err == nil {
+		log.Infof("reusing existing resource group %s", conf.ResourceGroup)
+		return nil
+	}
+
+	var tags map[string]*string
+	if !conf.NoGroupTags {
+		tags = make(map[string]*string)
+		ttl, now := "76h", fmt.Sprintf("%d", time.Now().Unix())
+		tags["now"] = &now
+		tags["ttl"] = &ttl
+		if conf.ResourceGroupTTL != "" {
+			if _, err := time.ParseDuration(conf.ResourceGroupTTL); err != nil {
+				return fmt.Errorf("invalid ttl provided: %q - %v", conf.ResourceGroupTTL, err)
+			}
+			tags["ttl"] = &conf.ResourceGroupTTL
+		}
+	}
+
+	rg := resources.Group{Location: &conf.Region, Tags: tags}
+	_, err = gc.CreateOrUpdate(context.Background(), conf.ResourceGroup, rg)
+	return err
+}
+
 func main() {
 	logger := logrus.New()
 	logger.Formatter = &logrus.TextFormatter{FullTimestamp: true}
-	log := logrus.NewEntry(logger).WithFields(logrus.Fields{"resourceGroup": os.Getenv("RESOURCEGROUP")})
+	log := logrus.NewEntry(logger)
+
+	if err := envconfig.Process("", &conf); err != nil {
+		log.Fatal(err)
+	}
+	if err := conf.init(); err != nil {
+		log.Fatal(err)
+	}
+	log = logrus.NewEntry(logger).WithFields(logrus.Fields{"resourceGroup": conf.ResourceGroup})
 
 	flag.Parse()
 	if err := validate(); err != nil {
 		log.Fatal(err)
 	}
 
+	if strings.ToUpper(*method) != http.MethodDelete {
+		log.Infof("creating resource group %s", conf.ResourceGroup)
+		if err := createResourceGroup(log); err != nil {
+			log.Fatal(err)
+		}
+	}
+
 	// simulate the RP
 	if !*useProd {
 		log.Info("starting the fake resource provider")
-		s := newServer(os.Getenv("RESOURCEGROUP"))
+		s := newServer(conf.ResourceGroup)
 		go s.ListenAndServe()
 	}
 
@@ -389,8 +478,8 @@ func main() {
 	if *useProd {
 		rpURL = sdk.DefaultBaseURI
 	}
-	rpc := sdk.NewOpenShiftManagedClustersClientWithBaseURI(rpURL, os.Getenv("AZURE_SUBSCRIPTION_ID"))
-	authorizer, err := azureclient.NewAuthorizer(os.Getenv("AZURE_CLIENT_ID"), os.Getenv("AZURE_CLIENT_SECRET"), os.Getenv("AZURE_TENANT_ID"))
+	rpc := sdk.NewOpenShiftManagedClustersClientWithBaseURI(rpURL, conf.SubscriptionID)
+	authorizer, err := azureclient.NewAuthorizer(conf.ClientID, conf.ClientSecret, conf.TenantID)
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/hack/create.sh
+++ b/hack/create.sh
@@ -29,18 +29,6 @@ if [[ -z "$AZURE_REGION" ]]; then
     echo error: must set AZURE_REGION
     exit 1
 fi
-valid_regions=(eastus westeurope australiasoutheast)
-match=0
-for region in "${valid_regions[@]}"; do
-    if [[ $region == "$AZURE_REGION" ]]; then
-        match=1
-        break
-    fi
-done
-if [[ $match = 0 ]]; then
-    echo "Error invalid region: must be one of ${valid_regions[@]}"
-    exit 1
-fi
 
 if [[ -z "$DNS_DOMAIN" ]]; then
     echo error: must set DNS_DOMAIN
@@ -62,15 +50,6 @@ export RESOURCEGROUP=$1
 
 rm -rf _data
 mkdir -p _data/_out
-
-if [[ -z "$NOGROUPTAGS" ]]; then
-  ttl=76h
-  if [[ -n "$RESOURCEGROUP_TTL" ]]; then
-    ttl=$RESOURCEGROUP_TTL
-  fi
-  GROUPTAGS="--tags now=$(date +%s) ttl=$ttl"
-fi
-az group create --subscription $AZURE_SUBSCRIPTION_ID -n $RESOURCEGROUP -l $AZURE_REGION $GROUPTAGS >/dev/null
 
 # if AZURE_CLIENT_ID is used as AZURE_AAD_CLIENT_ID, script will reset global team account!
 set +x

--- a/hack/delete.sh
+++ b/hack/delete.sh
@@ -4,27 +4,9 @@ if ! az account show >/dev/null; then
     exit 1
 fi
 
-if [[ -z "$DNS_DOMAIN" ]]; then
-    echo error: must set DNS_DOMAIN
-    exit 1
-fi
-
-if [[ -z "$DNS_RESOURCEGROUP" ]]; then
-    echo error: must set DNS_RESOURCEGROUP
-    exit 1
-fi
-
-if [[ "$NO_WAIT" == "true" ]]; then
-	NO_WAIT_FLAG="--no-wait"
-fi
-
 if [[ $# -eq 0 && ! -e _data/containerservice.yaml ]]; then
     echo error: _data/containerservice.yaml must exist
     exit 1
-fi
-
-if [[ -z "$AZURE_SUBSCRIPTION_ID" ]]; then
-    AZURE_SUBSCRIPTION_ID=$(az account show --query id --output tsv)
 fi
 
 if [[ $# -eq 1 ]]; then

--- a/hack/upgrade.sh
+++ b/hack/upgrade.sh
@@ -1,38 +1,6 @@
 #!/bin/bash -ex
 
-set +x
 if ! az account show >/dev/null; then
-    exit 1
-fi
-
-if [[ -z "$AZURE_SUBSCRIPTION_ID" ]]; then
-    echo error: must set AZURE_SUBSCRIPTION_ID
-    exit 1
-fi
-
-if [[ -z "$AZURE_TENANT_ID" ]]; then
-    echo error: must set AZURE_TENANT_ID
-    exit 1
-fi
-
-if [[ -z "$AZURE_CLIENT_ID" ]]; then
-    echo error: must set AZURE_CLIENT_ID
-    exit 1
-fi
-
-if [[ -z "$AZURE_CLIENT_SECRET" ]]; then
-    echo error: must set AZURE_CLIENT_SECRET
-    exit 1
-fi
-set -x
-
-if [[ -z "$DNS_DOMAIN" ]]; then
-    echo error: must set DNS_DOMAIN
-    exit 1
-fi
-
-if [[ -z "$DNS_RESOURCEGROUP" ]]; then
-    echo error: must set DNS_RESOURCEGROUP
     exit 1
 fi
 
@@ -46,7 +14,12 @@ if [[ $# -eq 1 ]]; then
 else
     export RESOURCEGROUP=$(awk '/^    resourceGroup:/ { print $2 }' <_data/containerservice.yaml)
 fi
-sed -i '/provisioningState/d' _data/manifest.yaml
 
+USE_PROD_FLAG="-use-prod=false"
+if [[ -n "$TEST_IN_PRODUCTION" ]]; then
+    USE_PROD_FLAG="-use-prod=true"
+fi
+
+sed -i '/provisioningState/d' _data/manifest.yaml
 go generate ./...
-go run cmd/createorupdate/createorupdate.go -timeout 1h
+go run cmd/createorupdate/createorupdate.go -timeout 1h $USE_PROD_FLAG

--- a/pkg/util/mocks/mock_azureclient/azureclient.go
+++ b/pkg/util/mocks/mock_azureclient/azureclient.go
@@ -486,6 +486,18 @@ func (mr *MockDeploymentsClientMockRecorder) CreateOrUpdate(arg0, arg1, arg2, ar
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "CreateOrUpdate", reflect.TypeOf((*MockDeploymentsClient)(nil).CreateOrUpdate), arg0, arg1, arg2, arg3)
 }
 
+// DeploymentClient mocks base method
+func (m *MockDeploymentsClient) DeploymentClient() resources.DeploymentsClient {
+	ret := m.ctrl.Call(m, "DeploymentClient")
+	ret0, _ := ret[0].(resources.DeploymentsClient)
+	return ret0
+}
+
+// DeploymentClient indicates an expected call of DeploymentClient
+func (mr *MockDeploymentsClientMockRecorder) DeploymentClient() *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeploymentClient", reflect.TypeOf((*MockDeploymentsClient)(nil).DeploymentClient))
+}
+
 // MockAccountsClient is a mock of AccountsClient interface
 type MockAccountsClient struct {
 	ctrl     *gomock.Controller


### PR DESCRIPTION
Collapsing some parts of our bash scripts in createorupdate and enabling random region selection to ensure in our tests we can deploy clusters in every supported region.