### PR TITLE
Move OSA request manifest out of hack/create.sh

### DIFF
--- a/env.example
+++ b/env.example
@@ -56,3 +56,6 @@ export DEPLOY_VERSION=v3.10
 # If set to true, avoid tagging the resource group to be cleaned up by the
 # pruner.
 #export NOGROUPTAGS=true
+
+# Path to the request to send to the OSA RP.
+#export MANIFEST=test/manifests/normal/create.yaml

--- a/hack/create.sh
+++ b/hack/create.sh
@@ -59,44 +59,13 @@ else
     AZURE_AAD_CLIENT_ID=$AZURE_CLIENT_ID
     AZURE_AAD_CLIENT_SECRET=$AZURE_CLIENT_SECRET
 fi
+export AZURE_AAD_CLIENT_SECRET
 set -x
 
-cat >_data/manifest.yaml <<EOF
-name: $RESOURCEGROUP
-location: $AZURE_REGION
-properties:
-  openShiftVersion: "$DEPLOY_VERSION"
-  fqdn: $RESOURCEGROUP.$AZURE_REGION.cloudapp.azure.com
-  authProfile:
-    identityProviders:
-    - name: Azure AD
-      provider:
-        kind: AADIdentityProvider
-        clientId: $AZURE_AAD_CLIENT_ID
-        secret: $AZURE_AAD_CLIENT_SECRET
-        tenantId: $AZURE_TENANT_ID
-  networkProfile:
-    vnetCidr: 10.0.0.0/8
-  routerProfiles:
-  - name: default
-  masterPoolProfile:
-    count: 3
-    vmSize: Standard_D2s_v3
-    subnetCidr: 10.0.0.0/24
-  agentPoolProfiles:
-  - name: infra
-    role: infra
-    count: 2
-    vmSize: Standard_D2s_v3
-    subnetCidr: 10.0.0.0/24
-    osType: Linux
-  - name: compute
-    role: compute
-    count: 1
-    vmSize: Standard_D2s_v3
-    subnetCidr: 10.0.0.0/24
-    osType: Linux
-EOF
+if [[ -z "$MANIFEST" ]]; then
+    MANIFEST="test/manifests/normal/create.yaml"
+fi
+cat $MANIFEST | envsubst > _data/manifest.yaml
 
 go generate ./...
 if [[ -n "$TEST_IN_PRODUCTION" ]]; then

--- a/hack/upgrade.sh
+++ b/hack/upgrade.sh
@@ -20,6 +20,10 @@ if [[ -n "$TEST_IN_PRODUCTION" ]]; then
     USE_PROD_FLAG="-use-prod=true"
 fi
 
+if [[ -n "$MANIFEST" ]]; then
+    cat $MANIFEST | envsubst > _data/manifest.yaml
+fi
+
 sed -i '/provisioningState/d' _data/manifest.yaml
 go generate ./...
 go run cmd/createorupdate/createorupdate.go -timeout 1h $USE_PROD_FLAG

--- a/test/manifests/normal/create.yaml
+++ b/test/manifests/normal/create.yaml
@@ -1,0 +1,34 @@
+name: $RESOURCEGROUP
+location: $AZURE_REGION
+properties:
+  openShiftVersion: "$DEPLOY_VERSION"
+  fqdn: $RESOURCEGROUP.$AZURE_REGION.cloudapp.azure.com
+  authProfile:
+    identityProviders:
+    - name: Azure AD
+      provider:
+        kind: AADIdentityProvider
+        clientId: $AZURE_AAD_CLIENT_ID
+        secret: $AZURE_AAD_CLIENT_SECRET
+        tenantId: $AZURE_TENANT_ID
+  networkProfile:
+    vnetCidr: 10.0.0.0/8
+  routerProfiles:
+  - name: default
+  masterPoolProfile:
+    count: 3
+    vmSize: Standard_D2s_v3
+    subnetCidr: 10.0.0.0/24
+  agentPoolProfiles:
+  - name: infra
+    role: infra
+    count: 2
+    vmSize: Standard_D2s_v3
+    subnetCidr: 10.0.0.0/24
+    osType: Linux
+  - name: compute
+    role: compute
+    count: 1
+    vmSize: Standard_D2s_v3
+    subnetCidr: 10.0.0.0/24
+    osType: Linux


### PR DESCRIPTION
I am moving the manifest out of hack/create.sh into `test/manifests` where we can place more manifests to test different flows (eg. custom vnet, different types of upgrades, etc.). Then, in order to actually write a test that would make use of a different manifest rather than the default we would place the manifest inside `test/testdata/{somename}/create.yaml` and set `MANIFEST=test/testdata/{somename}/create.yaml` in the prow job to make use of that request during cluster deployment. More work needs to be done to enable upgrades, will do in a follow-up.

/cc @kwoodson @jim-minter @cjryan @mjudeikis 