### PR TITLE
Simplify manifest helpers

### DIFF
--- a/cmd/createorupdate/createorupdate.go
+++ b/cmd/createorupdate/createorupdate.go
@@ -137,16 +137,28 @@ func execute(
 		return createOrUpdateAdmin(ctx, log, ac, conf.ResourceGroup, oc, adminManifest)
 	}
 
-	oc, err := fakerp.LoadClusterConfigFromManifest(log, conf.Manifest)
-	if err != nil {
-		return fmt.Errorf("failed reading manifest: %v", err)
-	}
-	// simulate the API call to the RP
 	dataDir, err := shared.FindDirectory(shared.DataDirectory)
 	if err != nil {
 		return fmt.Errorf("failed to find %s: %v", shared.DataDirectory, err)
 	}
 	defaultManifestFile := filepath.Join(dataDir, "manifest.yaml")
+	// TODO: Configuring this is probably not needed
+	manifest := conf.Manifest
+	// If no MANIFEST has been provided and this is a cluster
+	// creation, default to the test manifest.
+	if !shared.IsUpdate() && manifest == "" {
+		manifest = "test/manifests/normal/create.yaml"
+	}
+	// If this is a cluster upgrade, reuse the existing manifest.
+	if manifest == "" {
+		manifest = defaultManifestFile
+	}
+
+	oc, err := fakerp.GenerateManifest(manifest)
+	if err != nil {
+		return fmt.Errorf("failed reading manifest: %v", err)
+	}
+
 	return createOrUpdatev20180930preview(ctx, log, rpc, conf.ResourceGroup, oc, defaultManifestFile)
 }
 

