### PR TITLE
enable r/o cache on etcd disk

### DIFF
--- a/pkg/arm/resources.go
+++ b/pkg/arm/resources.go
@@ -582,6 +582,7 @@ func Vmss(pc *api.PluginConfig, cs *api.OpenShiftManagedCluster, app *api.AgentP
 		vmss.VirtualMachineProfile.StorageProfile.DataDisks = &[]compute.VirtualMachineScaleSetDataDisk{
 			{
 				Lun:          to.Int32Ptr(0),
+				Caching:      compute.CachingTypesReadOnly,
 				CreateOption: compute.DiskCreateOptionTypesEmpty,
 				DiskSizeGB:   to.Int32Ptr(32),
 			},


### PR DESCRIPTION
I don't think this will fundamentally change our performance, but I also think it's better on than off.