### PR TITLE
Remove az dependency from hack/delete.sh

### DIFF
--- a/hack/delete.sh
+++ b/hack/delete.sh
@@ -1,9 +1,5 @@
 #!/bin/bash -x
 
-if ! az account show >/dev/null; then
-    exit 1
-fi
-
 if [[ $# -eq 0 && ! -e _data/containerservice.yaml ]]; then
     echo error: _data/containerservice.yaml must exist
     exit 1

--- a/hack/etcdrecovery.sh
+++ b/hack/etcdrecovery.sh
@@ -1,9 +1,5 @@
 #!/bin/bash
 
-if ! az account show >/dev/null; then
-    exit 1
-fi
-
 if [[ $# -lt 2 ]]; then
     echo error: usage "$0 resourceGroup backupblobname"
     exit 1

--- a/hack/upgrade.sh
+++ b/hack/upgrade.sh
@@ -1,9 +1,5 @@
 #!/bin/bash -ex
 
-if ! az account show >/dev/null; then
-    exit 1
-fi
-
 if [[ $# -eq 0 && ! -e _data/containerservice.yaml ]]; then
     echo error: _data/containerservice.yaml must exist
     exit 1


### PR DESCRIPTION
Yesterday we pushed [a change in our e2e job](https://github.com/openshift/release/pull/2312) that drops `az login` from both cluster creation and deletion since it's not required anymore. Unfortunately, our delete.sh script has an artifact use of az that broke cluster deletion. 

/cc @charlesakalugwu @mjudeikis @jim-minter 