### PR TITLE
fix computer name / node name issues and tidy up

### DIFF
--- a/pkg/cluster/deploy.go
+++ b/pkg/cluster/deploy.go
@@ -51,7 +51,7 @@ type instanceName string
 type hash string
 
 type vmInfo struct {
-	ComputerName instanceName `json:"computerName,omitempty"`
+	InstanceName instanceName `json:"instanceName,omitempty"`
 	ScalesetHash hash         `json:"scalesetHash,omitempty"`
 }
 
@@ -119,7 +119,7 @@ func (u *simpleUpgrader) updateBlob(b map[instanceName]hash) error {
 	blob := make([]vmInfo, len(b))
 	for instancename, hash := range b {
 		blob = append(blob, vmInfo{
-			ComputerName: instancename,
+			InstanceName: instancename,
 			ScalesetHash: hash,
 		})
 	}
@@ -155,7 +155,7 @@ func (u *simpleUpgrader) readBlob() (map[instanceName]hash, error) {
 	}
 	b := make(map[instanceName]hash)
 	for _, vi := range blob {
-		b[vi.ComputerName] = vi.ScalesetHash
+		b[vi.InstanceName] = vi.ScalesetHash
 	}
 	return b, nil
 }

--- a/pkg/cluster/drain.go
+++ b/pkg/cluster/drain.go
@@ -10,7 +10,6 @@ import (
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/fields"
-	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/util/retry"
 
 	"github.com/openshift/openshift-azure/pkg/api"
@@ -36,12 +35,12 @@ func (u *simpleUpgrader) drain(ctx context.Context, cs *api.OpenShiftManagedClus
 		// no-op for now
 
 	case api.AgentPoolProfileRoleInfra, api.AgentPoolProfileRoleCompute:
-		err := setUnschedulable(ctx, u.kubeclient, computerName, true)
+		err := u.setUnschedulable(ctx, computerName, true)
 		if err != nil {
 			return err
 		}
 
-		err = deletePods(ctx, u.kubeclient, computerName)
+		err = u.deletePods(ctx, computerName)
 		if err != nil {
 			return err
 		}
@@ -53,15 +52,15 @@ func (u *simpleUpgrader) drain(ctx context.Context, cs *api.OpenShiftManagedClus
 	return u.kubeclient.CoreV1().Nodes().Delete(computerName.toKubernetes(), &metav1.DeleteOptions{})
 }
 
-func setUnschedulable(ctx context.Context, kc kubernetes.Interface, computerName computerName, unschedulable bool) error {
+func (u *simpleUpgrader) setUnschedulable(ctx context.Context, computerName computerName, unschedulable bool) error {
 	return retry.RetryOnConflict(retry.DefaultRetry, func() error {
-		node, err := kc.CoreV1().Nodes().Get(computerName.toKubernetes(), metav1.GetOptions{})
+		node, err := u.kubeclient.CoreV1().Nodes().Get(computerName.toKubernetes(), metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
 
 		node.Spec.Unschedulable = unschedulable
-		_, err = kc.CoreV1().Nodes().Update(node)
+		_, err = u.kubeclient.CoreV1().Nodes().Update(node)
 		return err
 	})
 }
@@ -82,8 +81,8 @@ func max(i, j time.Duration) time.Duration {
 	return j
 }
 
-func deletePods(ctx context.Context, kc kubernetes.Interface, computerName computerName) error {
-	podList, err := kc.CoreV1().Pods(metav1.NamespaceAll).List(metav1.ListOptions{
+func (u *simpleUpgrader) deletePods(ctx context.Context, computerName computerName) error {
+	podList, err := u.kubeclient.CoreV1().Pods(metav1.NamespaceAll).List(metav1.ListOptions{
 		FieldSelector: fields.SelectorFromSet(fields.Set{"spec.nodeName": computerName.toKubernetes()}).String(),
 	})
 	if err != nil {
@@ -102,7 +101,7 @@ func deletePods(ctx context.Context, kc kubernetes.Interface, computerName compu
 			continue
 		}
 
-		err = kc.CoreV1().Pods(pod.Namespace).Delete(pod.Name, &metav1.DeleteOptions{})
+		err = u.kubeclient.CoreV1().Pods(pod.Namespace).Delete(pod.Name, &metav1.DeleteOptions{})
 		switch {
 		case err == nil:
 			d := 30 * time.Second
@@ -125,7 +124,7 @@ func deletePods(ctx context.Context, kc kubernetes.Interface, computerName compu
 	defer t.Stop()
 	return wait.PollImmediateUntil(time.Second, func() (bool, error) {
 		for pod := range pods {
-			p, err := kc.CoreV1().Pods(pod.Namespace).Get(pod.Name, metav1.GetOptions{})
+			p, err := u.kubeclient.CoreV1().Pods(pod.Namespace).Get(pod.Name, metav1.GetOptions{})
 			switch {
 			case apierrors.IsNotFound(err) || (p != nil && p.ObjectMeta.UID != pod.ObjectMeta.UID):
 				delete(pods, pod)

--- a/pkg/cluster/drain_test.go
+++ b/pkg/cluster/drain_test.go
@@ -18,22 +18,22 @@ func TestUpgraderDrain(t *testing.T) {
 		name            string
 		kubeclient      *fake.Clientset
 		role            api.AgentPoolProfileRole
-		nodeName        string
+		computerName    computerName
 		wantErr         error
 		expectedActions [][]string
 	}{
 		{
-			name:     "master-empty",
-			role:     api.AgentPoolProfileRoleMaster,
-			nodeName: "master-000000",
+			name:         "master-empty",
+			role:         api.AgentPoolProfileRoleMaster,
+			computerName: "master-000000",
 			expectedActions: [][]string{
 				{"get", "nodes"}},
 			kubeclient: fake.NewSimpleClientset(),
 		},
 		{
-			name:     "unknown-role",
-			role:     "cant-find-this",
-			nodeName: "master-000000",
+			name:         "unknown-role",
+			role:         "cant-find-this",
+			computerName: "master-000000",
 			expectedActions: [][]string{
 				{"get", "nodes"}},
 			wantErr: errUnrecognisedRole,
@@ -44,9 +44,9 @@ func TestUpgraderDrain(t *testing.T) {
 			}),
 		},
 		{
-			name:     "master-no-pods",
-			role:     api.AgentPoolProfileRoleMaster,
-			nodeName: "master-000000",
+			name:         "master-no-pods",
+			role:         api.AgentPoolProfileRoleMaster,
+			computerName: "master-000000",
 			expectedActions: [][]string{
 				{"get", "nodes"},
 				{"delete", "nodes"}},
@@ -57,9 +57,9 @@ func TestUpgraderDrain(t *testing.T) {
 			}),
 		},
 		{
-			name:     "compute-with-a-pod",
-			role:     api.AgentPoolProfileRoleCompute,
-			nodeName: "kubernetes",
+			name:         "compute-with-a-pod",
+			role:         api.AgentPoolProfileRoleCompute,
+			computerName: "kubernetes",
 			expectedActions: [][]string{
 				{"get", "nodes"},
 				{"get", "nodes"},
@@ -84,7 +84,7 @@ func TestUpgraderDrain(t *testing.T) {
 		u := &simpleUpgrader{
 			kubeclient: tt.kubeclient,
 		}
-		if err := u.drain(context.Background(), nil, tt.role, tt.nodeName); err != tt.wantErr {
+		if err := u.drain(context.Background(), nil, tt.role, tt.computerName); err != tt.wantErr {
 			t.Errorf("[%v] simpleUpgrader.drain() error = %v, wantErr %v", tt.name, err, tt.wantErr)
 		}
 		actions := tt.kubeclient.Actions()

--- a/pkg/cluster/ready_test.go
+++ b/pkg/cluster/ready_test.go
@@ -120,7 +120,8 @@ func TestNodeIsReady(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		got, err := nodeIsReady(tt.kc, tt.computerName)
+		u := &simpleUpgrader{kubeclient: tt.kc}
+		got, err := u.nodeIsReady(tt.computerName)
 		if (err != nil) != tt.wantErr {
 			t.Errorf("nodeIsReady() error = %v, wantErr %v", err, tt.wantErr)
 			return
@@ -240,7 +241,8 @@ func TestMasterIsReady(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		got, err := masterIsReady(tt.kc, tt.computerName)
+		u := &simpleUpgrader{kubeclient: tt.kc}
+		got, err := u.masterIsReady(tt.computerName)
 		if (err != nil) != tt.wantErr {
 			t.Errorf("masterIsReady() error = %v, wantErr %v. Test: %v", err, tt.wantErr, tt.name)
 			return

--- a/pkg/cluster/ready_test.go
+++ b/pkg/cluster/ready_test.go
@@ -69,24 +69,24 @@ func TestIsPodReady(t *testing.T) {
 
 func TestNodeIsReady(t *testing.T) {
 	tests := []struct {
-		name     string
-		kc       *fake.Clientset
-		nodeName string
-		want     bool
-		wantErr  bool
+		name         string
+		kc           *fake.Clientset
+		computerName computerName
+		want         bool
+		wantErr      bool
 	}{
 		{
-			name:     "not found",
-			nodeName: "master-000000",
-			wantErr:  false,
-			want:     false,
-			kc:       fake.NewSimpleClientset(),
+			name:         "not found",
+			computerName: "master-000000",
+			wantErr:      false,
+			want:         false,
+			kc:           fake.NewSimpleClientset(),
 		},
 		{
-			name:     "not ready",
-			nodeName: "master-000000",
-			wantErr:  false,
-			want:     false,
+			name:         "not ready",
+			computerName: "master-000000",
+			wantErr:      false,
+			want:         false,
 			kc: fake.NewSimpleClientset(&corev1.Node{
 				TypeMeta: metav1.TypeMeta{
 					Kind: "node",
@@ -97,16 +97,16 @@ func TestNodeIsReady(t *testing.T) {
 			}),
 		},
 		{
-			name:     "ready",
-			nodeName: "master-000000",
-			wantErr:  false,
-			want:     true,
+			name:         "ready",
+			computerName: "master-00000A",
+			wantErr:      false,
+			want:         true,
 			kc: fake.NewSimpleClientset(&corev1.Node{
 				TypeMeta: metav1.TypeMeta{
 					Kind: "node",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "master-000000",
+					Name: "master-00000a",
 				},
 				Status: corev1.NodeStatus{
 					Conditions: []corev1.NodeCondition{
@@ -120,7 +120,7 @@ func TestNodeIsReady(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		got, err := nodeIsReady(tt.kc, tt.nodeName)
+		got, err := nodeIsReady(tt.kc, tt.computerName)
 		if (err != nil) != tt.wantErr {
 			t.Errorf("nodeIsReady() error = %v, wantErr %v", err, tt.wantErr)
 			return
@@ -133,24 +133,24 @@ func TestNodeIsReady(t *testing.T) {
 
 func TestMasterIsReady(t *testing.T) {
 	tests := []struct {
-		name     string
-		kc       kubernetes.Interface
-		nodeName string
-		want     bool
-		wantErr  bool
+		name         string
+		kc           kubernetes.Interface
+		computerName computerName
+		want         bool
+		wantErr      bool
 	}{
 		{
-			name:     "node not found",
-			nodeName: "master-000000",
-			wantErr:  false,
-			want:     false,
-			kc:       fake.NewSimpleClientset(),
+			name:         "node not found",
+			computerName: "master-000000",
+			wantErr:      false,
+			want:         false,
+			kc:           fake.NewSimpleClientset(),
 		},
 		{
-			name:     "node ready, pods not found",
-			nodeName: "master-000000",
-			wantErr:  false,
-			want:     false,
+			name:         "node ready, pods not found",
+			computerName: "master-000000",
+			wantErr:      false,
+			want:         false,
 			kc: fake.NewSimpleClientset(&corev1.Node{
 				TypeMeta: metav1.TypeMeta{
 					Kind: "node",
@@ -169,16 +169,16 @@ func TestMasterIsReady(t *testing.T) {
 			}),
 		},
 		{
-			name:     "node ready, pods ready",
-			nodeName: "master-000000",
-			wantErr:  false,
-			want:     true,
+			name:         "node ready, pods ready",
+			computerName: "master-00000A",
+			wantErr:      false,
+			want:         true,
 			kc: fake.NewSimpleClientset(&corev1.Node{
 				TypeMeta: metav1.TypeMeta{
 					Kind: "node",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "master-000000",
+					Name: "master-00000a",
 				},
 				Status: corev1.NodeStatus{
 					Conditions: []corev1.NodeCondition{
@@ -193,7 +193,7 @@ func TestMasterIsReady(t *testing.T) {
 					Kind: "pod",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "master-etcd-master-000000",
+					Name:      "master-etcd-master-00000a",
 					Namespace: "kube-system",
 				},
 				Status: corev1.PodStatus{
@@ -209,7 +209,7 @@ func TestMasterIsReady(t *testing.T) {
 					Kind: "pod",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "master-api-master-000000",
+					Name:      "master-api-master-00000a",
 					Namespace: "kube-system",
 				},
 				Status: corev1.PodStatus{
@@ -225,7 +225,7 @@ func TestMasterIsReady(t *testing.T) {
 					Kind: "pod",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "controllers-master-000000",
+					Name:      "controllers-master-00000a",
 					Namespace: "kube-system",
 				},
 				Status: corev1.PodStatus{
@@ -240,7 +240,7 @@ func TestMasterIsReady(t *testing.T) {
 		},
 	}
 	for _, tt := range tests {
-		got, err := masterIsReady(tt.kc, tt.nodeName)
+		got, err := masterIsReady(tt.kc, tt.computerName)
 		if (err != nil) != tt.wantErr {
 			t.Errorf("masterIsReady() error = %v, wantErr %v. Test: %v", err, tt.wantErr, tt.name)
 			return
@@ -379,7 +379,7 @@ func TestUpgraderWaitForNodes(t *testing.T) {
 					Kind: "node",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name: "master-000000",
+					Name: "master-00000a",
 				},
 				Status: corev1.NodeStatus{
 					Conditions: []corev1.NodeCondition{
@@ -394,7 +394,7 @@ func TestUpgraderWaitForNodes(t *testing.T) {
 					Kind: "pod",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "master-etcd-master-000000",
+					Name:      "master-etcd-master-00000a",
 					Namespace: "kube-system",
 				},
 				Status: corev1.PodStatus{
@@ -410,7 +410,7 @@ func TestUpgraderWaitForNodes(t *testing.T) {
 					Kind: "pod",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "master-api-master-000000",
+					Name:      "master-api-master-00000a",
 					Namespace: "kube-system",
 				},
 				Status: corev1.PodStatus{
@@ -426,7 +426,7 @@ func TestUpgraderWaitForNodes(t *testing.T) {
 					Kind: "pod",
 				},
 				ObjectMeta: metav1.ObjectMeta{
-					Name:      "controllers-master-000000",
+					Name:      "controllers-master-00000a",
 					Namespace: "kube-system",
 				},
 				Status: corev1.PodStatus{
@@ -449,7 +449,7 @@ func TestUpgraderWaitForNodes(t *testing.T) {
 						Name: to.StringPtr("ss-master"),
 						VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
 							OsProfile: &compute.OSProfile{
-								ComputerName: to.StringPtr("master-000000"),
+								ComputerName: to.StringPtr("master-00000A"),
 							},
 						},
 					},

--- a/pkg/cluster/update.go
+++ b/pkg/cluster/update.go
@@ -213,7 +213,7 @@ func (u *simpleUpgrader) updatePlusOne(ctx context.Context, cs *api.OpenShiftMan
 					return &api.PluginError{Err: err, Step: api.PluginStepUpdatePlusOneWaitForReady}
 				}
 				vmsBefore[*updated.InstanceID] = struct{}{}
-				blob[instanceName(*updated.Name)] = ssHashes[ssNameForVm(&updated)]
+				blob[instanceName(*updated.Name)] = ssHashes[ssNameForVM(&updated)]
 				if err := u.updateBlob(blob); err != nil {
 					return &api.PluginError{Err: err, Step: api.PluginStepUpdatePlusOneUpdateBlob}
 				}
@@ -235,7 +235,7 @@ func (u *simpleUpgrader) updatePlusOne(ctx context.Context, cs *api.OpenShiftMan
 func filterOldVMs(vms []compute.VirtualMachineScaleSetVM, blob map[instanceName]hash, ssHashes map[scalesetName]hash) []compute.VirtualMachineScaleSetVM {
 	var oldVMs []compute.VirtualMachineScaleSetVM
 	for _, vm := range vms {
-		if blob[instanceName(*vm.Name)] != ssHashes[ssNameForVm(&vm)] {
+		if blob[instanceName(*vm.Name)] != ssHashes[ssNameForVM(&vm)] {
 			oldVMs = append(oldVMs, vm)
 		} else {
 			log.Infof("skipping vm %q since it's already updated", *vm.Name)
@@ -244,7 +244,7 @@ func filterOldVMs(vms []compute.VirtualMachineScaleSetVM, blob map[instanceName]
 	return oldVMs
 }
 
-func ssNameForVm(vm *compute.VirtualMachineScaleSetVM) scalesetName {
+func ssNameForVM(vm *compute.VirtualMachineScaleSetVM) scalesetName {
 	hostname := strings.Split(*vm.Name, "_")[0]
 	return scalesetName(hostname)
 }


### PR DESCRIPTION
fixes #741
the 2nd commit is the key one here.  The idea is to introduce a new type for computer names - we have to remember to wrap all reads of ComputerName as `computerName(*vm.VirtualMachineScaleSetVMProperties.OsProfile.ComputerName)` but then we are reminded that we must do `computerName.toKubernetes()` whenever we want to use a computer name as a kubernetes node name.