### PR TITLE
Trap killing process on 8080

### DIFF
--- a/hack/create.sh
+++ b/hack/create.sh
@@ -16,7 +16,10 @@ USE_PROD_FLAG="-use-prod=false"
 if [[ -n "$TEST_IN_PRODUCTION" ]]; then
     USE_PROD_FLAG="-use-prod=true"
 else
-	hack/fakerp.sh $RESOURCEGROUP &
+    go generate ./...
+    go run cmd/fakerp/main.go &
 fi
+
+trap 'set +ex; return_id=$?; kill $(lsof -t -i :8080); wait; exit $return_id' EXIT
 
 go run cmd/createorupdate/createorupdate.go $USE_PROD_FLAG

--- a/hack/delete.sh
+++ b/hack/delete.sh
@@ -15,7 +15,10 @@ USE_PROD_FLAG="-use-prod=false"
 if [[ -n "$TEST_IN_PRODUCTION" ]]; then
     USE_PROD_FLAG="-use-prod=true"
 else
-	hack/fakerp.sh $RESOURCEGROUP &
+    go generate ./...
+    go run cmd/fakerp/main.go &
 fi
+
+trap 'set +ex; return_id=$?; kill $(lsof -t -i :8080); wait; exit $return_id' EXIT
 
 go run cmd/createorupdate/createorupdate.go -request=DELETE $USE_PROD_FLAG

--- a/hack/upgrade.sh
+++ b/hack/upgrade.sh
@@ -14,11 +14,13 @@ fi
 if [[ -n "$TEST_IN_PRODUCTION" ]]; then
     TEST_IN_PRODUCTION="-use-prod=true"
 else
-	hack/fakerp.sh $RESOURCEGROUP &
+    go generate ./...
+    go run cmd/fakerp/main.go &
 fi
 if [[ -n "$ADMIN_MANIFEST" ]]; then
     ADMIN_MANIFEST="-admin-manifest=$ADMIN_MANIFEST"
 fi
 
+trap 'set +ex; return_id=$?; kill $(lsof -t -i :8080); wait; exit $return_id' EXIT
 
 go run cmd/createorupdate/createorupdate.go -timeout 1h ${TEST_IN_PRODUCTION:-} ${ADMIN_MANIFEST:-}


### PR DESCRIPTION
@jim-minter @mjudeikis @charlesakalugwu this is the best approach I can come up with that does not involve:
* adding extra logic in the fake RP (https://github.com/openshift/openshift-azure/pull/926)
* using less cross-platform tools like `fuser` (https://github.com/openshift/openshift-azure/pull/927)

I am also trying to workaround the fact that we are using bash by replacing the callout to `hack/fakerp.sh` with using `go run` directly because running bash inside of bash is super slow and the $(lsof) subshell in the trap may not resolve correctly since the server has yet to start. The current approach is still a little racy but it avoids using weird wait logic for the server to come up in order to get the pid. Also, for some reason the process id returned from the async process execution `go run cmd/fakerp/main.go &` is different from the process id listening on the port, hence the use of `lsof`.

Fixes https://github.com/openshift/openshift-azure/issues/924