### PR TITLE
Validators split

### DIFF
--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/openshift/openshift-azure/pkg/addons"
 	"github.com/openshift/openshift-azure/pkg/api"
+	"github.com/openshift/openshift-azure/pkg/api/validate"
 	"github.com/openshift/openshift-azure/pkg/cluster"
 	"github.com/openshift/openshift-azure/pkg/util/azureclient"
 	azureclientstorage "github.com/openshift/openshift-azure/pkg/util/azureclient/storage"
@@ -107,7 +108,7 @@ func (s *sync) sync(ctx context.Context, log *logrus.Entry) (bool, error) {
 		return false, err
 	}
 
-	v := api.NewValidator(cs.Config.RunningUnderTest)
+	v := validate.NewAPIValidator(cs.Config.RunningUnderTest)
 	if errs := v.Validate(cs, nil, false); len(errs) > 0 {
 		return true, errors.Wrap(kerrors.NewAggregate(errs), "cannot validate _data/manifest.yaml")
 	}

--- a/pkg/api/validate/admin.go
+++ b/pkg/api/validate/admin.go
@@ -1,0 +1,31 @@
+package validate
+
+import (
+	"errors"
+
+	"github.com/openshift/openshift-azure/pkg/api"
+)
+
+// Validate validates a OpenShiftManagedCluster struct
+func (v *AdminAPIValidator) Validate(cs, oldCs *api.OpenShiftManagedCluster, externalOnly bool) (errs []error) {
+	// TODO are these error messages confusing since they may not correspond with the external model?
+	if oldCs == nil {
+		errs = append(errs, errors.New("admin requests cannot create clusters"))
+		return errs
+	}
+	if errs := validateContainerService(cs, externalOnly); len(errs) > 0 {
+		return errs
+	}
+	if errs := validateUpdateContainerService(cs, oldCs); len(errs) > 0 {
+		return errs
+	}
+	if errs := validateUpdateConfig(cs.Config, oldCs.Config); len(errs) > 0 {
+		return errs
+	}
+
+	for _, app := range cs.Properties.AgentPoolProfiles {
+		errs = append(errs, validateVMSize(app, v.runningUnderTest)...)
+	}
+
+	return nil
+}

--- a/pkg/api/validate/api.go
+++ b/pkg/api/validate/api.go
@@ -1,0 +1,18 @@
+package validate
+
+import (
+	"github.com/openshift/openshift-azure/pkg/api"
+)
+
+// Validate validates a OpenShiftManagedCluster struct
+func (v *APIValidator) Validate(cs, oldCs *api.OpenShiftManagedCluster, externalOnly bool) (errs []error) {
+	errs = append(errs, validateContainerService(cs, externalOnly)...)
+	errs = append(errs, validateUpdateContainerService(cs, oldCs)...)
+	// this limits use of RunningUnderTest variable inside our validators
+	// TODO: When removed this should be part of common validators
+	for _, app := range cs.Properties.AgentPoolProfiles {
+		errs = append(errs, validateVMSize(app, v.runningUnderTest)...)
+	}
+
+	return errs
+}

--- a/pkg/api/validate/plugin.go
+++ b/pkg/api/validate/plugin.go
@@ -1,18 +1,13 @@
-package api
+package validate
 
 import (
 	"fmt"
-	"regexp"
 
 	pluginapi "github.com/openshift/openshift-azure/pkg/api/plugin/api"
 )
 
