### PR TITLE
Enable configurable timeouts for e2e tests

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -10,6 +10,10 @@ if [[ -n "$FOCUS" ]]; then
     FOCUS="-ginkgo.focus=$FOCUS"
 fi
 
-go test ./test/e2e -timeout 20m -test.v -ginkgo.v "${FOCUS:-}" -ginkgo.noColor -tags e2e "${ARTIFACT_FLAG:-}"
+if [[ -z "$TIMEOUT" ]]; then
+    TIMEOUT=20m
+fi
+
+go test ./test/e2e -timeout "$TIMEOUT" -test.v -ginkgo.v "${FOCUS:-}" -ginkgo.noColor -tags e2e "${ARTIFACT_FLAG:-}"
 
 # -ldflags "-X github.com/openshift/openshift-azure/test/e2e.gitCommit=COMMIT"


### PR DESCRIPTION
As a follow-up to #780 this change allows configurable timeouts for e2e tests. Particularly useful for the update-based scenarios.

For an update test we can use the following make target utilizing the TIMEOUT

```
e2e-keyrotation:
	FOCUS=KeyRotation TIMEOUT=60m ./hack/e2e.sh
```
/cc @kargakis @mjudeikis 