### PR TITLE
Find core fakerp directories recursively

### DIFF
--- a/cmd/createorupdate/createorupdate.go
+++ b/cmd/createorupdate/createorupdate.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"net/url"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"time"
@@ -120,7 +120,11 @@ func execute(ctx context.Context, log *logrus.Entry, rpc v20180930preview.OpenSh
 		return err
 	}
 	// simulate the API call to the RP
-	defaultManifestFile := path.Join(fakerp.DataDirectory, "manifest.yaml")
+	dataDir, err := fakerp.FindDirectory(fakerp.DataDirectory)
+	if err != nil {
+		return err
+	}
+	defaultManifestFile := filepath.Join(dataDir, "manifest.yaml")
 	if err := wait.PollImmediate(time.Second, 1*time.Hour, func() (bool, error) {
 		if err := createOrUpdate(ctx, log, rpc, conf.ResourceGroup, oc, defaultManifestFile); err != nil {
 			if autoRestErr, ok := err.(autorest.DetailedError); ok {

--- a/pkg/fakerp/directory.go
+++ b/pkg/fakerp/directory.go
@@ -1,0 +1,34 @@
+package fakerp
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// FindDirectory returns the absolute path to a directory containing name within
+// the directory hierarchy of the caller. The search starts at the current working
+// directory of the caller
+func FindDirectory(name string) (string, error) {
+	current, err := os.Getwd()
+	if err != nil {
+		return "", fmt.Errorf("could not get working directory: %v", err)
+	}
+	return walkParents(current, name)
+}
+
+// walkParents takes a path to a directory and a folder name and attempts to recursively
+// walk up the ancestors of the path in an attempt to find an ancestor containing name
+func walkParents(path, name string) (string, error) {
+	if path == "/" {
+		return "", fmt.Errorf("could not find %s in the directory hierarchy", name)
+	}
+	target := filepath.Join(path, name)
+	if info, err := os.Stat(target); err == nil {
+		if info.IsDir() {
+			return target, nil
+		}
+	}
+	parent := filepath.Dir(path)
+	return walkParents(parent, name)
+}

--- a/pkg/fakerp/directory_test.go
+++ b/pkg/fakerp/directory_test.go
@@ -1,0 +1,59 @@
+package fakerp
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func basepath() string {
+	return fmt.Sprintf("%s/%s", os.TempDir(), "dirwalk")
+}
+
+func pathTo(name string) string {
+	return filepath.Join(basepath(), name)
+}
+
+func chDir(t *testing.T, name string) string {
+	if err := os.Chdir(pathTo(name)); err != nil {
+		t.Errorf("could not switch to directory: %v", err)
+	}
+	return name
+}
+
+func tmpDir(t *testing.T, name string) string {
+	err := os.MkdirAll(pathTo(name), os.ModePerm)
+	if err != nil {
+		t.Errorf("could not create %s: %v", name, err)
+	}
+	return name
+}
+
+func cleanUp(t *testing.T, workingDir string) {
+	if err := os.Chdir(workingDir); err != nil {
+		t.Errorf("could not change directory to %s: %v", workingDir, err)
+	}
+	if err := os.RemoveAll(basepath()); err != nil {
+		t.Errorf("could not remove base directory %s: %v", basepath(), err)
+	}
+}
+
+func TestFindDirectory(t *testing.T) {
+	wd, _ := os.Getwd()
+	defer cleanUp(t, wd)
+
+	tmpDir(t, "/directory/with/two/folders")
+	tmpDir(t, "/directory/with/secret")
+	chDir(t, "/directory/with/two")
+
+	secretDir, err := FindDirectory("secret")
+	if err != nil {
+		t.Errorf("error finding directory: %v", err)
+	}
+
+	target := pathTo("/directory/with/secret")
+	if secretDir != target {
+		t.Errorf("expected %s, got %s", secretDir, target)
+	}
+}

--- a/pkg/fakerp/manifest.go
+++ b/pkg/fakerp/manifest.go
@@ -5,7 +5,7 @@ import (
 	"html/template"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"strings"
 
 	"github.com/ghodss/yaml"
@@ -27,7 +27,11 @@ func readEnv() map[string]string {
 // LoadClusterConfigFromManifest reads (and potentially template) the mainifest
 func LoadClusterConfigFromManifest(log *logrus.Entry, manifestTemplate string, conf *Config) (*v20180930preview.OpenShiftManagedCluster, error) {
 	if IsUpdate() && conf.Manifest == "" && manifestTemplate == "" {
-		defaultManifestFile := path.Join(DataDirectory, "manifest.yaml")
+		dataDir, err := FindDirectory(DataDirectory)
+		if err != nil {
+			return nil, err
+		}
+		defaultManifestFile := filepath.Join(dataDir, "manifest.yaml")
 		log.Debugf("using manifest from %q", defaultManifestFile)
 		return loadManifestFromFile(defaultManifestFile)
 	}


### PR DESCRIPTION
**What type of PR is this?**
/kind feature

**What this PR does / why we need it:**
To ensure that our fake rp works from either `cmd/createorupdate.go` or E2E tests in `test/e2e` we need to standardize how the fake rp finds the various core/config directories it needs for its operation. This PR introduces a function which allows a client to discover the absolute path to any named folder within the directory hierarchy of the caller. 

**Which issue(s) this PR fixes:**
Fixes #826 

**Release note:**
```
allow fake rp to find core/config directories recursively within its directory hierarchy
```

/cc @kargakis @mjudeikis