-var (
-	imageVersion = regexp.MustCompile(`^[0-9]{3}.[0-9]{1,4}.[0-9]{8}$`)
-)
-
-// ValidatePluginTemplate validates an Plugin API external template/config struct
-func (v *Validator) ValidatePluginTemplate(t *pluginapi.Config) (errs []error) {
+// Validate validates an Plugin API external template/config struct
+func (v *PluginAPIValidator) Validate(t *pluginapi.Config) (errs []error) {
 	if t.ImageOffer != "osa" {
 		errs = append(errs, fmt.Errorf("imageOffer should be osa"))
 	}
@@ -49,12 +44,12 @@ func (v *Validator) ValidatePluginTemplate(t *pluginapi.Config) (errs []error) {
 		errs = append(errs, fmt.Errorf("genevaMetricsEndpoint cannot be empty"))
 	}
 	// validate certificates
-	errs = append(errs, v.validatePluginTemplateCertificates(t.Certificates)...)
-	errs = append(errs, v.validatePluginTemplateImages(t.Images)...)
+	errs = append(errs, v.validatePluginTemplateCertificates(&t.Certificates)...)
+	errs = append(errs, v.validatePluginTemplateImages(&t.Images)...)
 	return errs
 }
 
-func (v *Validator) validatePluginTemplateCertificates(c pluginapi.CertificateConfig) (errs []error) {
+func (v *PluginAPIValidator) validatePluginTemplateCertificates(c *pluginapi.CertificateConfig) (errs []error) {
 	if c.GenevaLogging.Key == nil {
 		errs = append(errs, fmt.Errorf("GenevaLogging key cannot be empty"))
 	} else if err := c.GenevaLogging.Key.Validate(); err != nil {
@@ -75,7 +70,7 @@ func (v *Validator) validatePluginTemplateCertificates(c pluginapi.CertificateCo
 	return errs
 }
 
-func (v *Validator) validatePluginTemplateImages(i pluginapi.ImageConfig) (errs []error) {
+func (v *PluginAPIValidator) validatePluginTemplateImages(i *pluginapi.ImageConfig) (errs []error) {
 	if i.Format == "" {
 		errs = append(errs, fmt.Errorf("images.Format cannot be empty"))
 	}

--- a/pkg/api/validate/plugin_test.go
+++ b/pkg/api/validate/plugin_test.go
@@ -1,4 +1,4 @@
-package api
+package validate
 
 import (
 	"errors"
@@ -54,8 +54,8 @@ func TestPluginTemplateValidate(t *testing.T) {
 		}
 
 	template := pluginapi.Config{}
-	v := Validator{}
-	errs := v.ValidatePluginTemplate(&template)
+	v := PluginAPIValidator{}
+	errs := v.Validate(&template)
 	if !reflect.DeepEqual(errs, expectedErrs) {
 		t.Errorf("expected errors:")
 		for _, err := range expectedErrs {

--- a/pkg/api/validate/types.go
+++ b/pkg/api/validate/types.go
@@ -1,0 +1,143 @@
+package validate
+
+import (
+	"net"
+	"regexp"
+
+	"github.com/openshift/openshift-azure/pkg/api"
+)
+
+var (
+	rxRfc1123 = regexp.MustCompile(`(?i)^` +
+		`([a-z0-9]|[a-z0-9][-a-z0-9]{0,61}[a-z0-9])` +
+		`(\.([a-z0-9]|[a-z0-9][-a-z0-9]{0,61}[a-z0-9]))*` +
+		`$`)
+
+	rxVNetID = regexp.MustCompile(`(?i)^` +
+		`/subscriptions/[^/]+` +
+		`/resourceGroups/[^/]+` +
+		`/providers/Microsoft\.Network` +
+		`/virtualNetworks/[^/]+` +
+		`$`)
+
+	rxAgentPoolProfileName = regexp.MustCompile(`^[a-z0-9]{1,12}$`)
+
+	// This regexp is to guard against InvalidDomainNameLabel for hostname validation
+	rxCloudDomainLabel = regexp.MustCompile(`^[a-z][a-z0-9-]{1,61}[a-z0-9]\.`)
+
+	// This regexp is to check image version format
+	imageVersion = regexp.MustCompile(`^[0-9]{3}.[0-9]{1,4}.[0-9]{8}$`)
+
+	validMasterAndInfraVMSizes = map[api.VMSize]struct{}{
+		// Rationale here is: a highly limited set of modern general purpose
+		// offerings which we can reason about and test for now.
+
+		// GENERAL PURPOSE VMS
+
+		api.StandardD4sV3:  {},
+		api.StandardD8sV3:  {},
+		api.StandardD16sV3: {},
+		api.StandardD32sV3: {},
+		api.StandardD64sV3: {},
+
+		// TODO: consider enabling storage optimized (Ls) series for masters and
+		// moving the etcd onto the VM SSD storage.
+
+		// TODO: enable vertical scaling of existing OSA clusters.
+	}
+
+	validComputeVMSizes = map[api.VMSize]struct{}{
+		// Rationale here is: modern offerings per (general purpose /
+		// memory-optimized / compute-optimized / storage-optimized) family,
+		// with at least 16GiB RAM, 32GiB SSD, 8 data disks, premium storage
+		// support.  GPU and HPC use cases are probably blocked for now on
+		// drivers / multiple agent pool support.
+
+		// GENERAL PURPOSE VMS
+
+		// Skiping StandardB* (burstable) VMs for now as they could be hard to
+		// reason about performance-wise.
+
+		api.StandardD4sV3:  {},
+		api.StandardD8sV3:  {},
+		api.StandardD16sV3: {},
+		api.StandardD32sV3: {},
+		api.StandardD64sV3: {},
+
+		api.StandardDS4V2: {},
+		api.StandardDS5V2: {},
+
+		// COMPUTE OPTIMIZED VMS
+
+		api.StandardF8sV2:  {},
+		api.StandardF16sV2: {},
+		api.StandardF32sV2: {},
+		api.StandardF64sV2: {},
+		api.StandardF72sV2: {},
+
+		api.StandardF8s:  {},
+		api.StandardF16s: {},
+
+		// MEMORY OPTIMIZED VMS
+
+		api.StandardE4sV3:  {},
+		api.StandardE8sV3:  {},
+		api.StandardE16sV3: {},
+		api.StandardE20sV3: {},
+		api.StandardE32sV3: {},
+		api.StandardE64sV3: {},
+
+		// Skipping StandardM* for now as they may require significant extra
+		// effort/spend to certify and support.
+
+		api.StandardGS2: {},
+		api.StandardGS3: {},
+		api.StandardGS4: {},
+		api.StandardGS5: {},
+
+		api.StandardDS12V2: {},
+		api.StandardDS13V2: {},
+		api.StandardDS14V2: {},
+		api.StandardDS15V2: {},
+
+		// STORAGE OPTIMIZED VMS
+
+		api.StandardL4s:  {},
+		api.StandardL8s:  {},
+		api.StandardL16s: {},
+		api.StandardL32s: {},
+	}
+)
+
+var (
+	clusterNetworkCIDR *net.IPNet
+	serviceNetworkCIDR *net.IPNet
+)
+
+// APIValidator validator for external API
+type APIValidator struct {
+	runningUnderTest bool
+}
+
+// AdminAPIValidator validator for external Admin API
+type AdminAPIValidator struct {
+	runningUnderTest bool
+}
+
+// PluginAPIValidator validator for external Plugin API
+type PluginAPIValidator struct{}
+
+// NewAPIValidator return instance of external API validator
+func NewAPIValidator(runningUnderTest bool) *APIValidator {
+	return &APIValidator{runningUnderTest: runningUnderTest}
+}
+
+// NewAdminValidator return instance of external Admin API validator
+func NewAdminValidator(runningUnderTest bool) *AdminAPIValidator {
+	return &AdminAPIValidator{runningUnderTest: runningUnderTest}
+}
+
+// NewPluginAPIValidator return instance of external Plugin API validator
+func NewPluginAPIValidator() *PluginAPIValidator {
+	return &PluginAPIValidator{}
+}

--- a/pkg/api/validate/update_validators.go
+++ b/pkg/api/validate/update_validators.go
@@ -1,0 +1,43 @@
+package validate
+
+import (
+	"fmt"
+	"reflect"
+
+	"github.com/go-test/deep"
+
+	"github.com/openshift/openshift-azure/pkg/api"
+)
+
+func validateUpdateContainerService(cs, oldCs *api.OpenShiftManagedCluster) (errs []error) {
+	if cs != nil && oldCs == nil {
+		return
+	}
+	newAgents := make(map[string]*api.AgentPoolProfile)
+	for i := range cs.Properties.AgentPoolProfiles {
+		newAgent := cs.Properties.AgentPoolProfiles[i]
+		newAgents[newAgent.Name] = &newAgent
+	}
+
+	old := oldCs.DeepCopy()
+
+	for i, o := range old.Properties.AgentPoolProfiles {
+		new, ok := newAgents[o.Name]
+		if !ok {
+			continue // we know we are going to fail the DeepEqual test below.
+		}
+		old.Properties.AgentPoolProfiles[i].Count = new.Count
+	}
+
+	if !reflect.DeepEqual(cs, old) {
+		errs = append(errs, fmt.Errorf("invalid change %s", deep.Equal(cs, old)))
+	}
+	return errs
+}
+
+func validateUpdateConfig(internalConfig, adminConfig api.Config) (errs []error) {
+	if !reflect.DeepEqual(internalConfig, adminConfig) {
+		errs = append(errs, fmt.Errorf("invalid change %s", deep.Equal(internalConfig, adminConfig)))
+	}
+	return
+}


### PR DESCRIPTION
This PR is proposal basis for now:

- Splits Validators to sub-package inside api package
- Splits 3 validators to separate interfaces
- has reusable validator functions for adminAPI and API
- isolates use of `RunningUnderTest` variable from validators to keep it to minimal. 

PR is built on top of https://github.com/openshift/openshift-azure/pull/922 as a follow-up 
fixes: https://github.com/openshift/openshift-azure/pull/922

/cc @jim-minter @kargakis @charlesakalugwu WDYT?