### PR TITLE
Remove e2e image

### DIFF
--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,4 +1,0 @@
-FROM centos:7
-RUN yum -y update
-COPY e2e.test .
-ENTRYPOINT [ "/e2e.test" ]

--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 COMMIT=$(shell git rev-parse --short HEAD)$(shell [[ $$(git status --porcelain --ignored) = "" ]] && echo -clean || echo -dirty)
 
 # all is the default target to build everything
-all: clean build sync e2e-bin
+all: clean build sync
 
 build: generate
 	go build ./...
@@ -49,14 +49,4 @@ e2e: generate
 e2e-prod:
 	go test ./test/e2erp -tags e2erp -test.v -ginkgo.v -ginkgo.randomizeAllSpecs -ginkgo.noColor -ginkgo.focus=Real -timeout 4h
 
-e2e-bin: generate
-	go test -tags e2e -ldflags "-X github.com/openshift/openshift-azure/test/e2e.gitCommit=$(COMMIT)" -i -c -o e2e.test ./test/e2e
-
-e2e-image: e2e-bin
-	go get github.com/openshift/imagebuilder/cmd/imagebuilder
-	imagebuilder -f Dockerfile.e2e -t $(E2E_IMAGE) .
-
-e2e-push: e2e-image
-	docker push $(E2E_IMAGE)
-
-.PHONY: clean sync-image sync-push verify unit e2e e2e-bin e2e-prod
+.PHONY: clean sync-image sync-push verify unit e2e e2e-prod


### PR DESCRIPTION
It never worked, and it seems we are in agreement that MSFT should run tests directly from the repo to run the exact same commit that the RP has vendored. 

/cc mjudeikis charlesakalugwu 