### PR TITLE
Support templated manifests in keyrotation e2e

### DIFF
--- a/cmd/createorupdate/createorupdate.go
+++ b/cmd/createorupdate/createorupdate.go
@@ -120,7 +120,7 @@ func createResourceGroup(conf *fakerp.Config) (bool, error) {
 }
 
 func execute(ctx context.Context, log *logrus.Entry, rpc v20180930preview.OpenShiftManagedClustersClient, conf *fakerp.Config) error {
-	oc, err := fakerp.LoadClusterConfigFromManifest(log, "", conf)
+	oc, err := fakerp.LoadClusterConfigFromManifest(log, conf.Manifest)
 	if err != nil {
 		return err
 	}

--- a/pkg/fakerp/manifest.go
+++ b/pkg/fakerp/manifest.go
@@ -25,8 +25,8 @@ func readEnv() map[string]string {
 }
 
 // LoadClusterConfigFromManifest reads (and potentially template) the mainifest
-func LoadClusterConfigFromManifest(log *logrus.Entry, manifestTemplate string, conf *Config) (*v20180930preview.OpenShiftManagedCluster, error) {
-	if IsUpdate() && conf.Manifest == "" && manifestTemplate == "" {
+func LoadClusterConfigFromManifest(log *logrus.Entry, manifestTemplate string) (*v20180930preview.OpenShiftManagedCluster, error) {
+	if IsUpdate() && manifestTemplate == "" {
 		dataDir, err := FindDirectory(DataDirectory)
 		if err != nil {
 			return nil, err
@@ -34,9 +34,6 @@ func LoadClusterConfigFromManifest(log *logrus.Entry, manifestTemplate string, c
 		defaultManifestFile := filepath.Join(dataDir, "manifest.yaml")
 		log.Debugf("using manifest from %q", defaultManifestFile)
 		return loadManifestFromFile(defaultManifestFile)
-	}
-	if manifestTemplate == "" {
-		manifestTemplate = conf.Manifest
 	}
 	if manifestTemplate == "" {
 		manifestTemplate = "test/manifests/normal/create.yaml"


### PR DESCRIPTION
This adds support for reading manifest files containing templated values coming from environment variables in the keyrotation e2e tests

/cc @kargakis 