### PR TITLE
Remove quotes from bash envs to fix Go flag parsing

### DIFF
--- a/test/e2e.sh
+++ b/test/e2e.sh
@@ -102,4 +102,4 @@ if [[ -n "$ARTIFACT_DIR" ]]; then
     ARTIFACT_KUBECONFIG_FLAG="-artifact-kubeconfig=_data/_out/admin.kubeconfig"
 fi
 
-go run cmd/createorupdate/createorupdate.go -rm "$USE_PROD_FLAG" "$EXEC_FLAG" "$UPDATE_FLAG" "$UPDATE_EXEC_FLAG" "$ARTIFACT_DIR_FLAG" "$ARTIFACT_KUBECONFIG_FLAG"
+go run cmd/createorupdate/createorupdate.go -rm $USE_PROD_FLAG $EXEC_FLAG $UPDATE_FLAG $UPDATE_EXEC_FLAG $ARTIFACT_DIR_FLAG $ARTIFACT_KUBECONFIG_FLAG


### PR DESCRIPTION
This broke the update test since EXEC is undefined and the go flag parsing would not interpret the last half of the flags.

/cc mjudeikis charlesakalugwu 