### PR TITLE
Add re-entrancy check e2e test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -82,7 +82,7 @@ cover: unit
 	go tool cover -html=coverage.out
 
 e2e:
-	FOCUS="\[AzureClusterReader\]|\[CustomerAdmin\]|\[EndUser\]" ./hack/e2e.sh
+	FOCUS="\[AzureClusterReader\]|\[CustomerAdmin\]|\[EndUser\]\[Fake\]" ./hack/e2e.sh
 
 e2e-prod:
 	FOCUS="\[Real\]" ./hack/e2e.sh

--- a/pkg/fakerp/fakerp.go
+++ b/pkg/fakerp/fakerp.go
@@ -54,10 +54,12 @@ func GetDeployer(log *logrus.Entry, cs *api.OpenShiftManagedCluster, config *api
 
 		log.Info("waiting for arm template deployment to complete")
 		if err := future.WaitForCompletionRef(ctx, deployments.Client()); err != nil {
-			return err
+			return fmt.Errorf("failed waiting for arm template deployment to complete: %#v", err)
 		}
-		_, err = future.Result(deployments.DeploymentClient())
-		return err
+		if _, err := future.Result(deployments.DeploymentClient()); err != nil {
+			return fmt.Errorf("failed to get arm template deloyment result: %#v", err)
+		}
+		return nil
 	}
 }
 

--- a/test/e2e/specs/customer_admin.go
+++ b/test/e2e/specs/customer_admin.go
@@ -16,7 +16,7 @@ import (
 	"github.com/openshift/openshift-azure/test/clients/openshift"
 )
 
