### PR TITLE
add clusterVersion field to tracking

### DIFF
--- a/pkg/api/admin/api/config.go
+++ b/pkg/api/admin/api/config.go
@@ -7,6 +7,8 @@ import (
 )
 
 type Config struct {
+	// ClusterVersion (out) defines release version of the plugin used to build the cluster
+	ClusterVersion *string `json:"clusterVersion,omitempty"`
 	// configuration of VMs in ARM template
 	ImageOffer     *string `json:"imageOffer,omitempty"`
 	ImagePublisher *string `json:"imagePublisher,omitempty"`

--- a/pkg/api/admin/api/types_test.go
+++ b/pkg/api/admin/api/types_test.go
@@ -74,6 +74,7 @@ var marshalled = []byte(`{
 		"Tags.key": "Tags.val"
 	},
 	"config": {
+		"clusterVersion": "Config.ClusterVersion",
 		"imageOffer": "Config.ImageOffer",
 		"imagePublisher": "Config.ImagePublisher",
 		"imageSku": "Config.ImageSKU",

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -9,6 +9,8 @@ import (
 )
 
 type Config struct {
+	// ClusterVersion defines release version of the plugin used to build the cluster
+	ClusterVersion string `json:"clusterVersion,omitempty"`
 	// configuration of VMs in ARM template
 	ImageOffer     string `json:"imageOffer,omitempty"`
 	ImagePublisher string `json:"imagePublisher,omitempty"`

--- a/pkg/api/converterfromplugin.go
+++ b/pkg/api/converterfromplugin.go
@@ -11,6 +11,7 @@ func ConvertFromPlugin(in *plugin.Config, old *Config) *Config {
 	if old != nil {
 		cs = old.DeepCopy()
 	}
+	cs.ClusterVersion = in.ClusterVersion
 	// Generic offering configurables
 	cs.ImageOffer = in.ImageOffer
 	cs.ImagePublisher = in.ImagePublisher

--- a/pkg/api/converterfromplugin_test.go
+++ b/pkg/api/converterfromplugin_test.go
@@ -24,6 +24,7 @@ func internalPluginConfig() Config {
 	// internal API Config
 	return Config{
 
+		ClusterVersion: "ClusterVersion",
 		// generic Offering configuration
 		ImageOffer:     "ImageOffer",
 		ImagePublisher: "ImagePublisher",

--- a/pkg/api/convertertoadmin.go
+++ b/pkg/api/convertertoadmin.go
@@ -101,6 +101,7 @@ func ConvertToAdmin(cs *OpenShiftManagedCluster) *admin.OpenShiftManagedCluster 
 
 func convertConfigToAdmin(cs *Config) *admin.Config {
 	return &admin.Config{
+		ClusterVersion:                   &cs.ClusterVersion,
 		ImageOffer:                       &cs.ImageOffer,
 		ImagePublisher:                   &cs.ImagePublisher,
 		ImageSKU:                         &cs.ImageSKU,

--- a/pkg/api/plugin/api/config.go
+++ b/pkg/api/plugin/api/config.go
@@ -6,6 +6,8 @@ import (
 )
 
 type Config struct {
+	// ClusterVersion defines release version of the plugin used to build the cluster
+	ClusterVersion string `json:"clusterVersion,omitempty"`
 	// configuration of VMs in ARM template
 	ImageOffer     string `json:"imageOffer,omitempty"`
 	ImagePublisher string `json:"imagePublisher,omitempty"`

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -83,6 +83,7 @@ var marshalled = []byte(`{
 		"Tags.key": "Tags.val"
 	},
 	"config": {
+		"clusterVersion": "Config.ClusterVersion",
 		"imageOffer": "Config.ImageOffer",
 		"imagePublisher": "Config.ImagePublisher",
 		"imageSku": "Config.ImageSKU",
@@ -373,6 +374,7 @@ func TestAdminAPIParity(t *testing.T) {
 
 	// TODO: why don't we just include all of these in the admin type?
 	notInAdmin := []*regexp.Regexp{
+		regexp.MustCompile(`^\.Config\.ClusterVersion$`),
 		regexp.MustCompile(`^\.Config\.RunningUnderTest$`),
 		regexp.MustCompile(`^\.Config\.Images\.ImagePullSecret$`),
 		regexp.MustCompile(`^\.Properties\.AzProfile\.`),

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -374,7 +374,6 @@ func TestAdminAPIParity(t *testing.T) {
 
 	// TODO: why don't we just include all of these in the admin type?
 	notInAdmin := []*regexp.Regexp{
-		regexp.MustCompile(`^\.Config\.ClusterVersion$`),
 		regexp.MustCompile(`^\.Config\.RunningUnderTest$`),
 		regexp.MustCompile(`^\.Config\.Images\.ImagePullSecret$`),
 		regexp.MustCompile(`^\.Properties\.AzProfile\.`),

--- a/pkg/api/validate/plugin.go
+++ b/pkg/api/validate/plugin.go
@@ -2,14 +2,8 @@ package validate
 
 import (
 	"fmt"
-	"regexp"
 
 	pluginapi "github.com/openshift/openshift-azure/pkg/api/plugin/api"
-)
-
-var (
-	imageVersion   = regexp.MustCompile(`^[0-9]{3}.[0-9]{1,4}.[0-9]{8}$`)
-	clusterVersion = regexp.MustCompile(`^v\d+\.\d+$`)
 )
 
 // Validate validates an Plugin API external template/config struct

--- a/pkg/api/validate/plugin.go
+++ b/pkg/api/validate/plugin.go
@@ -2,8 +2,14 @@ package validate
 
 import (
 	"fmt"
+	"regexp"
 
 	pluginapi "github.com/openshift/openshift-azure/pkg/api/plugin/api"
+)
+
+var (
+	imageVersion   = regexp.MustCompile(`^[0-9]{3}.[0-9]{1,4}.[0-9]{8}$`)
+	clusterVersion = regexp.MustCompile(`^v\d+\.\d+$`)
 )
 
 // Validate validates an Plugin API external template/config struct
@@ -19,6 +25,10 @@ func (v *PluginAPIValidator) Validate(t *pluginapi.Config) (errs []error) {
 	case "osa_311":
 	default:
 		errs = append(errs, fmt.Errorf("invalid ImageSKU %q", t.ImageSKU))
+	}
+	// validate ClusterVersion
+	if !clusterVersion.MatchString(t.ClusterVersion) {
+		errs = append(errs, fmt.Errorf("invalid ClusterVersion %q", t.ClusterVersion))
 	}
 	// validate ImageVersion
 	if !imageVersion.MatchString(t.ImageVersion) {

--- a/pkg/api/validate/plugin_test.go
+++ b/pkg/api/validate/plugin_test.go
@@ -10,7 +10,8 @@ import (
 
 func TestPluginTemplateValidate(t *testing.T) {
 	expectedErrs :=
-		[]error{errors.New(`imageOffer should be osa`),
+		[]error{errors.New(`invalid ClusterVersion ""`),
+			errors.New(`imageOffer should be osa`),
 			errors.New(`imagePublisher should be redhat`),
 			errors.New(`invalid ImageSKU ""`),
 			errors.New(`invalid ImageVersion ""`),

--- a/pkg/api/validate/plugin_test.go
+++ b/pkg/api/validate/plugin_test.go
@@ -10,10 +10,10 @@ import (
 
 func TestPluginTemplateValidate(t *testing.T) {
 	expectedErrs :=
-		[]error{errors.New(`invalid ClusterVersion ""`),
-			errors.New(`imageOffer should be osa`),
+		[]error{errors.New(`imageOffer should be osa`),
 			errors.New(`imagePublisher should be redhat`),
 			errors.New(`invalid ImageSKU ""`),
+			errors.New(`invalid ClusterVersion ""`),
 			errors.New(`invalid ImageVersion ""`),
 			errors.New(`genevaLoggingSector cannot be empty`),
 			errors.New(`genevaLoggingAccount cannot be empty`),

--- a/pkg/api/validate/types.go
+++ b/pkg/api/validate/types.go
@@ -25,9 +25,6 @@ var (
 	// This regexp is to guard against InvalidDomainNameLabel for hostname validation
 	rxCloudDomainLabel = regexp.MustCompile(`^[a-z][a-z0-9-]{1,61}[a-z0-9]\.`)
 
-	// This regexp is to check image version format
-	imageVersion = regexp.MustCompile(`^[0-9]{3}.[0-9]{1,4}.[0-9]{8}$`)
-
 	validMasterAndInfraVMSizes = map[api.VMSize]struct{}{
 		// Rationale here is: a highly limited set of modern general purpose
 		// offerings which we can reason about and test for now.

--- a/pkg/api/validate/types.go
+++ b/pkg/api/validate/types.go
@@ -25,6 +25,12 @@ var (
 	// This regexp is to guard against InvalidDomainNameLabel for hostname validation
 	rxCloudDomainLabel = regexp.MustCompile(`^[a-z][a-z0-9-]{1,61}[a-z0-9]\.`)
 
+	// This regexp is to check image version format
+	imageVersion = regexp.MustCompile(`^[0-9]{3}.[0-9]{1,4}.[0-9]{8}$`)
+
+	// This regexp is to check cluster version (plugin) format
+	clusterVersion = regexp.MustCompile(`^v\d+\.\d+$`)
+
 	validMasterAndInfraVMSizes = map[api.VMSize]struct{}{
 		// Rationale here is: a highly limited set of modern general purpose
 		// offerings which we can reason about and test for now.

--- a/pkg/api/validate/types_test.go
+++ b/pkg/api/validate/types_test.go
@@ -1,0 +1,54 @@
+package validate
+
+import "testing"
+
+func TestValidateImageVersion(t *testing.T) {
+	invalidVersions := []string{
+		".1.1",
+		"1.1",
+		"1.1.123456789",
+		"1.12345.1",
+		"1234.1.1",
+		"1.1",
+		"1",
+	}
+	for _, invalidVersion := range invalidVersions {
+		if imageVersion.MatchString(invalidVersion) {
+			t.Errorf("invalid Version passed test: %s", invalidVersion)
+		}
+	}
+	validVersions := []string{
+		"123.1.12345678",
+		"123.123.12345678",
+		"123.1234.12345678",
+	}
+	for _, validVersion := range validVersions {
+		if !imageVersion.MatchString(validVersion) {
+			t.Errorf("valid Version failed to test: %s", validVersion)
+		}
+	}
+}
+
+func TestValidateClusterVersion(t *testing.T) {
+	invalidVersions := []string{
+		".1.1",
+		"1.1",
+		"1.1.1",
+		"v1",
+		"v1.0.0",
+	}
+	for _, invalidVersion := range invalidVersions {
+		if clusterVersion.MatchString(invalidVersion) {
+			t.Errorf("invalid Version passed test: %s", invalidVersion)
+		}
+	}
+	validVersions := []string{
+		"v1.0",
+		"v123.123456789",
+	}
+	for _, validVersion := range validVersions {
+		if !clusterVersion.MatchString(validVersion) {
+			t.Errorf("valid Version failed to test: %s", validVersion)
+		}
+	}
+}

--- a/pluginconfig/pluginconfig-311.yaml
+++ b/pluginconfig/pluginconfig-311.yaml
@@ -12,6 +12,7 @@
   #  key: <Geveva metrics key value. Base64 in YAML, rsa.PrivateKey in struct>
   #  cert: <Geveva metrics certificate value. Format: Base64 in YAML, x509.Certificate struct>
 ## Geneva integration other details
+clusterVersion: v0.0
 genevaLoggingAccount: ccpopenshiftdiag
 genevaLoggingControlPlaneAccount: RPOpenShiftAccount
 genevaLoggingNamespace: CCPOpenShift

--- a/test/e2e/specs/fakerp/admin_api.go
+++ b/test/e2e/specs/fakerp/admin_api.go
@@ -1,0 +1,45 @@
+package fakerp
+
+import (
+	"context"
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/Azure/go-autorest/autorest/to"
+
+	"github.com/openshift/openshift-azure/test/clients/azure"
+)
+
+var _ = Describe("Validate AdimAPI field readability [AdminAPI][Fake]", func() {
+	var (
+		cli *azure.Client
+	)
+
+	BeforeEach(func() {
+		var err error
+		cli, err = azure.NewClientFromEnvironment(false)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should not be possible to update clusterVersion using AdminAPI", func() {
+		By("Reading the cluster state")
+		before, err := cli.OpenShiftManagedClustersAdmin.Get(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(before).NotTo(BeNil())
+		Expect(before.Config.ClusterVersion).To(BeEquivalentTo(to.StringPtr("v0.0")))
+
+		By("Updating the cluster state")
+		before.Config.ClusterVersion = to.StringPtr("v0.1")
+		update, err := cli.OpenShiftManagedClustersAdmin.CreateOrUpdate(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"), before)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(update).NotTo(BeNil())
+
+		By("Reading the cluster state")
+		after, err := cli.OpenShiftManagedClustersAdmin.Get(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(after).NotTo(BeNil())
+		Expect(after.Config.ClusterVersion).To(BeEquivalentTo(to.StringPtr("v0.0")))
+	})
+})


### PR DESCRIPTION
This adds an internal version field to tracking plugin code versions we will use for the release process. 
Was considering adding it into the main `ManagedOpenshiftCluster` object, but because its total internal type did it in the `Config` struct instead. 

https://docs.google.com/document/d/1einHXiv6r6tI5i1ce_PkZybmCYOWAqtYz5bgzWhKr5Q/edit#heading=h.6jiuaxjhr1fc

/cc @jim-minter 