### PR TITLE
populate cluster id

### DIFF
--- a/pkg/fakerp/fakerp.go
+++ b/pkg/fakerp/fakerp.go
@@ -19,6 +19,7 @@ import (
 	"github.com/openshift/openshift-azure/pkg/plugin"
 	"github.com/openshift/openshift-azure/pkg/tls"
 	"github.com/openshift/openshift-azure/pkg/util/azureclient"
+	"github.com/openshift/openshift-azure/pkg/util/resourceid"
 )
 
 func GetDeployer(log *logrus.Entry, cs *api.OpenShiftManagedCluster, config *api.PluginConfig) api.DeployFn {
@@ -212,6 +213,8 @@ func enrich(cs *api.OpenShiftManagedCluster) error {
 		Secret:   os.Getenv("AZURE_CLIENT_SECRET"),
 	}
 
+	// /subscriptions/{subscription}/resourcegroups/{resource_group}/providers/Microsoft.ContainerService/openshiftmanagedClusters/{cluster_name}
+	cs.ID = resourceid.ResourceID(cs.Properties.AzProfile.SubscriptionID, cs.Properties.AzProfile.ResourceGroup, "Microsoft.ContainerService/openshiftmanagedClusters", cs.Name)
 	return nil
 }
 


### PR DESCRIPTION
This populates clusterID field same as realRP.

In preparation for https://github.com/openshift/openshift-azure/issues/1011 to have same data in realRP and fakeRP

/cc @jim-minter 