### PR TITLE
Add e2e image and make targets

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,7 +3,7 @@
 /env
 /env.*
 !/env.example
-/e2e.test
+/e2e
 /kubeconfig*
 /sync
 /etcdbackup

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,0 +1,4 @@
+FROM centos:7
+RUN yum -y update
+COPY e2e .
+ENTRYPOINT [ "/e2e" ]


### PR DESCRIPTION
This adds a dockerfile and make targets for building the e2e tests, creating an image and pushing the image to quay. Coreesponding CI updates will be done in a follow-up.

/cc @kargakis @jim-minter 