### PR TITLE
Follow-up to https://github.com/openshift/openshift-azure/pull/818

### DIFF
--- a/pkg/cluster/initialize.go
+++ b/pkg/cluster/initialize.go
@@ -30,12 +30,11 @@ func (u *simpleUpgrader) initialize(ctx context.Context, cs *api.OpenShiftManage
 	}
 
 	// update tracking container
-	c = bsc.GetContainerReference(updateContainerName)
-	_, err = c.CreateIfNotExists(nil)
+	u.updateContainer = bsc.GetContainerReference(updateContainerName)
+	_, err = u.updateContainer.CreateIfNotExists(nil)
 	if err != nil {
 		return err
 	}
-	u.updateBlob = c.GetBlobReference(updateBlobName)
 
 	// cluster config container
 	c = bsc.GetContainerReference(ConfigContainerName)

--- a/pkg/cluster/initialize_test.go
+++ b/pkg/cluster/initialize_test.go
@@ -29,7 +29,6 @@ func TestInitialize(t *testing.T) {
 	updateCr := mock_storage.NewMockContainer(gmc)
 	bsa.EXPECT().GetContainerReference(updateContainerName).Return(updateCr)
 	updateCr.EXPECT().CreateIfNotExists(nil).Return(true, nil)
-	updateCr.EXPECT().GetBlobReference(updateBlobName)
 
 	configCr := mock_storage.NewMockContainer(gmc)
 	bsa.EXPECT().GetContainerReference(ConfigContainerName).Return(configCr)

--- a/pkg/cluster/types.go
+++ b/pkg/cluster/types.go
@@ -38,14 +38,14 @@ type Upgrader interface {
 }
 
 type simpleUpgrader struct {
-	pluginConfig   api.PluginConfig
-	accountsClient azureclient.AccountsClient
-	storageClient  storage.Client
-	updateBlob     storage.Blob
-	vmc            azureclient.VirtualMachineScaleSetVMsClient
-	ssc            azureclient.VirtualMachineScaleSetsClient
-	kubeclient     kubernetes.Interface
-	log            *logrus.Entry
+	pluginConfig    api.PluginConfig
+	accountsClient  azureclient.AccountsClient
+	storageClient   storage.Client
+	updateContainer storage.Container
+	vmc             azureclient.VirtualMachineScaleSetVMsClient
+	ssc             azureclient.VirtualMachineScaleSetsClient
+	kubeclient      kubernetes.Interface
+	log             *logrus.Entry
 }
 
 var _ Upgrader = &simpleUpgrader{}

--- a/pkg/cluster/updateblob.go
+++ b/pkg/cluster/updateblob.go
@@ -54,14 +54,13 @@ func (u *simpleUpgrader) writeUpdateBlob(blob updateblob) error {
 		return err
 	}
 
-	bsc := u.storageClient.GetBlobService()
-	c := bsc.GetContainerReference(updateContainerName)
-	u.updateBlob = c.GetBlobReference(updateBlobName)
-	return u.updateBlob.CreateBlockBlobFromReader(bytes.NewReader(data), nil)
+	updateBlob := u.updateContainer.GetBlobReference(updateBlobName)
+	return updateBlob.CreateBlockBlobFromReader(bytes.NewReader(data), nil)
 }
 
 func (u *simpleUpgrader) readUpdateBlob() (updateblob, error) {
-	rc, err := u.updateBlob.Get(nil)
+	updateBlob := u.updateContainer.GetBlobReference(updateBlobName)
+	rc, err := updateBlob.Get(nil)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Avoid storing the Blob object in the simpleUpgrader, evidently this was a
mistake.  On a Blob.Get() the blob MD5 is latched into the Blob object.  If
Blob.CreateBlockBlobFromReader() is called, the latched MD5 is not cleared,
resulting in an error on the subsequent Get().  Store the Container in the
simpleUpgrader to force the user to get the Blob themselves.