### PR TITLE
Fix fakerp.FindDirectory to find folders at system root

### DIFF
--- a/pkg/fakerp/directory.go
+++ b/pkg/fakerp/directory.go
@@ -20,14 +20,14 @@ func FindDirectory(name string) (string, error) {
 // walkParents takes a path to a directory and a folder name and attempts to recursively
 // walk up the ancestors of the path in an attempt to find an ancestor containing name
 func walkParents(path, name string) (string, error) {
-	if path == "/" {
-		return "", fmt.Errorf("could not find %s in the directory hierarchy", name)
-	}
 	target := filepath.Join(path, name)
 	if info, err := os.Stat(target); err == nil {
 		if info.IsDir() {
 			return target, nil
 		}
+	}
+	if path == "/" {
+		return "", fmt.Errorf("could not find %s in the directory hierarchy", name)
 	}
 	parent := filepath.Dir(path)
 	return walkParents(parent, name)

--- a/pkg/fakerp/directory_test.go
+++ b/pkg/fakerp/directory_test.go
@@ -57,3 +57,21 @@ func TestFindDirectory(t *testing.T) {
 		t.Errorf("expected %s, got %s", secretDir, target)
 	}
 }
+
+func TestFindDirectoryAtRoot(t *testing.T) {
+	wd, _ := os.Getwd()
+	defer cleanUp(t, wd)
+
+	tmpDir(t, "/_data")
+	chDir(t, "/")
+
+	dataDir, err := FindDirectory("_data")
+	if err != nil {
+		t.Errorf("error finding directory: %v", err)
+	}
+
+	target := pathTo("/_data")
+	if dataDir != target {
+		t.Errorf("expected %s, got %s", dataDir, target)
+	}
+}


### PR DESCRIPTION
I discovered this while working out how to run our e2e tests from a
container. walkParents was checking if the path we are analysing is the
system root (/) and exits if it is. The problem with this is that the
sought-after directory could be at root directory e.g. in a container at
/_data

This fix reverses the order of the stop condition in walkParents and allows
an e2e binary in a container (at /e2e) to find the _data or secrets
directories at /_data or /secrets in the container.

/cc @kargakis @mjudeikis