### PR TITLE
Remove unused arm error handling

### DIFF
--- a/pkg/fakerp/config.go
+++ b/pkg/fakerp/config.go
@@ -60,7 +60,7 @@ func NewConfig(log *logrus.Entry, needRegion bool) (*Config, error) {
 			// Randomly assign a supported region
 			rand.Seed(time.Now().UTC().UnixNano())
 			c.Region = supportedRegions[rand.Intn(len(supportedRegions))]
-			log.Infof("using randomly selected region %q", c.Region)
+			log.Infof("using randomly selected region %s", c.Region)
 		}
 
 		var supported bool
@@ -70,7 +70,7 @@ func NewConfig(log *logrus.Entry, needRegion bool) (*Config, error) {
 			}
 		}
 		if !supported {
-			return nil, fmt.Errorf("%q is not a supported region (supported regions: %v)", c.Region, supportedRegions)
+			return nil, fmt.Errorf("%s is not a supported region (supported regions: %v)", c.Region, supportedRegions)
 		}
 		os.Setenv("AZURE_REGION", c.Region)
 	}

--- a/pkg/fakerp/fakerp.go
+++ b/pkg/fakerp/fakerp.go
@@ -3,7 +3,6 @@ package fakerp
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -59,22 +58,8 @@ func GetDeployer(log *logrus.Entry, cs *api.OpenShiftManagedCluster, config *api
 		if err := future.WaitForCompletionRef(ctx, deployments.Client()); err != nil {
 			return err
 		}
-		resp, err := future.Result(deployments.DeploymentClient())
-		if err != nil {
-			return err
-		}
-		if *resp.Properties.ProvisioningState != "Succeeded" {
-			returnErr := fmt.Sprintf("arm deployment failed (correlation id: %s)", *resp.Properties.CorrelationID)
-			dopc := resources.NewDeploymentOperationsClient(cs.Properties.AzProfile.SubscriptionID)
-			dopc.Authorizer = authorizer
-			if op, err := dopc.Get(ctx, cs.Properties.AzProfile.ResourceGroup, *resp.Name, *resp.Properties.CorrelationID); err != nil {
-				log.Warn(err.Error())
-			} else {
-				returnErr = fmt.Sprintf("%s - %v", returnErr, op.Properties.StatusMessage)
-			}
-			return errors.New(returnErr)
-		}
-		return nil
+		_, err = future.Result(deployments.DeploymentClient())
+		return err
 	}
 }
 

--- a/pkg/fakerp/manifest.go
+++ b/pkg/fakerp/manifest.go
@@ -32,13 +32,13 @@ func LoadClusterConfigFromManifest(log *logrus.Entry, manifestTemplate string) (
 			return nil, err
 		}
 		defaultManifestFile := filepath.Join(dataDir, "manifest.yaml")
-		log.Debugf("using manifest from %q", defaultManifestFile)
+		log.Debugf("using manifest from %s", defaultManifestFile)
 		return loadManifestFromFile(defaultManifestFile)
 	}
 	if manifestTemplate == "" {
 		manifestTemplate = "test/manifests/normal/create.yaml"
 	}
-	log.Debugf("generating manifest from %q", manifestTemplate)
+	log.Debugf("generating manifest from %s", manifestTemplate)
 	return generateManifest(manifestTemplate)
 }
 
@@ -54,7 +54,7 @@ func WriteClusterConfigToManifest(oc *v20180930preview.OpenShiftManagedCluster, 
 func generateManifest(manifestFile string) (*v20180930preview.OpenShiftManagedCluster, error) {
 	t, err := template.ParseFiles(manifestFile)
 	if err != nil {
-		return nil, errors.Wrapf(err, "failed parsing the manifest %q", manifestFile)
+		return nil, errors.Wrapf(err, "failed parsing the manifest %s", manifestFile)
 	}
 
 	b := &bytes.Buffer{}


### PR DESCRIPTION
This error handling code is actually never executed when an ARM deployment fails.