### PR TITLE
update lb rules

### DIFF
--- a/pkg/arm/arm.go
+++ b/pkg/arm/arm.go
@@ -56,7 +56,7 @@ func (g *simpleGenerator) Generate(ctx context.Context, cs *api.OpenShiftManaged
 		},
 	}
 	if !isUpdate {
-		t.Resources = append(t.Resources, ipKubernetes(cs), lbKubernetes(cs), nsgWorker(cs))
+		t.Resources = append(t.Resources, ipOutbound(cs), lbKubernetes(cs), nsgWorker(cs))
 	}
 	for _, app := range cs.Properties.AgentPoolProfiles {
 		if app.Role == api.AgentPoolProfileRoleMaster || !isUpdate {

--- a/pkg/arm/arm.go
+++ b/pkg/arm/arm.go
@@ -49,14 +49,14 @@ func (g *simpleGenerator) Generate(ctx context.Context, cs *api.OpenShiftManaged
 		Resources: []interface{}{
 			vnet(cs),
 			ipAPIServer(cs),
-			lbAPIServer(cs),
+			lbAPIServer(&g.pluginConfig, cs),
 			storageRegistry(cs),
 			storageConfig(cs),
 			nsgMaster(cs),
 		},
 	}
 	if !isUpdate {
-		t.Resources = append(t.Resources, ipOutbound(cs), lbKubernetes(cs), nsgWorker(cs))
+		t.Resources = append(t.Resources, ipOutbound(cs), lbKubernetes(&g.pluginConfig, cs), nsgWorker(cs))
 	}
 	for _, app := range cs.Properties.AgentPoolProfiles {
 		if app.Role == api.AgentPoolProfileRoleMaster || !isUpdate {

--- a/pkg/arm/resources.go
+++ b/pkg/arm/resources.go
@@ -6,7 +6,7 @@ import (
 	"strings"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-06-01/compute"
-	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-02-01/network"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-07-01/network"
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2015-06-15/storage"
 	"github.com/Azure/go-autorest/autorest/to"
 
@@ -58,7 +58,7 @@ func fixupAPIVersions(template map[string]interface{}) {
 			"Microsoft.Network/networkSecurityGroups",
 			"Microsoft.Network/publicIPAddresses",
 			"Microsoft.Network/virtualNetworks":
-			apiVersion = "2018-02-01"
+			apiVersion = "2018-07-01"
 		case "Microsoft.Storage/storageAccounts":
 			apiVersion = "2015-06-15"
 		default:
@@ -266,9 +266,9 @@ func lbAPIServer(cs *api.OpenShiftManagedCluster) *network.LoadBalancer {
 					Name: to.StringPtr(lbAPIServerProbeName),
 				},
 			},
-			InboundNatRules:  &[]network.InboundNatRule{},
-			InboundNatPools:  &[]network.InboundNatPool{},
-			OutboundNatRules: &[]network.OutboundNatRule{},
+			InboundNatRules: &[]network.InboundNatRule{},
+			InboundNatPools: &[]network.InboundNatPool{},
+			OutboundRules:   &[]network.OutboundRule{},
 		},
 		Name:     to.StringPtr(lbAPIServerName),
 		Type:     to.StringPtr("Microsoft.Network/loadBalancers"),
@@ -351,9 +351,9 @@ func lbKubernetes(cs *api.OpenShiftManagedCluster) *network.LoadBalancer {
 					Name: to.StringPtr(lbKubernetesProbeName),
 				},
 			},
-			InboundNatRules:  &[]network.InboundNatRule{},
-			InboundNatPools:  &[]network.InboundNatPool{},
-			OutboundNatRules: &[]network.OutboundNatRule{},
+			InboundNatRules: &[]network.InboundNatRule{},
+			InboundNatPools: &[]network.InboundNatPool{},
+			OutboundRules:   &[]network.OutboundRule{},
 		},
 		Name:     to.StringPtr(lbKubernetesName),
 		Type:     to.StringPtr("Microsoft.Network/loadBalancers"),

--- a/pkg/arm/resources.go
+++ b/pkg/arm/resources.go
@@ -19,28 +19,28 @@ import (
 )
 
 const (
-	VnetName                              = "vnet"
-	vnetSubnetName                        = "default"
-	ipAPIServerName                       = "ip-apiserver"
-	ipKubernetesName                      = "ip-kubernetes"
-	lbAPIServerName                       = "lb-apiserver"
-	lbAPIServerFrontendConfigurationName  = "frontend"
-	lbAPIServerBackendPoolName            = "backend"
-	lbAPIServerLoadBalancingRuleName      = "port-443"
-	lbAPIServerProbeName                  = "port-443"
-	lbKubernetesName                      = "kubernetes" // must match KubeCloudSharedConfiguration ClusterName
-	lbKubernetesFrontendConfigurationName = "outbound"
-	lbKubernetesOutboundRuleName          = "outbound"
-	lbKubernetesBackendPoolName           = "kubernetes" // must match KubeCloudSharedConfiguration ClusterName
-	nsgMasterName                         = "nsg-master"
-	nsgMasterAllowSSHRuleName             = "allow_ssh"
-	nsgMasterAllowHTTPSRuleName           = "allow_https"
-	nsgWorkerName                         = "nsg-worker"
-	vmssNicName                           = "nic"
-	vmssNicPublicIPConfigurationName      = "ip"
-	vmssIPConfigurationName               = "ipconfig"
-	vmssCSEName                           = "cse"
-	vmssAdminUsername                     = "cloud-user"
+	VnetName                                      = "vnet"
+	vnetSubnetName                                = "default"
+	ipAPIServerName                               = "ip-apiserver"
+	ipOutboundName                                = "ip-outbound"
+	lbAPIServerName                               = "lb-apiserver"
+	lbAPIServerFrontendConfigurationName          = "frontend"
+	lbAPIServerBackendPoolName                    = "backend"
+	lbAPIServerLoadBalancingRuleName              = "port-443"
+	lbAPIServerProbeName                          = "port-443"
+	lbKubernetesName                              = "kubernetes" // must match KubeCloudSharedConfiguration ClusterName
+	lbKubernetesOutboundFrontendConfigurationName = "outbound"
+	lbKubernetesOutboundRuleName                  = "outbound"
+	lbKubernetesBackendPoolName                   = "kubernetes" // must match KubeCloudSharedConfiguration ClusterName
+	nsgMasterName                                 = "nsg-master"
+	nsgMasterAllowSSHRuleName                     = "allow_ssh"
+	nsgMasterAllowHTTPSRuleName                   = "allow_https"
+	nsgWorkerName                                 = "nsg-worker"
+	vmssNicName                                   = "nic"
+	vmssNicPublicIPConfigurationName              = "ip"
+	vmssIPConfigurationName                       = "ipconfig"
+	vmssCSEName                                   = "cse"
+	vmssAdminUsername                             = "cloud-user"
 )
 
 // fixupAPIVersions inserts an apiVersion field into the ARM template for each
@@ -174,7 +174,7 @@ func ipAPIServer(cs *api.OpenShiftManagedCluster) *network.PublicIPAddress {
 	}
 }
 
-func ipKubernetes(cs *api.OpenShiftManagedCluster) *network.PublicIPAddress {
+func ipOutbound(cs *api.OpenShiftManagedCluster) *network.PublicIPAddress {
 	return &network.PublicIPAddress{
 		Sku: &network.PublicIPAddressSku{
 			Name: network.PublicIPAddressSkuNameStandard,
@@ -183,7 +183,7 @@ func ipKubernetes(cs *api.OpenShiftManagedCluster) *network.PublicIPAddress {
 			PublicIPAllocationMethod: network.Static,
 			IdleTimeoutInMinutes:     to.Int32Ptr(15),
 		},
-		Name:     to.StringPtr(ipKubernetesName),
+		Name:     to.StringPtr(ipOutboundName),
 		Type:     to.StringPtr("Microsoft.Network/publicIPAddresses"),
 		Location: to.StringPtr(cs.Location),
 	}
@@ -290,11 +290,11 @@ func lbKubernetes(cs *api.OpenShiftManagedCluster) *network.LoadBalancer {
 								cs.Properties.AzProfile.SubscriptionID,
 								cs.Properties.AzProfile.ResourceGroup,
 								"Microsoft.Network/publicIPAddresses",
-								ipKubernetesName,
+								ipOutboundName,
 							)),
 						},
 					},
-					Name: to.StringPtr(lbKubernetesFrontendConfigurationName),
+					Name: to.StringPtr(lbKubernetesOutboundFrontendConfigurationName),
 				},
 			},
 			BackendAddressPools: &[]network.BackendAddressPool{
@@ -313,7 +313,7 @@ func lbKubernetes(cs *api.OpenShiftManagedCluster) *network.LoadBalancer {
 									cs.Properties.AzProfile.ResourceGroup,
 									"Microsoft.Network/loadBalancers",
 									lbKubernetesName,
-								) + "/frontendIPConfigurations/" + lbKubernetesFrontendConfigurationName),
+								) + "/frontendIPConfigurations/" + lbKubernetesOutboundFrontendConfigurationName),
 							},
 						},
 						BackendAddressPool: &network.SubResource{

--- a/pkg/arm/resources.go
+++ b/pkg/arm/resources.go
@@ -189,8 +189,8 @@ func ipOutbound(cs *api.OpenShiftManagedCluster) *network.PublicIPAddress {
 	}
 }
 
