### PR TITLE
DNS refactor in preparation for vanity domains.

### DIFF
--- a/pkg/cluster/healthcheck.go
+++ b/pkg/cluster/healthcheck.go
@@ -67,11 +67,18 @@ func (u *simpleUpgrader) HealthCheck(ctx context.Context, cs *api.OpenShiftManag
 
 	u.log.Info("checking developer console health")
 	err = u.doHealthCheck(ctx, getHealthCheckHTTPClient(cs), "https://"+cs.Properties.FQDN+"/console/", 10*time.Second)
-	if err != nil {
-		return err
-	}
-	u.log.Info("checking admin console health")
-	return u.doHealthCheck(ctx, getHealthCheckHTTPClient(cs), "https://console."+cs.Properties.RouterProfiles[0].PublicSubdomain, 10*time.Second)
+	return err
+
+	// currently this makes a tcp connection to console.publicsubdomain:443 then
+	// issues a GET with Host header console.publicsubdomain
+
+	// in the future when we enable vanity domains, the end user won't have
+	// created the publicsubdomain record yet, so this will need to make a tcp
+	// connection to console.fqdn:443 with an SNI header set to
+	// console.publicsubdomain,then issue a GET with Host header
+	// console.publicsubdomain
+	// u.log.Info("checking admin console health")
+	// return u.doHealthCheck(ctx, getHealthCheckHTTPClient(cs), "https://console."+cs.Properties.RouterProfiles[0].PublicSubdomain, 10*time.Second)
 }
 
 func (u *simpleUpgrader) WaitForHealthzStatusOk(ctx context.Context, cs *api.OpenShiftManagedCluster) error {

--- a/test/manifests/normal/create.yaml
+++ b/test/manifests/normal/create.yaml
@@ -15,6 +15,8 @@ properties:
     vnetCidr: 10.0.0.0/8
   routerProfiles:
   - name: default
+    publicSubdomain: "{{ .Env.ROUTER_SUBDOMAIN }}"
+    fqdn: "{{ .Env.ROUTER_FQDN }}"
   masterPoolProfile:
     count: 3
     vmSize: {{if eq (index .Env "RUNNING_UNDER_TEST") "true" }}Standard_D2s_v3{{else}}Standard_D4s_v3{{end}}


### PR DESCRIPTION
In preparation for the upcoming work for vanity domains, we would like to align our DNS setup to mirror what the real RP does.  This includes creating a DNS zone with a random name and placing it inside of the resource group beside the cluster.