--- a/cmd/createorupdate/createorupdate.go
+++ b/cmd/createorupdate/createorupdate.go
@@ -125,22 +125,20 @@ func execute(
 	conf *fakerp.Config,
 	adminManifest string,
 ) error {
-	if adminManifest != "" {
-		data, err := ioutil.ReadFile(adminManifest)
-		if err != nil {
-			return fmt.Errorf("failed reading admin manifest: %v", err)
-		}
-		var oc *admin.OpenShiftManagedCluster
-		if err := yaml.Unmarshal(data, &oc); err != nil {
-			return fmt.Errorf("failed unmarshaling admin manifest: %v", err)
-		}
-		return createOrUpdateAdmin(ctx, log, ac, conf.ResourceGroup, oc, adminManifest)
-	}
-
 	dataDir, err := shared.FindDirectory(shared.DataDirectory)
 	if err != nil {
 		return fmt.Errorf("failed to find %s: %v", shared.DataDirectory, err)
 	}
+
+	if adminManifest != "" {
+		oc, err := fakerp.GenerateManifestAdmin(adminManifest)
+		if err != nil {
+			return fmt.Errorf("failed reading admin manifest: %v", err)
+		}
+		defaultAdminManifest := filepath.Join(dataDir, "manifest-admin.yaml")
+		return createOrUpdateAdmin(ctx, log, ac, conf.ResourceGroup, oc, defaultAdminManifest)
+	}
+
 	defaultManifestFile := filepath.Join(dataDir, "manifest.yaml")
 	// TODO: Configuring this is probably not needed
 	manifest := conf.Manifest

--- a/pkg/fakerp/client/manifest.go
+++ b/pkg/fakerp/client/manifest.go
@@ -5,15 +5,12 @@ import (
 	"html/template"
 	"io/ioutil"
 	"os"
-	"path/filepath"
 	"strings"
 
 	"github.com/ghodss/yaml"
 	"github.com/pkg/errors"
-	"github.com/sirupsen/logrus"
 
 	v20180930preview "github.com/openshift/openshift-azure/pkg/api/2018-09-30-preview/api"
-	"github.com/openshift/openshift-azure/pkg/fakerp/shared"
 )
 
 func readEnv() map[string]string {
@@ -25,24 +22,6 @@ func readEnv() map[string]string {
 	return env
 }
 
-// LoadClusterConfigFromManifest reads (and potentially template) the mainifest
-func LoadClusterConfigFromManifest(log *logrus.Entry, manifestTemplate string) (*v20180930preview.OpenShiftManagedCluster, error) {
-	if shared.IsUpdate() && manifestTemplate == "" {
-		dataDir, err := shared.FindDirectory(shared.DataDirectory)
-		if err != nil {
-			return nil, err
-		}
-		defaultManifestFile := filepath.Join(dataDir, "manifest.yaml")
-		log.Debugf("using manifest from %s", defaultManifestFile)
-		return loadManifestFromFile(defaultManifestFile)
-	}
-	if manifestTemplate == "" {
-		manifestTemplate = "test/manifests/normal/create.yaml"
-	}
-	log.Debugf("generating manifest from %s", manifestTemplate)
-	return generateManifest(manifestTemplate)
-}
-
 // WriteClusterConfigToManifest write to file
 func WriteClusterConfigToManifest(oc *v20180930preview.OpenShiftManagedCluster, manifestFile string) error {
 	out, err := yaml.Marshal(oc)
@@ -52,7 +31,11 @@ func WriteClusterConfigToManifest(oc *v20180930preview.OpenShiftManagedCluster, 
 	return ioutil.WriteFile(manifestFile, out, 0666)
 }
 
-func generateManifest(manifestFile string) (*v20180930preview.OpenShiftManagedCluster, error) {
+// GenerateManifest accepts a manifest file and returns a typed OSA
+// v20180930preview struct that can be used to request OSA creates
+// and updates. If the provided manifest is templatized, it will be
+// parsed appropriately.
+func GenerateManifest(manifestFile string) (*v20180930preview.OpenShiftManagedCluster, error) {
 	t, err := template.ParseFiles(manifestFile)
 	if err != nil {
 		return nil, errors.Wrapf(err, "failed parsing the manifest %s", manifestFile)
@@ -73,20 +56,4 @@ func generateManifest(manifestFile string) (*v20180930preview.OpenShiftManagedCl
 		oc.Properties.ProvisioningState = nil
 	}
 	return oc, nil
-}
-
-func loadManifestFromFile(manifest string) (*v20180930preview.OpenShiftManagedCluster, error) {
-	in, err := ioutil.ReadFile(manifest)
-	if err != nil {
-		return nil, err
-	}
-	var oc v20180930preview.OpenShiftManagedCluster
-	if err := yaml.Unmarshal(in, &oc); err != nil {
-		return nil, err
-	}
-
-	if oc.Properties != nil {
-		oc.Properties.ProvisioningState = nil
-	}
-	return &oc, nil
 }

--- a/test/e2e/specs/fakerp/admin.go
+++ b/test/e2e/specs/fakerp/admin.go
@@ -23,7 +23,6 @@ import (
 	"github.com/openshift/openshift-azure/pkg/util/ready"
 	"github.com/openshift/openshift-azure/test/clients/azure"
 	"github.com/openshift/openshift-azure/test/clients/openshift"
-	"github.com/openshift/openshift-azure/test/util/log"
 )
 
 var _ = Describe("Openshift on Azure admin e2e tests [AzureClusterReader][Fake]", func() {
@@ -158,7 +157,7 @@ var _ = Describe("Openshift on Azure admin e2e tests [AzureClusterReader][Fake]"
 		Expect(err).ToNot(HaveOccurred())
 
 		By("ensuring the update blob has the right amount of entries")
-		external, err := fakerp.LoadClusterConfigFromManifest(log.GetTestLogger(), *manifest)
+		external, err := fakerp.GenerateManifest(*manifest)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(external).NotTo(BeNil())
 		expectedEntries := *external.Properties.MasterPoolProfile.Count

--- a/test/e2e/specs/fakerp/keyrotation.go
+++ b/test/e2e/specs/fakerp/keyrotation.go
@@ -17,7 +17,6 @@ import (
 	fakerp "github.com/openshift/openshift-azure/pkg/fakerp/client"
 	"github.com/openshift/openshift-azure/pkg/util/managedcluster"
 	"github.com/openshift/openshift-azure/test/clients/azure"
-	"github.com/openshift/openshift-azure/test/util/log"
 )
 
 var _ = Describe("Key Rotation E2E tests [KeyRotation][Fake][LongRunning]", func() {
@@ -48,7 +47,7 @@ var _ = Describe("Key Rotation E2E tests [KeyRotation][Fake][LongRunning]", func
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Parsing the external manifest")
-		external, err := fakerp.LoadClusterConfigFromManifest(log.GetTestLogger(), *manifest)
+		external, err := fakerp.GenerateManifest(*manifest)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(external).NotTo(BeNil())
 

--- a/test/e2e/specs/realrp/realrp.go
+++ b/test/e2e/specs/realrp/realrp.go
@@ -41,7 +41,7 @@ var _ = Describe("Resource provider e2e tests [Default][Real]", func() {
 		Expect(err).ToNot(HaveOccurred())
 
 		By("creating an OSA cluster")
-		config, err := client.LoadClusterConfigFromManifest(log.GetTestLogger(), "../../test/manifests/normal/create.yaml")
+		config, err := client.GenerateManifest("../../test/manifests/normal/create.yaml")
 		Expect(err).ToNot(HaveOccurred())
 		deployCtx, cancelFn := context.WithTimeout(context.Background(), 30*time.Minute)
 		defer cancelFn()

--- a/test/e2e/specs/realrp/vnetpeering.go
+++ b/test/e2e/specs/realrp/vnetpeering.go
@@ -85,7 +85,7 @@ var _ = Describe("Peer Vnet tests [Vnet][Real][LongRunning]", func() {
 		Expect(len(*vnet.VirtualNetworkPeerings)).To(Equal(0))
 
 		// load cluster config
-		config, err := client.LoadClusterConfigFromManifest(tlog.GetTestLogger(), "../../test/manifests/normal/create.yaml")
+		config, err := client.GenerateManifest("../../test/manifests/normal/create.yaml")
 		Expect(err).ToNot(HaveOccurred())
 
 		// Set pre-created peer vnetid in cluster config

--- a/test/e2e/specs/scaleupdown.go
+++ b/test/e2e/specs/scaleupdown.go
@@ -21,7 +21,6 @@ import (
 	"github.com/openshift/openshift-azure/pkg/util/ready"
 	"github.com/openshift/openshift-azure/test/clients/azure"
 	"github.com/openshift/openshift-azure/test/clients/openshift"
-	"github.com/openshift/openshift-azure/test/util/log"
 )
 
 var _ = Describe("Scale Up/Down E2E tests [ScaleUpDown][Fake][LongRunning]", func() {
@@ -57,7 +56,7 @@ var _ = Describe("Scale Up/Down E2E tests [ScaleUpDown][Fake][LongRunning]", fun
 
 	It("should be possible to maintain a healthy cluster after scaling it out and in", func() {
 		By("Fetching the scale up manifest")
-		external, err := fakerp.LoadClusterConfigFromManifest(log.GetTestLogger(), *scaleUpManifest)
+		external, err := fakerp.GenerateManifest(*scaleUpManifest)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(external).NotTo(BeNil())
 
@@ -138,7 +137,7 @@ var _ = Describe("Scale Up/Down E2E tests [ScaleUpDown][Fake][LongRunning]", fun
 		Expect(len(nodes)).To(Equal(2))
 
 		By("Fetching the scale down manifest")
-		external, err = fakerp.LoadClusterConfigFromManifest(log.GetTestLogger(), *scaleDownManifest)
+		external, err = fakerp.GenerateManifest(*scaleDownManifest)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(external).NotTo(BeNil())
 


### PR DESCRIPTION
Since defaulting is only used in createorupdate and
every test is using its own manifest, it makes sense
to simplify the helper and move the defaulting logic
in createorupdate.