-func lbAPIServer(cs *api.OpenShiftManagedCluster) *network.LoadBalancer {
-	return &network.LoadBalancer{
+func lbAPIServer(pc *api.PluginConfig, cs *api.OpenShiftManagedCluster) *network.LoadBalancer {
+	lb := &network.LoadBalancer{
 		Sku: &network.LoadBalancerSku{
 			Name: network.LoadBalancerSkuNameStandard,
 		},
@@ -273,10 +273,16 @@ func lbAPIServer(cs *api.OpenShiftManagedCluster) *network.LoadBalancer {
 		Type:     to.StringPtr("Microsoft.Network/loadBalancers"),
 		Location: to.StringPtr(cs.Location),
 	}
+
+	if pc.TestConfig.RunningUnderTest {
+		(*lb.LoadBalancingRules)[0].EnableTCPReset = to.BoolPtr(true)
+	}
+
+	return lb
 }
 
-func lbKubernetes(cs *api.OpenShiftManagedCluster) *network.LoadBalancer {
-	return &network.LoadBalancer{
+func lbKubernetes(pc *api.PluginConfig, cs *api.OpenShiftManagedCluster) *network.LoadBalancer {
+	lb := &network.LoadBalancer{
 		Sku: &network.LoadBalancerSku{
 			Name: network.LoadBalancerSkuNameStandard,
 		},
@@ -334,6 +340,12 @@ func lbKubernetes(cs *api.OpenShiftManagedCluster) *network.LoadBalancer {
 		Type:     to.StringPtr("Microsoft.Network/loadBalancers"),
 		Location: to.StringPtr(cs.Location),
 	}
+
+	if pc.TestConfig.RunningUnderTest {
+		(*lb.OutboundRules)[0].EnableTCPReset = to.BoolPtr(true)
+	}
+
+	return lb
 }
 
 func storageRegistry(cs *api.OpenShiftManagedCluster) *storage.Account {

--- a/pkg/arm/resources_test.go
+++ b/pkg/arm/resources_test.go
@@ -27,7 +27,7 @@ func TestFixupDepends(t *testing.T) {
 		{
 			name: "have deps, but missing resources",
 			resources: []interface{}{
-				lbAPIServer(cs),
+				lbAPIServer(&api.PluginConfig{}, cs),
 			},
 			expect: []string{},
 		},
@@ -35,7 +35,7 @@ func TestFixupDepends(t *testing.T) {
 			name: "have deps and dependent resources",
 			resources: []interface{}{
 				ipAPIServer(cs),
-				lbAPIServer(cs),
+				lbAPIServer(&api.PluginConfig{}, cs),
 			},
 			expect: []string{"/subscriptions/sess/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/ip-apiserver"},
 		},


### PR DESCRIPTION
This PR:
1) updates to use outbound rules instead of dummy inbound rules to make our worker vm internet connectivity work
2) switches on "enableTCPReset" - I'll be interested to see if this alters the behaviour of #560.  Ssee https://docs.microsoft.com/en-US/azure/load-balancer/load-balancer-tcp-reset for more info