### PR TITLE
Catch, retry, and log the x509 exception.  Small refactor.

### DIFF
--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -36,9 +36,10 @@ var (
 type sync struct {
 	azs  azureclient.AccountsClient
 	blob azureclientstorage.Blob
+	log  *logrus.Entry
 }
 
-func (s *sync) init(ctx context.Context) error {
+func (s *sync) init(ctx context.Context, entry *logrus.Entry) error {
 	cpc, err := cloudprovider.Load("_data/_out/azure.conf")
 	if err != nil {
 		return err
@@ -58,11 +59,13 @@ func (s *sync) init(ctx context.Context) error {
 
 	s.blob = bsc.GetContainerReference(cluster.ConfigContainerName).GetBlobReference(cluster.ConfigBlobName)
 
+	s.log = entry
+
 	return nil
 }
 
 func (s *sync) getBlob() (*api.OpenShiftManagedCluster, error) {
-	logrus.Print("reading config blob")
+	s.log.Print("reading config blob")
 
 	var rc io.ReadCloser
 	var err error
@@ -79,7 +82,7 @@ func (s *sync) getBlob() (*api.OpenShiftManagedCluster, error) {
 		return nil, err
 	}
 	defer rc.Close()
-	logrus.Print("read config blob")
+	s.log.Print("read config blob")
 
 	b, err := ioutil.ReadAll(rc)
 	if err != nil {
@@ -97,8 +100,8 @@ func (s *sync) getBlob() (*api.OpenShiftManagedCluster, error) {
 // desired state that is kept in a blob in an Azure storage
 // account. It returns whether it managed to access the
 // config blob or not and any error that occured.
-func (s *sync) sync(ctx context.Context) (bool, error) {
-	logrus.Print("Sync process started")
+func (s *sync) sync(ctx context.Context, log *logrus.Entry) (bool, error) {
+	s.log.Print("Sync process started")
 	cs, err := s.getBlob()
 	if err != nil {
 		return false, err
@@ -109,36 +112,39 @@ func (s *sync) sync(ctx context.Context) (bool, error) {
 		return true, errors.Wrap(kerrors.NewAggregate(errs), "cannot validate _data/manifest.yaml")
 	}
 
-	if err := addons.Main(ctx, cs, s.azs, *dryRun); err != nil {
+	if err := addons.Main(ctx, cs, s.azs, s.log, *dryRun); err != nil {
 		return true, errors.Wrap(err, "cannot sync cluster config")
 	}
 
-	logrus.Print("Sync process complete")
+	s.log.Print("Sync process complete")
 	return true, nil
 }
 
 func main() {
 	flag.Parse()
-	logrus.SetLevel(log.SanitizeLogLevel(*logLevel))
-	logrus.SetFormatter(&logrus.TextFormatter{FullTimestamp: true})
-	logrus.Printf("sync pod starting, git commit %s", gitCommit)
+	// log := logrus.New()
+	logger := logrus.New()
+	logger.Formatter = &logrus.TextFormatter{FullTimestamp: true}
+	logger.SetLevel(log.SanitizeLogLevel(*logLevel))
+	log := logrus.NewEntry(logger)
+	log.Printf("sync pod starting, git commit %s", gitCommit)
 
 	s := new(sync)
 	ctx := context.Background()
 
-	if err := s.init(ctx); err != nil {
-		logrus.Fatalf("Cannot initialize sync: %v", err)
+	if err := s.init(ctx, log); err != nil {
+		log.Fatalf("Cannot initialize sync: %v", err)
 	}
 
 	for {
-		gotBlob, err := s.sync(ctx)
+		gotBlob, err := s.sync(ctx, log)
 		if !gotBlob {
 			// If we didn't manage to access the blob, error out and start
 			// again.
-			logrus.Fatalf("Error while accessing config blob: %v", err)
+			log.Fatalf("Error while accessing config blob: %v", err)
 		}
 		if err != nil {
-			logrus.Printf("Error while syncing: %v", err)
+			log.Printf("Error while syncing: %v", err)
 		}
 		if *once {
 			return

--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -39,7 +39,7 @@ type sync struct {
 	log  *logrus.Entry
 }
 
-func (s *sync) init(ctx context.Context, entry *logrus.Entry) error {
+func (s *sync) init(ctx context.Context, log *logrus.Entry) error {
 	cpc, err := cloudprovider.Load("_data/_out/azure.conf")
 	if err != nil {
 		return err
@@ -59,7 +59,7 @@ func (s *sync) init(ctx context.Context, entry *logrus.Entry) error {
 
 	s.blob = bsc.GetContainerReference(cluster.ConfigContainerName).GetBlobReference(cluster.ConfigBlobName)
 
-	s.log = entry
+	s.log = log
 
 	return nil
 }
@@ -112,7 +112,7 @@ func (s *sync) sync(ctx context.Context, log *logrus.Entry) (bool, error) {
 		return true, errors.Wrap(kerrors.NewAggregate(errs), "cannot validate _data/manifest.yaml")
 	}
 
-	if err := addons.Main(ctx, cs, s.azs, s.log, *dryRun); err != nil {
+	if err := addons.Main(ctx, s.log, cs, s.azs, *dryRun); err != nil {
 		return true, errors.Wrap(err, "cannot sync cluster config")
 	}
 
@@ -122,7 +122,6 @@ func (s *sync) sync(ctx context.Context, log *logrus.Entry) (bool, error) {
 
 func main() {
 	flag.Parse()
-	// log := logrus.New()
 	logger := logrus.New()
 	logger.Formatter = &logrus.TextFormatter{FullTimestamp: true}
 	logger.SetLevel(log.SanitizeLogLevel(*logLevel))

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -13,7 +13,7 @@ import (
 	"time"
 
 	"github.com/ghodss/yaml"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/apimachinery/pkg/util/wait"
@@ -189,7 +189,7 @@ var (
 // writeDB uses the discovery and dynamic clients to synchronise an API server's
 // objects with db.
 // TODO: need to implement deleting objects which we don't want any more.
-func writeDB(client Interface, db map[string]unstructured.Unstructured) error {
+func writeDB(client Interface, db map[string]unstructured.Unstructured, log *logrus.Entry) error {
 	// impose an order to improve debuggability.
 	var keys []string
 	for k := range db {
@@ -245,8 +245,8 @@ func writeDB(client Interface, db map[string]unstructured.Unstructured) error {
 	return client.ApplyResources(scFilter, db, keys)
 }
 
-func Main(ctx context.Context, cs *api.OpenShiftManagedCluster, azs azureclient.AccountsClient, dryRun bool) error {
-	client, err := newClient(ctx, cs, azs, dryRun)
+func Main(ctx context.Context, cs *api.OpenShiftManagedCluster, azs azureclient.AccountsClient, log *logrus.Entry, dryRun bool) error {
+	client, err := newClient(ctx, cs, azs, log, dryRun)
 	if err != nil {
 		return err
 	}
@@ -291,5 +291,5 @@ func Main(ctx context.Context, cs *api.OpenShiftManagedCluster, azs azureclient.
 		return nil
 	}
 
-	return writeDB(client, db)
+	return writeDB(client, db, log)
 }

--- a/pkg/addons/addons.go
+++ b/pkg/addons/addons.go
@@ -245,8 +245,8 @@ func writeDB(client Interface, db map[string]unstructured.Unstructured, log *log
 	return client.ApplyResources(scFilter, db, keys)
 }
 
-func Main(ctx context.Context, cs *api.OpenShiftManagedCluster, azs azureclient.AccountsClient, log *logrus.Entry, dryRun bool) error {
-	client, err := newClient(ctx, cs, azs, log, dryRun)
+func Main(ctx context.Context, log *logrus.Entry, cs *api.OpenShiftManagedCluster, azs azureclient.AccountsClient, dryRun bool) error {
+	client, err := newClient(ctx, log, cs, azs, dryRun)
 	if err != nil {
 		return err
 	}

--- a/pkg/addons/client.go
+++ b/pkg/addons/client.go
@@ -51,7 +51,7 @@ type client struct {
 	log        *logrus.Entry
 }
 
-func newClient(ctx context.Context, cs *acsapi.OpenShiftManagedCluster, azs azureclient.AccountsClient, log *logrus.Entry, dryRun bool) (Interface, error) {
+func newClient(ctx context.Context, log *logrus.Entry, cs *acsapi.OpenShiftManagedCluster, azs azureclient.AccountsClient, dryRun bool) (Interface, error) {
 	if dryRun {
 		return &dryClient{}, nil
 	}
@@ -90,7 +90,7 @@ func newClient(ctx context.Context, cs *acsapi.OpenShiftManagedCluster, azs azur
 	if err != nil {
 		return nil, err
 	}
-	if _, err := wait.ForHTTPStatusOk(ctx, transport, c.restconfig.Host+"/healthz", log); err != nil {
+	if _, err := wait.ForHTTPStatusOk(ctx, log, transport, c.restconfig.Host+"/healthz"); err != nil {
 		return nil, err
 	}
 

--- a/pkg/addons/client.go
+++ b/pkg/addons/client.go
@@ -7,7 +7,7 @@ import (
 	"strings"
 
 	"github.com/go-test/deep"
-	log "github.com/sirupsen/logrus"
+	"github.com/sirupsen/logrus"
 	kapiextensions "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	kerrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/api/meta"
@@ -50,9 +50,10 @@ type client struct {
 	dyn        dynamic.ClientPool
 	grs        []*discovery.APIGroupResources
 	azs        azureclient.AccountsClient
+	log        *logrus.Entry
 }
 
-func newClient(ctx context.Context, cs *acsapi.OpenShiftManagedCluster, azs azureclient.AccountsClient, dryRun bool) (Interface, error) {
+func newClient(ctx context.Context, cs *acsapi.OpenShiftManagedCluster, azs azureclient.AccountsClient, log *logrus.Entry, dryRun bool) (Interface, error) {
 	if dryRun {
 		return &dryClient{}, nil
 	}
@@ -92,6 +93,7 @@ func newClient(ctx context.Context, cs *acsapi.OpenShiftManagedCluster, azs azur
 		ae:         ae,
 		cli:        cli,
 		azs:        azs,
+		log:        log,
 	}
 
 	transport, err := rest.TransportFor(c.restconfig)
@@ -99,7 +101,7 @@ func newClient(ctx context.Context, cs *acsapi.OpenShiftManagedCluster, azs azur
 		return nil, err
 	}
 
-	if _, err := wait.ForHTTPStatusOk(ctx, transport, c.restconfig.Host+"/healthz"); err != nil {
+	if _, err := wait.ForHTTPStatusOk(ctx, transport, c.restconfig.Host+"/healthz", log); err != nil {
 		return nil, err
 	}
 
@@ -144,7 +146,7 @@ func (c *client) ApplyResources(filter func(unstructured.Unstructured) bool, db 
 			continue
 		}
 
-		if err := write(c.dyn, c.grs, &o); err != nil {
+		if err := write(c.dyn, c.grs, &o, c.log); err != nil {
 			return err
 		}
 	}
@@ -152,7 +154,7 @@ func (c *client) ApplyResources(filter func(unstructured.Unstructured) bool, db 
 }
 
 // write synchronises a single object with the API server.
-func write(dyn dynamic.ClientPool, grs []*discovery.APIGroupResources, o *unstructured.Unstructured) error {
+func write(dyn dynamic.ClientPool, grs []*discovery.APIGroupResources, o *unstructured.Unstructured, log *logrus.Entry) error {
 	dc, err := dyn.ClientForGroupVersionKind(o.GroupVersionKind())
 	if err != nil {
 		return err
@@ -189,7 +191,7 @@ func write(dyn dynamic.ClientPool, grs []*discovery.APIGroupResources, o *unstru
 		var existing *unstructured.Unstructured
 		existing, err = dc.Resource(res, o.GetNamespace()).Get(o.GetName(), metav1.GetOptions{})
 		if kerrors.IsNotFound(err) {
-			log.Infof("Create " + KeyFunc(o.GroupVersionKind().GroupKind(), o.GetNamespace(), o.GetName()))
+			log.Info("Create " + KeyFunc(o.GroupVersionKind().GroupKind(), o.GetNamespace(), o.GetName()))
 			_, err = dc.Resource(res, o.GetNamespace()).Create(o)
 			if kerrors.IsAlreadyExists(err) {
 				// The "hot path" in write() is Get, check, then maybe Update.
@@ -214,10 +216,10 @@ func write(dyn dynamic.ClientPool, grs []*discovery.APIGroupResources, o *unstru
 		}
 		Default(*existing)
 
-		if !needsUpdate(existing, o) {
+		if !needsUpdate(existing, o, log) {
 			return
 		}
-		printDiff(existing, o)
+		printDiff(existing, o, log)
 
 		o.SetResourceVersion(rv)
 		_, err = dc.Resource(res, o.GetNamespace()).Update(o)
@@ -227,20 +229,20 @@ func write(dyn dynamic.ClientPool, grs []*discovery.APIGroupResources, o *unstru
 	return err
 }
 
-func needsUpdate(existing, o *unstructured.Unstructured) bool {
+func needsUpdate(existing, o *unstructured.Unstructured, log *logrus.Entry) bool {
 	handleSpecialObjects(*existing, *o)
 
 	if reflect.DeepEqual(*existing, *o) {
-		log.Infof("Skip " + KeyFunc(o.GroupVersionKind().GroupKind(), o.GetNamespace(), o.GetName()))
+		log.Info("Skip " + KeyFunc(o.GroupVersionKind().GroupKind(), o.GetNamespace(), o.GetName()))
 		return false
 	}
 
-	log.Infof("Update " + KeyFunc(o.GroupVersionKind().GroupKind(), o.GetNamespace(), o.GetName()))
+	log.Info("Update " + KeyFunc(o.GroupVersionKind().GroupKind(), o.GetNamespace(), o.GetName()))
 
 	return true
 }
 
-func printDiff(existing, o *unstructured.Unstructured) bool {
+func printDiff(existing, o *unstructured.Unstructured, log *logrus.Entry) bool {
 	// TODO: we should have tests that monitor these diffs:
 	// 1) when a cluster is created
 	// 2) when sync is run twice back-to-back on the same cluster
@@ -250,7 +252,7 @@ func printDiff(existing, o *unstructured.Unstructured) bool {
 	diffShown := false
 	if strings.ToLower(oGroupKind.String()) != "secret" {
 		for _, diff := range deep.Equal(*existing, *o) {
-			log.Infof("- " + diff)
+			log.Info("- " + diff)
 			diffShown = true
 		}
 	}

--- a/pkg/addons/client_test.go
+++ b/pkg/addons/client_test.go
@@ -36,12 +36,16 @@ var clientTests = []struct {
 		diff:     false, // no diff expected
 	},
 }
-var logger = logrus.New()
-var entry = logrus.NewEntry(logger)
+var log *logrus.Entry
+
+func init() {
+	logger := logrus.New()
+	log = logrus.NewEntry(logger)
+}
 
 func TestNeedsUpdate(t *testing.T) {
 	for _, test := range clientTests {
-		if got := needsUpdate(test.existing, test.updated, entry); got != test.exp {
+		if got := needsUpdate(test.existing, test.updated, log); got != test.exp {
 			t.Errorf("%s: expected update %t, got %t", test.name, test.exp, got)
 		}
 	}
@@ -49,7 +53,7 @@ func TestNeedsUpdate(t *testing.T) {
 
 func TestShouldPrintDiff(t *testing.T) {
 	for _, test := range clientTests {
-		if got := printDiff(test.existing, test.updated, entry); got != test.diff {
+		if got := printDiff(test.existing, test.updated, log); got != test.diff {
 			t.Errorf("%s: expected to print diff %t, got %t", test.name, test.diff, got)
 		}
 	}

--- a/pkg/addons/client_test.go
+++ b/pkg/addons/client_test.go
@@ -3,6 +3,7 @@ package addons
 import (
 	"testing"
 
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 )
 
@@ -35,10 +36,12 @@ var clientTests = []struct {
 		diff:     false, // no diff expected
 	},
 }
+var logger = logrus.New()
+var entry = logrus.NewEntry(logger)
 
 func TestNeedsUpdate(t *testing.T) {
 	for _, test := range clientTests {
-		if got := needsUpdate(test.existing, test.updated); got != test.exp {
+		if got := needsUpdate(test.existing, test.updated, entry); got != test.exp {
 			t.Errorf("%s: expected update %t, got %t", test.name, test.exp, got)
 		}
 	}
@@ -46,7 +49,7 @@ func TestNeedsUpdate(t *testing.T) {
 
 func TestShouldPrintDiff(t *testing.T) {
 	for _, test := range clientTests {
-		if got := printDiff(test.existing, test.updated); got != test.diff {
+		if got := printDiff(test.existing, test.updated, entry); got != test.diff {
 			t.Errorf("%s: expected to print diff %t, got %t", test.name, test.diff, got)
 		}
 	}

--- a/pkg/cluster/deploy.go
+++ b/pkg/cluster/deploy.go
@@ -57,7 +57,7 @@ func (u *simpleUpgrader) Deploy(ctx context.Context, cs *api.OpenShiftManagedClu
 	if err != nil {
 		return &api.PluginError{Err: err, Step: api.PluginStepInitializeUpdateBlob}
 	}
-	err = managedcluster.WaitForHealthz(ctx, cs.Config.AdminKubeconfig, u.log)
+	err = managedcluster.WaitForHealthz(ctx, cs, u.log)
 	if err != nil {
 		return &api.PluginError{Err: err, Step: api.PluginStepWaitForWaitForOpenShiftAPI}
 	}

--- a/pkg/cluster/deploy.go
+++ b/pkg/cluster/deploy.go
@@ -57,7 +57,7 @@ func (u *simpleUpgrader) Deploy(ctx context.Context, cs *api.OpenShiftManagedClu
 	if err != nil {
 		return &api.PluginError{Err: err, Step: api.PluginStepInitializeUpdateBlob}
 	}
-	err = managedcluster.WaitForHealthz(ctx, cs, u.log)
+	err = managedcluster.WaitForHealthz(ctx, u.log, cs)
 	if err != nil {
 		return &api.PluginError{Err: err, Step: api.PluginStepWaitForWaitForOpenShiftAPI}
 	}

--- a/pkg/cluster/deploy.go
+++ b/pkg/cluster/deploy.go
@@ -57,7 +57,7 @@ func (u *simpleUpgrader) Deploy(ctx context.Context, cs *api.OpenShiftManagedClu
 	if err != nil {
 		return &api.PluginError{Err: err, Step: api.PluginStepInitializeUpdateBlob}
 	}
-	err = managedcluster.WaitForHealthz(ctx, cs.Config.AdminKubeconfig)
+	err = managedcluster.WaitForHealthz(ctx, cs.Config.AdminKubeconfig, u.log)
 	if err != nil {
 		return &api.PluginError{Err: err, Step: api.PluginStepWaitForWaitForOpenShiftAPI}
 	}

--- a/pkg/cluster/types.go
+++ b/pkg/cluster/types.go
@@ -66,7 +66,10 @@ func (u *simpleUpgrader) CreateClients(ctx context.Context, cs *api.OpenShiftMan
 	u.accountsClient = azureclient.NewAccountsClient(cs.Properties.AzProfile.SubscriptionID, authorizer, u.pluginConfig.AcceptLanguages)
 	u.vmc = azureclient.NewVirtualMachineScaleSetVMsClient(cs.Properties.AzProfile.SubscriptionID, authorizer, u.pluginConfig.AcceptLanguages)
 	u.ssc = azureclient.NewVirtualMachineScaleSetsClient(cs.Properties.AzProfile.SubscriptionID, authorizer, u.pluginConfig.AcceptLanguages)
-
-	u.kubeclient, err = managedcluster.ClientsetFromV1Config(cs.Config.AdminKubeconfig)
+	restconfig, err := managedcluster.RestConfigFromV1Config(cs.Config.AdminKubeconfig)
+	if err != nil {
+		return err
+	}
+	u.kubeclient, err = kubernetes.NewForConfig(restconfig)
 	return err
 }

--- a/pkg/cluster/update.go
+++ b/pkg/cluster/update.go
@@ -32,7 +32,7 @@ func (u *simpleUpgrader) Update(ctx context.Context, cs *api.OpenShiftManagedClu
 	if err != nil {
 		return &api.PluginError{Err: err, Step: api.PluginStepHashScaleSets}
 	}
-	err = managedcluster.WaitForHealthz(ctx, cs.Config.AdminKubeconfig, u.log)
+	err = managedcluster.WaitForHealthz(ctx, cs, u.log)
 	if err != nil {
 		return &api.PluginError{Err: err, Step: api.PluginStepWaitForWaitForOpenShiftAPI}
 	}

--- a/pkg/cluster/update.go
+++ b/pkg/cluster/update.go
@@ -32,7 +32,7 @@ func (u *simpleUpgrader) Update(ctx context.Context, cs *api.OpenShiftManagedClu
 	if err != nil {
 		return &api.PluginError{Err: err, Step: api.PluginStepHashScaleSets}
 	}
-	err = managedcluster.WaitForHealthz(ctx, cs, u.log)
+	err = managedcluster.WaitForHealthz(ctx, u.log, cs)
 	if err != nil {
 		return &api.PluginError{Err: err, Step: api.PluginStepWaitForWaitForOpenShiftAPI}
 	}

--- a/pkg/cluster/update.go
+++ b/pkg/cluster/update.go
@@ -32,7 +32,7 @@ func (u *simpleUpgrader) Update(ctx context.Context, cs *api.OpenShiftManagedClu
 	if err != nil {
 		return &api.PluginError{Err: err, Step: api.PluginStepHashScaleSets}
 	}
-	err = managedcluster.WaitForHealthz(ctx, cs.Config.AdminKubeconfig)
+	err = managedcluster.WaitForHealthz(ctx, cs.Config.AdminKubeconfig, u.log)
 	if err != nil {
 		return &api.PluginError{Err: err, Step: api.PluginStepWaitForWaitForOpenShiftAPI}
 	}

--- a/pkg/util/managedcluster/managedcluster.go
+++ b/pkg/util/managedcluster/managedcluster.go
@@ -5,6 +5,7 @@ import (
 	"io/ioutil"
 
 	"github.com/ghodss/yaml"
+	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
 	"k8s.io/client-go/tools/clientcmd"
@@ -55,7 +56,7 @@ func ClientsetFromV1Config(config *v1.Config) (*kubernetes.Clientset, error) {
 
 // WaitForHealthz takes a context, v1 config.
 // It waits for the cluster to respond to healthz requests.
-func WaitForHealthz(ctx context.Context, config *v1.Config) error {
+func WaitForHealthz(ctx context.Context, config *v1.Config, log *logrus.Entry) error {
 	restconfig, err := getRestConfigFromV1Config(config)
 	if err != nil {
 		return err
@@ -67,6 +68,6 @@ func WaitForHealthz(ctx context.Context, config *v1.Config) error {
 	}
 
 	// Wait for the healthz to be 200 status
-	_, err = wait.ForHTTPStatusOk(ctx, t, restconfig.Host+"/healthz")
+	_, err = wait.ForHTTPStatusOk(ctx, t, restconfig.Host+"/healthz", log)
 	return err
 }

--- a/pkg/util/wait/wait.go
+++ b/pkg/util/wait/wait.go
@@ -8,6 +8,7 @@ package wait
 
 import (
 	"context"
+	"crypto/x509"
 	"io"
 	"net"
 	"net/http"
@@ -16,6 +17,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/wait"
 )
 
@@ -37,15 +39,15 @@ type SimpleHTTPClient interface {
 }
 
 // ForHTTPStatusOk poll until URL returns 200
-func ForHTTPStatusOk(ctx context.Context, transport http.RoundTripper, urltocheck string) (*http.Response, error) {
+func ForHTTPStatusOk(ctx context.Context, transport http.RoundTripper, urltocheck string, log *logrus.Entry) (*http.Response, error) {
 	cli := &http.Client{
 		Transport: transport,
 		Timeout:   10 * time.Second,
 	}
-	return forHTTPStatusOk(ctx, cli, urltocheck, time.Second)
+	return forHTTPStatusOk(ctx, cli, urltocheck, time.Second, log)
 }
 
-func forHTTPStatusOk(ctx context.Context, cli SimpleHTTPClient, urltocheck string, interval time.Duration) (*http.Response, error) {
+func forHTTPStatusOk(ctx context.Context, cli SimpleHTTPClient, urltocheck string, interval time.Duration, log *logrus.Entry) (*http.Response, error) {
 	req, err := http.NewRequest("GET", urltocheck, nil)
 	if err != nil {
 		return nil, err
@@ -61,6 +63,10 @@ func forHTTPStatusOk(ctx context.Context, cli SimpleHTTPClient, urltocheck strin
 						return false, nil
 					}
 				}
+			}
+			if _, ok := err.Err.(x509.UnknownAuthorityError); ok {
+				log.Info(err)
+				return false, nil
 			}
 			if err.Timeout() || err.Err == io.EOF || err.Err == io.ErrUnexpectedEOF {
 				return false, nil

--- a/pkg/util/wait/wait.go
+++ b/pkg/util/wait/wait.go
@@ -39,15 +39,15 @@ type SimpleHTTPClient interface {
 }
 
 // ForHTTPStatusOk poll until URL returns 200
-func ForHTTPStatusOk(ctx context.Context, transport http.RoundTripper, urltocheck string, log *logrus.Entry) (*http.Response, error) {
+func ForHTTPStatusOk(ctx context.Context, log *logrus.Entry, transport http.RoundTripper, urltocheck string) (*http.Response, error) {
 	cli := &http.Client{
 		Transport: transport,
 		Timeout:   10 * time.Second,
 	}
-	return forHTTPStatusOk(ctx, cli, urltocheck, time.Second, log)
+	return forHTTPStatusOk(ctx, log, cli, urltocheck, time.Second)
 }
 
-func forHTTPStatusOk(ctx context.Context, cli SimpleHTTPClient, urltocheck string, interval time.Duration, log *logrus.Entry) (*http.Response, error) {
+func forHTTPStatusOk(ctx context.Context, log *logrus.Entry, cli SimpleHTTPClient, urltocheck string, interval time.Duration) (*http.Response, error) {
 	req, err := http.NewRequest("GET", urltocheck, nil)
 	if err != nil {
 		return nil, err

--- a/pkg/util/wait/wait_test.go
+++ b/pkg/util/wait/wait_test.go
@@ -12,16 +12,16 @@ import (
 	"testing"
 	"time"
 
-	"github.com/sirupsen/logrus"
-
 	"github.com/golang/mock/gomock"
+	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/openshift-azure/pkg/util/mocks/mock_wait"
 )
 
 func TestForHTTPStatusOk(t *testing.T) {
 	urltocheck := "http://localhost:12345/nowhere"
-	log := &logrus.Entry{}
+	logger := logrus.New()
+	log := logrus.NewEntry(logger)
 
 	type cliResp struct {
 		err  error
@@ -109,7 +109,7 @@ func TestForHTTPStatusOk(t *testing.T) {
 			mockCli.EXPECT().Do(req).Return(resp.resp, resp.err)
 		}
 
-		_, err := forHTTPStatusOk(context.Background(), mockCli, urltocheck, time.Nanosecond, log)
+		_, err := forHTTPStatusOk(context.Background(), log, mockCli, urltocheck, time.Nanosecond)
 		if tt.wantErr != (err != nil) || tt.wantErr && tt.err.Error() != err.Error() {
 			t.Errorf("forHTTPStatusOk(%s) error = %v, Err %v", tt.name, err, tt.err)
 		}

--- a/pkg/util/wait/wait_test.go
+++ b/pkg/util/wait/wait_test.go
@@ -12,6 +12,8 @@ import (
 	"testing"
 	"time"
 
+	"github.com/sirupsen/logrus"
+
 	"github.com/golang/mock/gomock"
 
 	"github.com/openshift/openshift-azure/pkg/util/mocks/mock_wait"
@@ -19,6 +21,7 @@ import (
 
 func TestForHTTPStatusOk(t *testing.T) {
 	urltocheck := "http://localhost:12345/nowhere"
+	log := &logrus.Entry{}
 
 	type cliResp struct {
 		err  error
@@ -106,7 +109,7 @@ func TestForHTTPStatusOk(t *testing.T) {
 			mockCli.EXPECT().Do(req).Return(resp.resp, resp.err)
 		}
 
-		_, err := forHTTPStatusOk(context.Background(), mockCli, urltocheck, time.Nanosecond)
+		_, err := forHTTPStatusOk(context.Background(), mockCli, urltocheck, time.Nanosecond, log)
 		if tt.wantErr != (err != nil) || tt.wantErr && tt.err.Error() != err.Error() {
 			t.Errorf("forHTTPStatusOk(%s) error = %v, Err %v", tt.name, err, tt.err)
 		}

--- a/test/e2e/specs/end_user.go
+++ b/test/e2e/specs/end_user.go
@@ -10,6 +10,7 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
+	"github.com/sirupsen/logrus"
 
 	"k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1beta1"
@@ -29,6 +30,7 @@ var _ = Describe("Openshift on Azure end user e2e tests [EndUser]", func() {
 	var (
 		cli       *openshift.Client
 		namespace string
+		log       *logrus.Entry = &logrus.Entry{}
 	)
 
 	BeforeEach(func() {
@@ -89,7 +91,7 @@ var _ = Describe("Openshift on Azure end user e2e tests [EndUser]", func() {
 		By(fmt.Sprintf("hitting the route and checking the contents (%v)", time.Now()))
 		timeout, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
-		resp, err := waitutil.ForHTTPStatusOk(timeout, nil, url)
+		resp, err := waitutil.ForHTTPStatusOk(timeout, nil, url, log)
 		Expect(err).NotTo(HaveOccurred())
 		defer resp.Body.Close()
 		contents, err := ioutil.ReadAll(resp.Body)
@@ -151,7 +153,7 @@ var _ = Describe("Openshift on Azure end user e2e tests [EndUser]", func() {
 			defer cancel()
 
 			for i := 0; i < times; i++ {
-				resp, err := waitutil.ForHTTPStatusOk(timeout, nil, url)
+				resp, err := waitutil.ForHTTPStatusOk(timeout, nil, url, log)
 				if err != nil {
 					return err
 				}

--- a/test/e2e/specs/end_user.go
+++ b/test/e2e/specs/end_user.go
@@ -10,8 +10,8 @@ import (
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
-	"github.com/sirupsen/logrus"
 
+	"github.com/sirupsen/logrus"
 	"k8s.io/api/core/v1"
 	policy "k8s.io/api/policy/v1beta1"
 	rbacv1 "k8s.io/api/rbac/v1"
@@ -30,7 +30,8 @@ var _ = Describe("Openshift on Azure end user e2e tests [EndUser]", func() {
 	var (
 		cli       *openshift.Client
 		namespace string
-		log       *logrus.Entry = &logrus.Entry{}
+		logger    *logrus.Logger = logrus.New()
+		log       *logrus.Entry  = logrus.NewEntry(logger)
 	)
 
 	BeforeEach(func() {
@@ -91,7 +92,7 @@ var _ = Describe("Openshift on Azure end user e2e tests [EndUser]", func() {
 		By(fmt.Sprintf("hitting the route and checking the contents (%v)", time.Now()))
 		timeout, cancel := context.WithTimeout(context.Background(), 30*time.Second)
 		defer cancel()
-		resp, err := waitutil.ForHTTPStatusOk(timeout, nil, url, log)
+		resp, err := waitutil.ForHTTPStatusOk(timeout, log, nil, url)
 		Expect(err).NotTo(HaveOccurred())
 		defer resp.Body.Close()
 		contents, err := ioutil.ReadAll(resp.Body)
@@ -153,7 +154,7 @@ var _ = Describe("Openshift on Azure end user e2e tests [EndUser]", func() {
 			defer cancel()
 
 			for i := 0; i < times; i++ {
-				resp, err := waitutil.ForHTTPStatusOk(timeout, nil, url, log)
+				resp, err := waitutil.ForHTTPStatusOk(timeout, log, nil, url)
 				if err != nil {
 					return err
 				}


### PR DESCRIPTION
Attempt at catching and handling the x509 error returned by the healthz check for a cluster.

Fixes https://github.com/openshift/openshift-azure/issues/527

- [x] Adds logging to the httpstatus check.  This entails passing a logger which gets a little messy.
- [x] Clean up waitforhealthz to remove kubeconfig
- [x] Share the restconfig parts and remove the unused clientsetFromv1Config