### PR TITLE
Make sure enduser can't delete any azure resources

### DIFF
--- a/pkg/util/azureclient/resources.go
+++ b/pkg/util/azureclient/resources.go
@@ -38,3 +38,26 @@ func (c *deploymentsClient) Client() autorest.Client {
 func (c *deploymentsClient) DeploymentClient() resources.DeploymentsClient {
 	return c.DeploymentsClient
 }
+
+// ResourcesClient is a minimal interface for azure Resources Client
+type ResourcesClient interface {
+	DeleteByID(ctx context.Context, resourceID string) (result resources.DeleteByIDFuture, err error)
+	ListByResourceGroup(ctx context.Context, resourceGroupName string, filter string, expand string, top *int32) (result resources.ListResultPage, err error)
+}
+
+type resourcesClient struct {
+	resources.Client
+}
+
+var _ ResourcesClient = &resourcesClient{}
+
+// NewResourcesClient creates a new ResourcesClient
+func NewResourcesClient(subscriptionID string, authorizer autorest.Authorizer, languages []string) ResourcesClient {
+	client := resources.NewClient(subscriptionID)
+	client.Authorizer = authorizer
+	client.RequestInspector = addAcceptLanguages(languages)
+
+	return &resourcesClient{
+		Client: client,
+	}
+}

--- a/test/clients/azure/client.go
+++ b/test/clients/azure/client.go
@@ -20,6 +20,7 @@ var (
 	realRpFocus  = regexp.MustCompile("Real")
 )
 
+// Client is the main controller for azure client objects
 type Client struct {
 	Accounts                         azureclient.AccountsClient
 	Applications                     azureclient.ApplicationsClient
@@ -28,8 +29,10 @@ type Client struct {
 	VirtualMachineScaleSets          azureclient.VirtualMachineScaleSetsClient
 	VirtualMachineScaleSetExtensions azureclient.VirtualMachineScaleSetExtensionsClient
 	VirtualMachineScaleSetVMs        azureclient.VirtualMachineScaleSetVMsClient
+	Resources                        azureclient.ResourcesClient
 }
 
+// NewClientFromEnvironment creates a new azure client from environment variables
 func NewClientFromEnvironment() (*Client, error) {
 	authorizer, err := azureclient.NewAuthorizerFromEnvironment()
 	if err != nil {
@@ -73,5 +76,6 @@ func NewClientFromEnvironment() (*Client, error) {
 		VirtualMachineScaleSets:          azureclient.NewVirtualMachineScaleSetsClient(subscriptionID, authorizer, nil),
 		VirtualMachineScaleSetExtensions: azureclient.NewVirtualMachineScaleSetExtensionsClient(subscriptionID, authorizer, nil),
 		VirtualMachineScaleSetVMs:        azureclient.NewVirtualMachineScaleSetVMsClient(subscriptionID, authorizer, nil),
+		Resources:                        azureclient.NewResourcesClient(subscriptionID, authorizer, nil),
 	}, nil
 }


### PR DESCRIPTION
Should this loop over general `ResourcesClient.List()` instead? (e.g. _all_ resources in the subscription?)

@kargakis @jim-minter @charlesakalugwu ptal