### PR TITLE
Setup codecov integration

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,9 @@ endif
 cover: unit
 	go tool cover -html=coverage.out
 
+codecov: unit
+	./hack/codecov-report.sh
+
 e2e:
 	FOCUS="\[AzureClusterReader\]|\[CustomerAdmin\]|\[EndUser\]\[Fake\]" TIMEOUT=60m ./hack/e2e.sh
 

--- a/Makefile
+++ b/Makefile
@@ -89,7 +89,7 @@ verify:
 	go run ./hack/lint-addons/lint-addons.go -n
 
 unit: generate
-	go test ./... -coverprofile=coverage.out
+	go test ./... -coverprofile=coverage.out -covermode=atomic
 ifneq ($(ARTIFACT_DIR),)
 	mkdir -p $(ARTIFACT_DIR)
 	cp coverage.out $(ARTIFACT_DIR)

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 ## openshift-azure
 
+[![Coverage Status](https://codecov.io/gh/openshift/openshift-azure/branch/master/graph/badge.svg)](https://codecov.io/gh/openshift/openshift-azure)
 [![Go Report Card](https://goreportcard.com/badge/github.com/openshift/openshift-azure)](https://goreportcard.com/report/github.com/openshift/openshift-azure)
 [![GoDoc](https://godoc.org/github.com/openshift/openshift-azure?status.svg)](https://godoc.org/github.com/openshift/openshift-azure)
 

--- a/codecov.yaml
+++ b/codecov.yaml
@@ -1,0 +1,26 @@
+codecov:
+  notify:
+    require_ci_to_pass: no
+
+coverage:
+  precision: 2
+  round: down
+  range: "50...100"
+
+  status:
+    project: no
+    patch: no
+    changes: no
+
+parsers:
+  gcov:
+    branch_detection:
+      conditional: yes
+      loop: yes
+      method: no
+      macro: no
+
+comment:
+  layout: "header, diff"
+  behavior: default
+  require_changes: no

--- a/hack/codecov-report.sh
+++ b/hack/codecov-report.sh
@@ -1,0 +1,10 @@
+#!/bin/bash
+
+set -eo pipefail
+
+if [[ -z "${CODECOV_UPLOAD_TOKEN}" ]]; then
+    echo "CODECOV_UPLOAD_TOKEN must be set"
+    exit 1
+fi
+
+bash <(curl -s https://codecov.io/bash) -t ${CODECOV_UPLOAD_TOKEN} -f coverage.out


### PR DESCRIPTION
This prepares the openshift-azure project for codecov integration. 

Before merging, we need to do the following:

- [x] We need to signup for a codecov account using an openshift account not attached to any given contributor https://docs.google.com/document/d/1UxVr2py_tAup-8WQl8SJ8mZ0dBdGfSOnzUd5MLRSXcs/edit
- [x] After registering openshift-azure for codecov integration, we need to get the `report upload token` and make sure that is set in a secret mounted by our CI test containers. The `CODECOV_UPLOAD_TOKEN` environment variable should be available to the container from which `make codecov` is executed. If the instrumented repo is a private one, then `CODECOV_GRAPH_TOKEN` should also be made available.
- [x] Create a `codecov` prow job which is run before every pull request and on every branch (pre and post submits) which internally calls `make codecov` (https://github.com/openshift/release/pull/2512)

See a working example of codecov PR comments, linking, the codecov badge amongst other things at: https://github.com/charlesakalugwu/codecov/pulls?q=is%3Apr+is%3Aclosed

/cc @kargakis @mjudeikis @jim-minter 
/hold
