### PR TITLE
Set region from the external manifest in e2e tests if unset

### DIFF
--- a/cmd/createorupdate/createorupdate.go
+++ b/cmd/createorupdate/createorupdate.go
@@ -254,4 +254,6 @@ func main() {
 	if err != nil {
 		log.Fatal(err)
 	}
+
+	fmt.Printf("Cluster available at https://%s.%s.cloudapp.azure.com/\n", conf.ResourceGroup, conf.Region)
 }

--- a/hack/create.sh
+++ b/hack/create.sh
@@ -18,7 +18,3 @@ if [[ -n "$TEST_IN_PRODUCTION" ]]; then
 else
   go run cmd/createorupdate/createorupdate.go
 fi
-
-echo
-echo  Cluster available at https://$RESOURCEGROUP.$AZURE_REGION.cloudapp.azure.com/
-echo


### PR DESCRIPTION
Fixes https://github.com/openshift/openshift-azure/issues/869

This will allow us to continue using random region selection in our tests.