### PR TITLE
Use create futures appropriately in the fake rp

### DIFF
--- a/pkg/fakerp/middleware.go
+++ b/pkg/fakerp/middleware.go
@@ -13,7 +13,7 @@ func (s *Server) logger(handler http.Handler) http.Handler {
 
 func (s *Server) validator(handler http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodPut {
+		if r.Method != http.MethodGet {
 			select {
 			case s.inProgress <- struct{}{}:
 				// continue

--- a/pkg/util/azureclient/openshiftmanagedcluster/2018-09-30-preview/client.go
+++ b/pkg/util/azureclient/openshiftmanagedcluster/2018-09-30-preview/client.go
@@ -180,7 +180,7 @@ func (client OpenShiftManagedClustersClient) CreateOrUpdateSender(req *http.Requ
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated, http.StatusAccepted))
 	if err != nil {
 		return
 	}
@@ -194,7 +194,7 @@ func (client OpenShiftManagedClustersClient) CreateOrUpdateResponder(resp *http.
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated, http.StatusAccepted),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
 	result.Response = autorest.Response{Response: resp}

--- a/pkg/util/azureclient/openshiftmanagedcluster/admin/client.go
+++ b/pkg/util/azureclient/openshiftmanagedcluster/admin/client.go
@@ -165,7 +165,7 @@ func (client OpenShiftManagedClustersClient) CreateOrUpdateSender(req *http.Requ
 	if err != nil {
 		return
 	}
-	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated))
+	err = autorest.Respond(resp, azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated, http.StatusAccepted))
 	if err != nil {
 		return
 	}
@@ -179,7 +179,7 @@ func (client OpenShiftManagedClustersClient) CreateOrUpdateResponder(resp *http.
 	err = autorest.Respond(
 		resp,
 		client.ByInspecting(),
-		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusCreated, http.StatusAccepted),
 		autorest.ByUnmarshallingJSON(&result),
 		autorest.ByClosing())
 	result.Response = autorest.Response{Response: resp}


### PR DESCRIPTION
I was playing around with futures and I was thinking that the way we have implemented PUTs currently in the fake RP is wrong since it's a synchronous process whereas it probably should be asynchronous. I am not sure how this is implemented in the prod RP though and the fact that the clients are not treating http.StatusAccepted as a valid status returned during a PUT makes me think that this may work differently in prod or it's probably an oversight in the OSA sdk? 

@julienstroheker @amanohar @jim-minter 