### PR TITLE
Avoid skipping errors in the e2e framework

### DIFF
--- a/test/e2e/specs/customer_admin.go
+++ b/test/e2e/specs/customer_admin.go
@@ -25,13 +25,9 @@ var _ = Describe("Openshift on Azure customer-admin e2e tests [CustomerAdmin]", 
 	BeforeEach(func() {
 		var err error
 		cli, err = openshift.NewEndUserClient()
-		if err != nil {
-			Skip(err.Error())
-		}
+		Expect(err).ToNot(HaveOccurred())
 		admincli, err = openshift.NewCustomerAdminClient()
-		if err != nil {
-			Skip(err.Error())
-		}
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	It("should not read nodes", func() {

--- a/test/e2e/specs/customer_reader.go
+++ b/test/e2e/specs/customer_reader.go
@@ -24,13 +24,9 @@ var _ = Describe("Openshift on Azure customer-reader e2e tests [CustomerAdmin]",
 	BeforeEach(func() {
 		var err error
 		cli, err = openshift.NewEndUserClient()
-		if err != nil {
-			Skip(err.Error())
-		}
+		Expect(err).ToNot(HaveOccurred())
 		readercli, err = openshift.NewCustomerReaderClient()
-		if err != nil {
-			Skip(err.Error())
-		}
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	It("should not read nodes", func() {

--- a/test/e2e/specs/end_user.go
+++ b/test/e2e/specs/end_user.go
@@ -35,9 +35,7 @@ var _ = Describe("Openshift on Azure end user e2e tests [EndUser]", func() {
 	BeforeEach(func() {
 		var err error
 		cli, err = openshift.NewEndUserClient()
-		if err != nil {
-			Skip(err.Error())
-		}
+		Expect(err).ToNot(HaveOccurred())
 
 		namespace, err = randomstring.RandomString("abcdefghijklmnopqrstuvwxyz0123456789", 5)
 		Expect(err).ToNot(HaveOccurred())

--- a/test/e2e/specs/fakerp/admin.go
+++ b/test/e2e/specs/fakerp/admin.go
@@ -24,9 +24,7 @@ var _ = Describe("Openshift on Azure admin e2e tests [AzureClusterReader]", func
 	BeforeEach(func() {
 		var err error
 		cli, err = openshift.NewAzureClusterReaderClient()
-		if err != nil {
-			Skip(err.Error())
-		}
+		Expect(err).ToNot(HaveOccurred())
 	})
 
 	It("should label nodes correctly", func() {

--- a/test/e2e/specs/realrp/realrp.go
+++ b/test/e2e/specs/realrp/realrp.go
@@ -2,6 +2,7 @@ package realrp
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"os"
 
@@ -27,11 +28,9 @@ var _ = Describe("Resource provider e2e tests [Real]", func() {
 	BeforeEach(func() {
 		var err error
 		cli, err = azure.NewClientFromEnvironment()
-		if err != nil {
-			Skip(err.Error())
-		}
+		Expect(err).ToNot(HaveOccurred())
 		if os.Getenv("AZURE_REGION") == "" || os.Getenv("RESOURCEGROUP") == "" {
-			Skip("AZURE_REGION and/or RESOURCEGROUP not set")
+			Expect(errors.New("AZURE_REGION and/or RESOURCEGROUP not set")).ToNot(HaveOccurred())
 		}
 	})
 


### PR DESCRIPTION
Otherwise we risk allowing failed tests to succeed in CI eg. https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/openshift_openshift-azure/794/pull-ci-openshift-openshift-azure-master-e2e-azure-keyrotation/1 failed with 
```
S [SKIPPING] in Spec Setup (BeforeEach) [0.001 seconds]
Key Rotation E2E tests [KeyRotation] [Update]
/go/src/github.com/openshift/openshift-azure/test/e2e/specs/updates/keyrotation/keyrotation.go:23
  should be possible to maintain a healthy cluster after rotating all credentials [BeforeEach]
  /go/src/github.com/openshift/openshift-azure/test/e2e/specs/updates/keyrotation/keyrotation.go:40

  failed to get oauth token from client credentials: parameter 'clientID' cannot be empty

  /go/src/github.com/openshift/openshift-azure/test/e2e/specs/updates/keyrotation/keyrotation.go:36
---------------------------
```
/cc @jim-minter @charlesakalugwu 