### PR TITLE
Add NO_WAIT functionality for DELETEs

### DIFF
--- a/pkg/fakerp/config.go
+++ b/pkg/fakerp/config.go
@@ -34,6 +34,7 @@ type Config struct {
 	NoGroupTags      bool   `envconfig:"NOGROUPTAGS"`
 	ResourceGroupTTL string `envconfig:"RESOURCEGROUP_TTL"`
 	Manifest         string `envconfig:"MANIFEST"`
+	NoWait           bool   `envconfig:"NO_WAIT"`
 }
 
 func NewConfig(log *logrus.Entry) (*Config, error) {


### PR DESCRIPTION
Also:
* fix resource group deletion to exit successfully if the resource
group is already deleted (fixes https://github.com/openshift/openshift-azure/issues/698)
* use the delete future appropriately