-var _ = Describe("Openshift on Azure customer-admin e2e tests [CustomerAdmin]", func() {
+var _ = Describe("Openshift on Azure customer-admin e2e tests [CustomerAdmin][Fake]", func() {
 	var (
 		cli      *openshift.Client
 		admincli *openshift.Client

--- a/test/e2e/specs/customer_reader.go
+++ b/test/e2e/specs/customer_reader.go
@@ -15,7 +15,7 @@ import (
 	"github.com/openshift/openshift-azure/test/clients/openshift"
 )
 
-var _ = Describe("Openshift on Azure customer-reader e2e tests [CustomerAdmin]", func() {
+var _ = Describe("Openshift on Azure customer-reader e2e tests [CustomerAdmin][Fake]", func() {
 	var (
 		cli       *openshift.Client
 		readercli *openshift.Client

--- a/test/e2e/specs/end_user.go
+++ b/test/e2e/specs/end_user.go
@@ -26,7 +26,7 @@ import (
 	"github.com/openshift/openshift-azure/test/clients/openshift"
 )
 
-var _ = Describe("Openshift on Azure end user e2e tests [EndUser]", func() {
+var _ = Describe("Openshift on Azure end user e2e tests [EndUser][Fake]", func() {
 	var (
 		cli       *openshift.Client
 		namespace string

--- a/test/e2e/specs/fakerp/admin.go
+++ b/test/e2e/specs/fakerp/admin.go
@@ -1,6 +1,13 @@
 package fakerp
 
 import (
+	"context"
+	"encoding/json"
+	"flag"
+	"io/ioutil"
+	"net/http"
+	"os"
+	"reflect"
 	"strings"
 	"time"
 
@@ -11,14 +18,21 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/util/wait"
 
+	"github.com/openshift/openshift-azure/pkg/fakerp"
 	"github.com/openshift/openshift-azure/pkg/jsonpath"
 	"github.com/openshift/openshift-azure/pkg/util/ready"
+	"github.com/openshift/openshift-azure/test/clients/azure"
 	"github.com/openshift/openshift-azure/test/clients/openshift"
+	"github.com/openshift/openshift-azure/test/util/log"
 )
 
-var _ = Describe("Openshift on Azure admin e2e tests [AzureClusterReader]", func() {
+var _ = Describe("Openshift on Azure admin e2e tests [AzureClusterReader][Fake]", func() {
 	var (
 		cli *openshift.Client
+		// TODO: Unfortunately cannot use "manifest" because the flag name is already
+		// used by the key rotation test; Figure out whether we want to collapse these
+		// into a single flag and do it.
+		manifest = flag.String("request", "../../_data/manifest.yaml", "Path to the manifest to send to the RP")
 	)
 
 	BeforeEach(func() {
@@ -121,5 +135,49 @@ var _ = Describe("Openshift on Azure admin e2e tests [AzureClusterReader]", func
 			format := jsonpath.MustCompile("$.imageConfig.format").MustGetString(nodeConfig)
 			Expect(strings.HasPrefix(format, registryPrefix)).To(BeTrue())
 		}
+	})
+
+	It("should ensure no unnecessary VM rotations occured", func() {
+		azurecli, err := azure.NewClientFromEnvironment(true)
+		Expect(err).ToNot(HaveOccurred())
+
+		type updateBlob struct {
+			InstanceName string
+			ScaleSetHash string
+		}
+
+		By("reading the update blob before running an update")
+		bref := azurecli.BlobStorage.GetContainerReference("update")
+		brc, err := bref.GetBlobReference("update").Get(nil)
+		Expect(err).ToNot(HaveOccurred())
+		defer brc.Close()
+		data, err := ioutil.ReadAll(brc)
+		Expect(err).ToNot(HaveOccurred())
+		var before []updateBlob
+		err = json.Unmarshal(data, &before)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("running an update")
+		external, err := fakerp.LoadClusterConfigFromManifest(log.GetTestLogger(), *manifest)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(external).NotTo(BeNil())
+		updated, err := azurecli.OpenShiftManagedClusters.CreateOrUpdateAndWait(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"), *external)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(updated.StatusCode).To(Equal(http.StatusOK))
+		Expect(updated).NotTo(BeNil())
+
+		By("reading the update blob after running an update")
+		bref = azurecli.BlobStorage.GetContainerReference("update")
+		arc, err := bref.GetBlobReference("update").Get(nil)
+		Expect(err).ToNot(HaveOccurred())
+		defer arc.Close()
+		data, err = ioutil.ReadAll(arc)
+		Expect(err).ToNot(HaveOccurred())
+		var after []updateBlob
+		err = json.Unmarshal(data, &after)
+		Expect(err).ToNot(HaveOccurred())
+
+		By("comparing the update blob before and after an update")
+		Expect(reflect.DeepEqual(before, after)).To(Equal(true))
 	})
 })

--- a/test/e2e/specs/realrp/realrp.go
+++ b/test/e2e/specs/realrp/realrp.go
@@ -43,7 +43,7 @@ var _ = Describe("Resource provider e2e tests [Real]", func() {
 
 	BeforeEach(func() {
 		var err error
-		cli, err = azure.NewClientFromEnvironment()
+		cli, err = azure.NewClientFromEnvironment(false)
 		Expect(err).ToNot(HaveOccurred())
 		if os.Getenv("AZURE_REGION") == "" {
 			Expect(errors.New("AZURE_REGION is not set")).ToNot(HaveOccurred())

--- a/test/e2e/specs/scaleupdown.go
+++ b/test/e2e/specs/scaleupdown.go
@@ -10,7 +10,6 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/sirupsen/logrus"
 	apiappsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -22,6 +21,7 @@ import (
 	"github.com/openshift/openshift-azure/pkg/util/ready"
 	"github.com/openshift/openshift-azure/test/clients/azure"
 	"github.com/openshift/openshift-azure/test/clients/openshift"
+	"github.com/openshift/openshift-azure/test/util/log"
 )
 
 var _ = Describe("Scale Up/Down E2E tests [ScaleUpDown][Fake][LongRunning]", func() {
@@ -38,7 +38,7 @@ var _ = Describe("Scale Up/Down E2E tests [ScaleUpDown][Fake][LongRunning]", fun
 
 	BeforeEach(func() {
 		var err error
-		azurecli, err = azure.NewClientFromEnvironment()
+		azurecli, err = azure.NewClientFromEnvironment(false)
 		Expect(err).NotTo(HaveOccurred())
 		occli, err = openshift.NewEndUserClient()
 		Expect(err).NotTo(HaveOccurred())
@@ -56,13 +56,8 @@ var _ = Describe("Scale Up/Down E2E tests [ScaleUpDown][Fake][LongRunning]", fun
 	})
 
 	It("should be possible to maintain a healthy cluster after scaling it out and in", func() {
-		logrus.SetLevel(logrus.DebugLevel)
-		logrus.SetFormatter(&logrus.TextFormatter{FullTimestamp: true})
-		logrus.SetOutput(GinkgoWriter)
-		log := logrus.NewEntry(logrus.StandardLogger())
-
 		By("Fetching the scale up manifest")
-		external, err := fakerp.LoadClusterConfigFromManifest(log, *scaleUpManifest)
+		external, err := fakerp.LoadClusterConfigFromManifest(log.GetTestLogger(), *scaleUpManifest)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(external).NotTo(BeNil())
 
@@ -143,7 +138,7 @@ var _ = Describe("Scale Up/Down E2E tests [ScaleUpDown][Fake][LongRunning]", fun
 		Expect(len(nodes)).To(Equal(2))
 
 		By("Fetching the scale down manifest")
-		external, err = fakerp.LoadClusterConfigFromManifest(log, *scaleDownManifest)
+		external, err = fakerp.LoadClusterConfigFromManifest(log.GetTestLogger(), *scaleDownManifest)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(external).NotTo(BeNil())
 

--- a/test/util/log/log.go
+++ b/test/util/log/log.go
@@ -1,0 +1,14 @@
+package log
+
+import (
+	. "github.com/onsi/ginkgo"
+
+	"github.com/sirupsen/logrus"
+)
+
+func GetTestLogger() *logrus.Entry {
+	logrus.SetLevel(logrus.DebugLevel)
+	logrus.SetFormatter(&logrus.TextFormatter{FullTimestamp: true})
+	logrus.SetOutput(GinkgoWriter)
+	return logrus.NewEntry(logrus.StandardLogger())
+}


### PR DESCRIPTION
We will also need a test where an actual upgrade is invoked and at the end we ensure the update blob is different than what it was before the update.