### PR TITLE
add additional VM flavours and increase maximum number of compute nodes

### DIFF
--- a/pkg/addons/translate.go
+++ b/pkg/addons/translate.go
@@ -152,14 +152,14 @@ var Translations = map[string][]struct {
 			Path:       jsonpath.MustCompile("$.data.'node-config.yaml'"),
 			NestedPath: jsonpath.MustCompile("$.kubeletArguments.'kube-reserved'[0]"),
 			F: func(cs *api.OpenShiftManagedCluster) (interface{}, error) {
-				return config.Derived.KubeReserved(cs, api.AgentPoolProfileRoleCompute), nil
+				return config.Derived.KubeReserved(cs, api.AgentPoolProfileRoleCompute)
 			},
 		},
 		{
 			Path:       jsonpath.MustCompile("$.data.'node-config.yaml'"),
 			NestedPath: jsonpath.MustCompile("$.kubeletArguments.'system-reserved'[0]"),
 			F: func(cs *api.OpenShiftManagedCluster) (interface{}, error) {
-				return config.Derived.SystemReserved(cs, api.AgentPoolProfileRoleCompute), nil
+				return config.Derived.SystemReserved(cs, api.AgentPoolProfileRoleCompute)
 			},
 		},
 	},
@@ -173,14 +173,14 @@ var Translations = map[string][]struct {
 			Path:       jsonpath.MustCompile("$.data.'node-config.yaml'"),
 			NestedPath: jsonpath.MustCompile("$.kubeletArguments.'kube-reserved'[0]"),
 			F: func(cs *api.OpenShiftManagedCluster) (interface{}, error) {
-				return config.Derived.KubeReserved(cs, api.AgentPoolProfileRoleInfra), nil
+				return config.Derived.KubeReserved(cs, api.AgentPoolProfileRoleInfra)
 			},
 		},
 		{
 			Path:       jsonpath.MustCompile("$.data.'node-config.yaml'"),
 			NestedPath: jsonpath.MustCompile("$.kubeletArguments.'system-reserved'[0]"),
 			F: func(cs *api.OpenShiftManagedCluster) (interface{}, error) {
-				return config.Derived.SystemReserved(cs, api.AgentPoolProfileRoleInfra), nil
+				return config.Derived.SystemReserved(cs, api.AgentPoolProfileRoleInfra)
 			},
 		},
 	},
@@ -194,7 +194,7 @@ var Translations = map[string][]struct {
 			Path:       jsonpath.MustCompile("$.data.'node-config.yaml'"),
 			NestedPath: jsonpath.MustCompile("$.kubeletArguments.'system-reserved'[0]"),
 			F: func(cs *api.OpenShiftManagedCluster) (interface{}, error) {
-				return config.Derived.SystemReserved(cs, api.AgentPoolProfileRoleMaster), nil
+				return config.Derived.SystemReserved(cs, api.AgentPoolProfileRoleMaster)
 			},
 		},
 	},

