### PR TITLE
adding VnetID field to APIs and code to populate it after deploy

### DIFF
--- a/pkg/api/2018-09-30-preview/api/types.go
+++ b/pkg/api/2018-09-30-preview/api/types.go
@@ -89,9 +89,14 @@ const (
 
 // NetworkProfile contains configuration for OpenShift networking.
 type NetworkProfile struct {
+	// VnetCIDR (in): the CIDR with which the OSA cluster's Vnet is configured
 	VnetCIDR *string `json:"vnetCidr,omitempty"`
 
-	// PeerVnetID is expected to be empty or match
+	// VnetID (out): the ID of the Vnet created for the OSA cluster
+	VnetID *string `json:"vnetId,omitempty"`
+
+	// PeerVnetID (in, optional): ID of a Vnet with which the OSA cluster Vnet should be peered.
+	// If non-empty, this should match
 	// `^/subscriptions/[^/]+
 	//   /resourceGroups/[^/]+
 	//   /providers/Microsoft.Network

--- a/pkg/api/2018-09-30-preview/api/types_test.go
+++ b/pkg/api/2018-09-30-preview/api/types_test.go
@@ -26,6 +26,7 @@ var marshalled = []byte(`{
 		"fqdn": "Properties.FQDN",
 		"networkProfile": {
 			"vnetCidr": "Properties.NetworkProfile.VnetCIDR",
+			"vnetId": "Properties.NetworkProfile.VnetID",
 			"peerVnetId": "Properties.NetworkProfile.PeerVnetID"
 		},
 		"routerProfiles": [

--- a/pkg/api/admin/api/types.go
+++ b/pkg/api/admin/api/types.go
@@ -91,9 +91,14 @@ const (
 
 // NetworkProfile contains configuration for OpenShift networking.
 type NetworkProfile struct {
+	// VnetCIDR (in): the CIDR with which the OSA cluster's Vnet is configured
 	VnetCIDR *string `json:"vnetCidr,omitempty"`
 
-	// PeerVnetID is expected to be empty or match
+	// VnetID (out): the ID of the Vnet created for the OSA cluster
+	VnetID *string `json:"vnetId,omitempty"`
+
+	// PeerVnetID (in, optional): ID of a Vnet with which the OSA cluster Vnet should be peered.
+	// If non-empty, this should match
 	// `^/subscriptions/[^/]+
 	//   /resourceGroups/[^/]+
 	//   /providers/Microsoft.Network

--- a/pkg/api/admin/api/types_test.go
+++ b/pkg/api/admin/api/types_test.go
@@ -28,6 +28,7 @@ var marshalled = []byte(`{
 		"fqdn": "Properties.FQDN",
 		"networkProfile": {
 			"vnetCidr": "Properties.NetworkProfile.VnetCIDR",
+			"vnetId": "Properties.NetworkProfile.VnetID",
 			"peerVnetId": "Properties.NetworkProfile.PeerVnetID"
 		},
 		"routerProfiles": [

--- a/pkg/api/converterfromadmin.go
+++ b/pkg/api/converterfromadmin.go
@@ -79,6 +79,9 @@ func mergePropertiesAdmin(oc *admin.OpenShiftManagedCluster, cs *OpenShiftManage
 	}
 
 	if oc.Properties.NetworkProfile != nil {
+		if oc.Properties.NetworkProfile.VnetID != nil {
+			cs.Properties.NetworkProfile.VnetID = *oc.Properties.NetworkProfile.VnetID
+		}
 		if oc.Properties.NetworkProfile.VnetCIDR != nil {
 			cs.Properties.NetworkProfile.VnetCIDR = *oc.Properties.NetworkProfile.VnetCIDR
 		}

--- a/pkg/api/converterfromv20180930preview.go
+++ b/pkg/api/converterfromv20180930preview.go
@@ -81,6 +81,9 @@ func mergeProperties(oc *v20180930preview.OpenShiftManagedCluster, cs *OpenShift
 	}
 
 	if oc.Properties.NetworkProfile != nil {
+		if oc.Properties.NetworkProfile.VnetID != nil {
+			cs.Properties.NetworkProfile.VnetID = *oc.Properties.NetworkProfile.VnetID
+		}
 		if oc.Properties.NetworkProfile.VnetCIDR != nil {
 			cs.Properties.NetworkProfile.VnetCIDR = *oc.Properties.NetworkProfile.VnetCIDR
 		}

--- a/pkg/api/converterfromv20180930preview_test.go
+++ b/pkg/api/converterfromv20180930preview_test.go
@@ -74,6 +74,7 @@ func internalManagedCluster() *OpenShiftManagedCluster {
 				},
 			},
 			NetworkProfile: NetworkProfile{
+				VnetID:     "Properties.NetworkProfile.VnetID",
 				VnetCIDR:   "Properties.NetworkProfile.VnetCIDR",
 				PeerVnetID: "Properties.NetworkProfile.PeerVnetID",
 			},

--- a/pkg/api/convertertoadmin.go
+++ b/pkg/api/convertertoadmin.go
@@ -33,6 +33,7 @@ func ConvertToAdmin(cs *OpenShiftManagedCluster) *admin.OpenShiftManagedCluster 
 	}
 
 	oc.Properties.NetworkProfile = &admin.NetworkProfile{
+		VnetID:     &cs.Properties.NetworkProfile.VnetID,
 		VnetCIDR:   &cs.Properties.NetworkProfile.VnetCIDR,
 		PeerVnetID: &cs.Properties.NetworkProfile.PeerVnetID,
 	}

--- a/pkg/api/convertertov20180930preview.go
+++ b/pkg/api/convertertov20180930preview.go
@@ -35,6 +35,7 @@ func ConvertToV20180930preview(cs *OpenShiftManagedCluster) *v20180930preview.Op
 	}
 
 	oc.Properties.NetworkProfile = &v20180930preview.NetworkProfile{
+		VnetID:     &cs.Properties.NetworkProfile.VnetID,
 		VnetCIDR:   &cs.Properties.NetworkProfile.VnetCIDR,
 		PeerVnetID: &cs.Properties.NetworkProfile.PeerVnetID,
 	}

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -86,9 +86,14 @@ const (
 
 // NetworkProfile contains configuration for OpenShift networking.
 type NetworkProfile struct {
+	// VnetCIDR (in): the CIDR with which the OSA cluster's Vnet is configured
 	VnetCIDR string `json:"vnetCidr,omitempty"`
 
-	// PeerVnetID is expected to be empty or match
+	// VnetID (out): the ID of the Vnet created for the OSA cluster
+	VnetID string `json:"vnetId,omitempty"`
+
+	// PeerVnetID (in, optional): ID of a Vnet with which the OSA cluster Vnet should be peered.
+	// If non-empty, this should match
 	// `^/subscriptions/[^/]+
 	//   /resourceGroups/[^/]+
 	//   /providers/Microsoft.Network

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -31,6 +31,7 @@ var marshalled = []byte(`{
 		"fqdn": "Properties.FQDN",
 		"networkProfile": {
 			"vnetCidr": "Properties.NetworkProfile.VnetCIDR",
+			"vnetId": "Properties.NetworkProfile.VnetID",
 			"peerVnetId": "Properties.NetworkProfile.PeerVnetID"
 		},
 		"routerProfiles": [

--- a/pkg/api/validate.go
+++ b/pkg/api/validate.go
@@ -454,6 +454,9 @@ func (v *Validator) validateNetworkProfile(np *NetworkProfile) (errs []error) {
 		errs = append(errs, fmt.Errorf("networkProfile cannot be nil"))
 		return
 	}
+	if np.VnetID != "" && !rxVNetID.MatchString(np.VnetID) {
+		errs = append(errs, fmt.Errorf("invalid properties.networkProfile.vnetId %q", np.VnetID))
+	}
 	if !isValidIPV4CIDR(np.VnetCIDR) {
 		errs = append(errs, fmt.Errorf("invalid properties.networkProfile.vnetCidr %q", np.VnetCIDR))
 	}

--- a/pkg/api/validate_test.go
+++ b/pkg/api/validate_test.go
@@ -165,6 +165,17 @@ func TestValidate(t *testing.T) {
 			},
 			expectedErrs: []error{errors.New(`invalid properties.publicHostname "www.example.com"`)},
 		},
+		"network profile valid VnetId": {
+			f: func(oc *OpenShiftManagedCluster) {
+				oc.Properties.NetworkProfile.VnetID = "/subscriptions/b07e8fae-2f3f-4769-8fa8-8570b426ba13/resourceGroups/test/providers/Microsoft.Network/virtualNetworks/vnet"
+			},
+		},
+		"network profile invalid VnetId": {
+			f: func(oc *OpenShiftManagedCluster) {
+				oc.Properties.NetworkProfile.VnetID = "foo"
+			},
+			expectedErrs: []error{errors.New(`invalid properties.networkProfile.vnetId "foo"`)},
+		},
 		"network profile bad vnetCidr": {
 			f: func(oc *OpenShiftManagedCluster) {
 				oc.Properties.NetworkProfile.VnetCIDR = "foo"

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -12,6 +12,7 @@ import (
 	"github.com/openshift/openshift-azure/pkg/arm"
 	"github.com/openshift/openshift-azure/pkg/cluster"
 	"github.com/openshift/openshift-azure/pkg/config"
+	"github.com/openshift/openshift-azure/pkg/util/resourceid"
 )
 
 type plugin struct {
@@ -132,6 +133,11 @@ func (p *plugin) CreateOrUpdate(ctx context.Context, cs *api.OpenShiftManagedClu
 	p.log.Info("starting health check")
 	if err := p.clusterUpgrader.HealthCheck(ctx, cs); err != nil {
 		return err
+	}
+
+	if cs != nil {
+		// setting VnetID based on VnetName
+		cs.Properties.NetworkProfile.VnetID = resourceid.ResourceID(cs.Properties.AzProfile.SubscriptionID, cs.Properties.AzProfile.ResourceGroup, "Microsoft.Network/virtualNetworks", arm.VnetName)
 	}
 
 	// explicitly return nil if all went well

--- a/pkg/util/resourceid/resourceid.go
+++ b/pkg/util/resourceid/resourceid.go
@@ -1,0 +1,8 @@
+package resourceid
+
+import "fmt"
+
+// ResourceID constructs an Azure resource ID offline from the provided components
+func ResourceID(subscriptionID, resourceGroup, resourceProvider, resourceName string) string {
+	return fmt.Sprintf("/subscriptions/%s/resourceGroups/%s/providers/%s/%s", subscriptionID, resourceGroup, resourceProvider, resourceName)
+}


### PR DESCRIPTION
Fixes #544 
Adding the VnetID field to all 3 APIs, converters, validator, unit tests. Also the code to populate the field + subset of the azure Network client.
