### PR TITLE
Export GetPluginConfig to allow it to be used from e2e tests

### DIFF
--- a/pkg/fakerp/config.go
+++ b/pkg/fakerp/config.go
@@ -73,7 +73,7 @@ func NewConfig(log *logrus.Entry) (*Config, error) {
 	return &c, nil
 }
 
-func getPluginConfig() (*api.PluginConfig, error) {
+func GetPluginConfig() (*api.PluginConfig, error) {
 	tc := api.TestConfig{
 		RunningUnderTest:      os.Getenv("RUNNING_UNDER_TEST") != "",
 		ImageResourceGroup:    os.Getenv("IMAGE_RESOURCEGROUP"),

--- a/pkg/fakerp/server.go
+++ b/pkg/fakerp/server.go
@@ -254,7 +254,7 @@ func (s *Server) handlePut(w http.ResponseWriter, req *http.Request) {
 	ctx = context.WithValue(ctx, api.ContextKeyTenantID, s.conf.TenantID)
 
 	// populate plugin configuration
-	config, err := getPluginConfig()
+	config, err := GetPluginConfig()
 	if err != nil {
 		resp := "400 Bad Request: Failed to configure plugin"
 		s.log.Debugf("%s: %v", resp, err)


### PR DESCRIPTION
Certain update-based e2e tests such as keyrotation will need access to a
plugin config in order to call generate on a mutated config blob. This
change provides a single way to get a plugin config that can be shared
between the production code and our e2e tests

```
pluginConfig := fakerp.GetPluginConfig()
```

/cc @kargakis @mjudeikis 