### PR TITLE
Enable partial requests to update clusters

### DIFF
--- a/pkg/api/2018-09-30-preview/api/client.go
+++ b/pkg/api/2018-09-30-preview/api/client.go
@@ -114,15 +114,7 @@ func NewOpenShiftManagedClustersClientWithBaseURI(baseURI string, subscriptionID
 func (client OpenShiftManagedClustersClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, resourceName string, parameters OpenShiftManagedCluster) (result OpenShiftManagedClustersCreateOrUpdateFuture, err error) {
 	if err := validation.Validate([]validation.Validation{
 		{TargetValue: parameters,
-			Constraints: []validation.Constraint{{Target: "parameters.Properties", Name: validation.Null, Rule: false,
-				Chain: []validation.Constraint{{Target: "parameters.Properties.OpenShiftVersion", Name: validation.Null, Rule: true, Chain: nil},
-					{Target: "parameters.Properties.MasterPoolProfile", Name: validation.Null, Rule: false,
-						Chain: []validation.Constraint{{Target: "parameters.Properties.MasterPoolProfile.Count", Name: validation.Null, Rule: true,
-							Chain: []validation.Constraint{{Target: "parameters.Properties.MasterPoolProfile.Count", Name: validation.InclusiveMaximum, Rule: int64(10), Chain: nil},
-								{Target: "parameters.Properties.MasterPoolProfile.Count", Name: validation.InclusiveMinimum, Rule: 1, Chain: nil},
-							}},
-						}},
-				}}}}}); err != nil {
+			Constraints: []validation.Constraint{{Target: "parameters.Properties", Name: validation.Null, Rule: false}}}}); err != nil {
 		return result, validation.NewError("containerservice.OpenShiftManagedClustersClient", "CreateOrUpdate", err.Error())
 	}
 

--- a/test/manifests/normal/scaleup.yaml
+++ b/test/manifests/normal/scaleup.yaml
@@ -1,0 +1,4 @@
+properties:
+  agentPoolProfiles:
+  - name: compute
+    count: 2


### PR DESCRIPTION
Managed to scale up a cluster with the following partial request. @charlesakalugwu we should probably reuse it since that's how scale up requests are going to look like when they land in the prod RP.

/cc jim-minter charlesakalugwu 