### PR TITLE
Avoid setting VMScaleSetVMReimageInput during master VM reimaging

### DIFF
--- a/pkg/cluster/update_master.go
+++ b/pkg/cluster/update_master.go
@@ -6,7 +6,6 @@ import (
 	"sort"
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-06-01/compute"
-	"github.com/Azure/go-autorest/autorest/to"
 
 	"github.com/openshift/openshift-azure/pkg/api"
 	"github.com/openshift/openshift-azure/pkg/cluster/kubeclient"
@@ -76,7 +75,7 @@ func (u *simpleUpgrader) UpdateMasterAgentPool(ctx context.Context, cs *api.Open
 		}
 
 		u.log.Infof("reimaging %s", computerName)
-		err = u.vmc.Reimage(ctx, cs.Properties.AzProfile.ResourceGroup, ssName, *vm.InstanceID, &compute.VirtualMachineScaleSetVMReimageParameters{TempDisk: to.BoolPtr(true)})
+		err = u.vmc.Reimage(ctx, cs.Properties.AzProfile.ResourceGroup, ssName, *vm.InstanceID, nil)
 		if err != nil {
 			return &api.PluginError{Err: err, Step: api.PluginStepUpdateMasterAgentPoolReimage}
 		}

--- a/pkg/cluster/update_master_test.go
+++ b/pkg/cluster/update_master_test.go
@@ -181,7 +181,7 @@ func TestUpdateMasterAgentPool(t *testing.T) {
 				}).Return(nil).After(c)
 
 				// 4. reimage
-				c = vmc.EXPECT().Reimage(ctx, tt.cs.Properties.AzProfile.ResourceGroup, "ss-master", *vm.InstanceID, &compute.VirtualMachineScaleSetVMReimageParameters{TempDisk: to.BoolPtr(true)}).Return(nil).After(c)
+				c = vmc.EXPECT().Reimage(ctx, tt.cs.Properties.AzProfile.ResourceGroup, "ss-master", *vm.InstanceID, nil).Return(nil).After(c)
 
 				// 5. start
 				c = vmc.EXPECT().Start(ctx, tt.cs.Properties.AzProfile.ResourceGroup, "ss-master", *vm.InstanceID).Return(nil).After(c)


### PR DESCRIPTION
closes #1068

/cc @jim-minter @kargakis @asalkeld @mjudeikis 