### PR TITLE
Add another spec to e2erp

### DIFF
--- a/test/e2erp/client_test.go
+++ b/test/e2erp/client_test.go
@@ -27,7 +27,6 @@ type AzureConfig struct {
 	ClientID        string   `envconfig:"AZURE_CLIENT_ID" required:"true"`
 	ClientSecret    string   `envconfig:"AZURE_CLIENT_SECRET" required:"true"`
 	ResourceGroup   string   `envconfig:"RESOURCEGROUP" required:"true"`
-	ClusterName     string   `envconfig:"CLUSTERNAME"`
 	AcceptLanguages []string `envconfig:"ACCEPT_LANGUAGES" default:"en-us"`
 }
 
@@ -43,7 +42,6 @@ type testClient struct {
 
 	resourceGroup    string
 	location         string
-	clusterName      string
 	appResourceGroup string
 }
 
@@ -81,11 +79,8 @@ func newTestClient(conf AzureConfig) *testClient {
 	appsc := azureclient.NewApplicationsClient(subID, authorizer, conf.AcceptLanguages)
 	accsc := azureclient.NewAccountsClient(subID, authorizer, conf.AcceptLanguages)
 
-	clusterName := conf.ResourceGroup
-	if conf.ClusterName != "" {
-		clusterName = conf.ClusterName
-	}
-	appRg := ApplicationResourceGroup(conf.ResourceGroup, clusterName, conf.Region)
+	// TODO: az cli tool supports more than 1 cluster per RG, may need to use another env var for the cluster name in the future
+	appRg := ApplicationResourceGroup(conf.ResourceGroup, conf.ResourceGroup, conf.Region)
 
 	return &testClient{
 		ctx:              ctx,
@@ -97,7 +92,6 @@ func newTestClient(conf AzureConfig) *testClient {
 		appsc:            appsc,
 		accsc:            accsc,
 		resourceGroup:    conf.ResourceGroup,
-		clusterName:      clusterName,
 		location:         conf.Region,
 		appResourceGroup: appRg,
 	}

--- a/test/e2erp/client_test.go
+++ b/test/e2erp/client_test.go
@@ -3,12 +3,14 @@
 package e2erp
 
 import (
+	"context"
 	"fmt"
 	"regexp"
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
 	"github.com/onsi/ginkgo/config"
 
+	"github.com/openshift/openshift-azure/pkg/api"
 	"github.com/openshift/openshift-azure/pkg/util/azureclient"
 	sdk "github.com/openshift/openshift-azure/pkg/util/azureclient/osa-go-sdk/services/containerservice/mgmt/2018-09-30-preview/containerservice"
 )
@@ -25,19 +27,24 @@ type AzureConfig struct {
 	ClientID        string   `envconfig:"AZURE_CLIENT_ID" required:"true"`
 	ClientSecret    string   `envconfig:"AZURE_CLIENT_SECRET" required:"true"`
 	ResourceGroup   string   `envconfig:"RESOURCEGROUP" required:"true"`
+	ClusterName     string   `envconfig:"CLUSTERNAME"`
 	AcceptLanguages []string `envconfig:"ACCEPT_LANGUAGES" default:"en-us"`
 }
 
 type testClient struct {
+	ctx   context.Context
 	gc    resources.GroupsClient
 	rpc   sdk.OpenShiftManagedClustersClient
 	ssc   azureclient.VirtualMachineScaleSetsClient
 	ssvmc azureclient.VirtualMachineScaleSetVMsClient
 	ssec  azureclient.VirtualMachineScaleSetExtensionsClient
 	appsc azureclient.ApplicationsClient
+	accsc azureclient.AccountsClient
 
-	resourceGroup string
-	location      string
+	resourceGroup    string
+	location         string
+	clusterName      string
+	appResourceGroup string
 }
 
 func newTestClient(conf AzureConfig) *testClient {
@@ -48,6 +55,11 @@ func newTestClient(conf AzureConfig) *testClient {
 	subID := conf.SubscriptionID
 	gc := resources.NewGroupsClient(subID)
 	gc.Authorizer = authorizer
+
+	ctx := context.Background()
+	ctx = context.WithValue(ctx, api.ContextKeyClientID, conf.ClientID)
+	ctx = context.WithValue(ctx, api.ContextKeyClientSecret, conf.ClientSecret)
+	ctx = context.WithValue(ctx, api.ContextKeyTenantID, conf.TenantID)
 
 	var rpc sdk.OpenShiftManagedClustersClient
 	focus := []byte(config.GinkgoConfig.FocusString)
@@ -67,15 +79,26 @@ func newTestClient(conf AzureConfig) *testClient {
 	ssvmc := azureclient.NewVirtualMachineScaleSetVMsClient(subID, authorizer, conf.AcceptLanguages)
 	ssec := azureclient.NewVirtualMachineScaleSetExtensionsClient(subID, authorizer, conf.AcceptLanguages)
 	appsc := azureclient.NewApplicationsClient(subID, authorizer, conf.AcceptLanguages)
+	accsc := azureclient.NewAccountsClient(subID, authorizer, conf.AcceptLanguages)
+
+	clusterName := conf.ResourceGroup
+	if conf.ClusterName != "" {
+		clusterName = conf.ClusterName
+	}
+	appRg := ApplicationResourceGroup(conf.ResourceGroup, clusterName, conf.Region)
 
 	return &testClient{
-		gc:            gc,
-		rpc:           rpc,
-		ssc:           ssc,
-		ssvmc:         ssvmc,
-		ssec:          ssec,
-		appsc:         appsc,
-		resourceGroup: conf.ResourceGroup,
-		location:      conf.Region,
+		ctx:              ctx,
+		gc:               gc,
+		rpc:              rpc,
+		ssc:              ssc,
+		ssvmc:            ssvmc,
+		ssec:             ssec,
+		appsc:            appsc,
+		accsc:            accsc,
+		resourceGroup:    conf.ResourceGroup,
+		clusterName:      clusterName,
+		location:         conf.Region,
+		appResourceGroup: appRg,
 	}
 }


### PR DESCRIPTION
This spec will ensure a user cannot read the config blob from the
storage account (or read the storage account at all)