--- a/pkg/api/2018-09-30-preview/api/types.go
+++ b/pkg/api/2018-09-30-preview/api/types.go
@@ -156,11 +156,52 @@ const (
 // VMSize represents supported VMSizes
 type VMSize string
 
+// VMSizes
 const (
-	// StandardD2sV3 represents Standard_D2s_v3
-	StandardD2sV3 VMSize = "Standard_D2s_v3"
-	// StandardD4sV3 represents Standard_D2s_v3
-	StandardD4sV3 VMSize = "Standard_D4s_v3"
+	// General purpose VMs
+	StandardD2sV3  VMSize = "Standard_D2s_v3"
+	StandardD4sV3  VMSize = "Standard_D4s_v3"
+	StandardD8sV3  VMSize = "Standard_D8s_v3"
+	StandardD16sV3 VMSize = "Standard_D16s_v3"
+	StandardD32sV3 VMSize = "Standard_D32s_v3"
+	StandardD64sV3 VMSize = "Standard_D64s_v3"
+
+	StandardDS4V2 VMSize = "Standard_DS4_v2"
+	StandardDS5V2 VMSize = "Standard_DS5_v2"
+
+	// Compute optimized VMs
+	StandardF8sV2  VMSize = "Standard_F8s_v2"
+	StandardF16sV2 VMSize = "Standard_F16s_v2"
+	StandardF32sV2 VMSize = "Standard_F32s_v2"
+	StandardF64sV2 VMSize = "Standard_F64s_v2"
+	StandardF72sV2 VMSize = "Standard_F72s_v2"
+
+	StandardF8s  VMSize = "Standard_F8s"
+	StandardF16s VMSize = "Standard_F16s"
+
+	// Memory optimized VMs
+	StandardE4sV3  VMSize = "Standard_E4s_v3"
+	StandardE8sV3  VMSize = "Standard_E8s_v3"
+	StandardE16sV3 VMSize = "Standard_E16s_v3"
+	StandardE20sV3 VMSize = "Standard_E20s_v3"
+	StandardE32sV3 VMSize = "Standard_E32s_v3"
+	StandardE64sV3 VMSize = "Standard_E64s_v3"
+
+	StandardGS2 VMSize = "Standard_GS2"
+	StandardGS3 VMSize = "Standard_GS3"
+	StandardGS4 VMSize = "Standard_GS4"
+	StandardGS5 VMSize = "Standard_GS5"
+
+	StandardDS12V2 VMSize = "Standard_DS12_v2"
+	StandardDS13V2 VMSize = "Standard_DS13_v2"
+	StandardDS14V2 VMSize = "Standard_DS14_v2"
+	StandardDS15V2 VMSize = "Standard_DS15_v2"
+
+	// Storage optimized VMs
+	StandardL4s  VMSize = "Standard_L4s"
+	StandardL8s  VMSize = "Standard_L8s"
+	StandardL16s VMSize = "Standard_L16s"
+	StandardL32s VMSize = "Standard_L32s"
 )
 
 // AuthProfile defines all possible authentication profiles for the OpenShift

--- a/pkg/api/default.go
+++ b/pkg/api/default.go
@@ -1,35 +1,5 @@
 package api
 
-// DefaultVMSizeKubeArguments defines default values of kube-arguments based on the VM size
-var DefaultVMSizeKubeArguments = map[VMSize]map[AgentPoolProfileRole]map[ReservedResource]string{
-	StandardD2sV3: {
-		AgentPoolProfileRoleMaster: {
-			SystemReserved: "cpu=500m,memory=1Gi",
-		},
-		AgentPoolProfileRoleCompute: {
-			KubeReserved:   "cpu=200m,memory=512Mi",
-			SystemReserved: "cpu=200m,memory=512Mi",
-		},
-		AgentPoolProfileRoleInfra: {
-			KubeReserved:   "cpu=200m,memory=512Mi",
-			SystemReserved: "cpu=200m,memory=512Mi",
-		},
-	},
-	StandardD4sV3: {
-		AgentPoolProfileRoleMaster: {
-			SystemReserved: "cpu=1000m,memory=1Gi",
-		},
-		AgentPoolProfileRoleCompute: {
-			KubeReserved:   "cpu=500m,memory=512Mi",
-			SystemReserved: "cpu=500m,memory=512Mi",
-		},
-		AgentPoolProfileRoleInfra: {
-			KubeReserved:   "cpu=500m,memory=512Mi",
-			SystemReserved: "cpu=500m,memory=512Mi",
-		},
-	},
-}
-
 // AzureLocations defines a) known regions where we permit OSA to be deployed,
 // and b) mapping from OSA region to a LogAnalytics region.  Logging data sent
 // to LogAnalytics must remain in the same sovereign.  See

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -133,16 +133,6 @@ const (
 	OSTypeWindows OSType = "Windows"
 )
 
-// ReservedResources represents the type of reserved resource
-type ReservedResource string
-
-const (
-	// SystemReserved is for reserved system resources
-	SystemReserved ReservedResource = "system-reserved"
-	// KubeReserved is for reserved kubelet resources
-	KubeReserved ReservedResource = "kube-reserved"
-)
-
 // AgentPoolProfileRole represents the role of the AgentPoolProfile.
 type AgentPoolProfileRole string
 
@@ -158,11 +148,52 @@ const (
 // VMSize represents supported VMSizes
 type VMSize string
 
+// VMSizes
 const (
-	// StandardD2sV3 represents Standard_D2s_v3
-	StandardD2sV3 VMSize = "Standard_D2s_v3"
-	// StandardD4sV3 represents Standard_D2s_v3
-	StandardD4sV3 VMSize = "Standard_D4s_v3"
+	// General purpose VMs
+	StandardD2sV3  VMSize = "Standard_D2s_v3"
+	StandardD4sV3  VMSize = "Standard_D4s_v3"
+	StandardD8sV3  VMSize = "Standard_D8s_v3"
+	StandardD16sV3 VMSize = "Standard_D16s_v3"
+	StandardD32sV3 VMSize = "Standard_D32s_v3"
+	StandardD64sV3 VMSize = "Standard_D64s_v3"
+
+	StandardDS4V2 VMSize = "Standard_DS4_v2"
+	StandardDS5V2 VMSize = "Standard_DS5_v2"
+
+	// Compute optimized VMs
+	StandardF8sV2  VMSize = "Standard_F8s_v2"
+	StandardF16sV2 VMSize = "Standard_F16s_v2"
+	StandardF32sV2 VMSize = "Standard_F32s_v2"
+	StandardF64sV2 VMSize = "Standard_F64s_v2"
+	StandardF72sV2 VMSize = "Standard_F72s_v2"
+
+	StandardF8s  VMSize = "Standard_F8s"
+	StandardF16s VMSize = "Standard_F16s"
+
+	// Memory optimized VMs
+	StandardE4sV3  VMSize = "Standard_E4s_v3"
+	StandardE8sV3  VMSize = "Standard_E8s_v3"
+	StandardE16sV3 VMSize = "Standard_E16s_v3"
+	StandardE20sV3 VMSize = "Standard_E20s_v3"
+	StandardE32sV3 VMSize = "Standard_E32s_v3"
+	StandardE64sV3 VMSize = "Standard_E64s_v3"
+
+	StandardGS2 VMSize = "Standard_GS2"
+	StandardGS3 VMSize = "Standard_GS3"
+	StandardGS4 VMSize = "Standard_GS4"
+	StandardGS5 VMSize = "Standard_GS5"
+
+	StandardDS12V2 VMSize = "Standard_DS12_v2"
+	StandardDS13V2 VMSize = "Standard_DS13_v2"
+	StandardDS14V2 VMSize = "Standard_DS14_v2"
+	StandardDS15V2 VMSize = "Standard_DS15_v2"
+
+	// Storage optimized VMs
+	StandardL4s  VMSize = "Standard_L4s"
+	StandardL8s  VMSize = "Standard_L8s"
+	StandardL16s VMSize = "Standard_L16s"
+	StandardL32s VMSize = "Standard_L32s"
 )
 
 // AuthProfile defines all possible authentication profiles for the OpenShift

--- a/pkg/api/validate_test.go
+++ b/pkg/api/validate_test.go
@@ -263,6 +263,7 @@ func TestValidate(t *testing.T) {
 			},
 			expectedErrs: []error{
 				errors.New(`invalid properties.agentPoolProfiles["infra"].vmSize "SuperBigVM"`),
+				errors.New(`invalid properties.agentPoolProfiles.vmSize "SuperBigVM": master and infra vmSizes must match`),
 			},
 		},
 		"agent pool unmatched subnet cidr": {
@@ -313,7 +314,7 @@ func TestValidate(t *testing.T) {
 					}
 				}
 			},
-			expectedErrs: []error{errors.New(`invalid masterPoolProfile.count 1`)},
+			expectedErrs: []error{errors.New(`invalid properties.masterPoolProfile.count 1`)},
 		},
 		//we dont check authProfile because it is non pointer struct. Which is all zero values.
 		"authProfile.identityProviders empty": {


### PR DESCRIPTION
Allow master and infra nodes to be Standard_D{2-64}s_v3.
Allow a range of additional values for compute nodes.
Increase maximum number of compute nodes to 20.
See code for rationales.