### PR TITLE
Adding support for multiple e2e make targets.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ generate:
 TAG ?= $(shell git rev-parse --short HEAD)
 SYNC_IMAGE ?= quay.io/openshift-on-azure/sync:$(TAG)
 E2E_IMAGE ?= quay.io/openshift-on-azure/e2e-tests:$(TAG)
+E2E_EXEC ?= ./hack/e2e.sh
 
 sync: generate
 	go build -ldflags "-X main.gitCommit=$(COMMIT)" ./cmd/sync
@@ -44,7 +45,7 @@ cover: unit
 	go tool cover -html=coverage.out
 
 e2e: generate
-	./hack/e2e.sh
+	sh ${E2E_EXEC}
 
 e2e-prod:
 	go test ./test/e2erp -tags e2erp -test.v -ginkgo.v -ginkgo.randomizeAllSpecs -ginkgo.noColor -ginkgo.focus=Real -timeout 4h

--- a/Makefile
+++ b/Makefile
@@ -17,7 +17,6 @@ generate:
 TAG ?= $(shell git rev-parse --short HEAD)
 SYNC_IMAGE ?= quay.io/openshift-on-azure/sync:$(TAG)
 E2E_IMAGE ?= quay.io/openshift-on-azure/e2e-tests:$(TAG)
-E2E_EXEC ?= ./hack/e2e.sh
 
 sync: generate
 	go build -ldflags "-X main.gitCommit=$(COMMIT)" ./cmd/sync
@@ -45,9 +44,12 @@ cover: unit
 	go tool cover -html=coverage.out
 
 e2e: generate
-	sh ${E2E_EXEC}
+	./hack/e2e.sh
 
 e2e-prod:
 	go test ./test/e2erp -tags e2erp -test.v -ginkgo.v -ginkgo.randomizeAllSpecs -ginkgo.noColor -ginkgo.focus=Real -timeout 4h
 
-.PHONY: clean sync-image sync-push verify unit e2e e2e-prod
+e2e-bushslicer: generate
+	SUITE=bushslicer ./hack/e2e.sh
+
+.PHONY: clean sync-image sync-push verify unit e2e e2e-prod e2e-bushslicer

--- a/hack/e2e-bushslicer.sh
+++ b/hack/e2e-bushslicer.sh
@@ -1,0 +1,16 @@
+#!/bin/bash
+
+set -eo pipefail
+
+echo "SUITE=>${SUITE}"
+if [[ -z "$RESOURCEGROUP" ]]; then
+    RESOURCEGROUP=$(awk '/^    resourceGroup:/ { print $2 }' <_data/containerservice.yaml)
+fi
+
+if [[ -n "$ARTIFACT_DIR" ]]; then
+  ARTIFACT_FLAG="-artifact-dir=$ARTIFACT_DIR"
+fi
+
+
+# TODO: figure out env variables and other information required by cucumber
+/usr/bin/scl enable rh-git29 rh-ror50 /opt/rh/rh-ruby24/root/usr/local/bin/cucumber

--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -41,3 +41,9 @@ if [[ -z "$SUITE" || "$SUITE" == "customer-cluster-admin" ]]; then
   KUBECONFIG=$KUBECONFIG_END_USER oc login $fqdn --username enduser --password "$(awk '/^  endUserPasswd:/{ print $2 }' <_data/containerservice.yaml)" --insecure-skip-tls-verify=true
   go test ./test/e2e -test.v -ginkgo.v -ginkgo.focus="\[CustomerAdmin\]" -ginkgo.noColor -ginkgo.randomizeAllSpecs -tags e2e -kubeconfig ../../_data/_out/enduser.kubeconfig "${ARTIFACT_FLAG:-}"
 fi
+
+if [[ -z "$SUITE" || "$SUITE" == "bushslicer" ]]; then
+  echo "Running bushslicer tests"
+  # TODO: setup environment here
+  /usr/bin/scl enable rh-git29 rh-ror50 -- /opt/rh/rh-ruby24/root/usr/local/bin/cucumber feature/cli/build.feature:5
+fi


### PR DESCRIPTION
Adding the ability as per @kargakis request to call multiple e2e targets and re-use the e2e-azure templates.

@kargakis, is this what you had in mind?