### PR TITLE
Add AdminUpdating provisioning state

### DIFF
--- a/pkg/api/2018-09-30-preview/api/types.go
+++ b/pkg/api/2018-09-30-preview/api/types.go
@@ -74,6 +74,8 @@ const (
 	Creating ProvisioningState = "Creating"
 	// Updating means the existing OSA resource is being updated.
 	Updating ProvisioningState = "Updating"
+	// AdminUpdating means the existing OSA resource is being updated with admin privileges.
+	AdminUpdating ProvisioningState = "AdminUpdating"
 	// Failed means the OSA resource is in failed state.
 	Failed ProvisioningState = "Failed"
 	// Succeeded means the last create/update succeeded.

--- a/pkg/api/admin/api/types.go
+++ b/pkg/api/admin/api/types.go
@@ -76,6 +76,8 @@ const (
 	Creating ProvisioningState = "Creating"
 	// Updating means the existing OSA resource is being updated.
 	Updating ProvisioningState = "Updating"
+	// AdminUpdating means the existing OSA resource is being updated with admin privileges.
+	AdminUpdating ProvisioningState = "AdminUpdating"
 	// Failed means the OSA resource is in failed state.
 	Failed ProvisioningState = "Failed"
 	// Succeeded means the last create/update succeeded.

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -71,6 +71,8 @@ const (
 	Creating ProvisioningState = "Creating"
 	// Updating means the existing OSA resource is being updated.
 	Updating ProvisioningState = "Updating"
+	// AdminUpdating means the existing OSA resource is being updated with admin privileges.
+	AdminUpdating ProvisioningState = "AdminUpdating"
 	// Failed means the OSA resource is in failed state.
 	Failed ProvisioningState = "Failed"
 	// Succeeded means the last create/update succeeded.

--- a/pkg/api/validate/validators.go
+++ b/pkg/api/validate/validators.go
@@ -314,6 +314,7 @@ func validateProvisioningState(ps api.ProvisioningState) (errs []error) {
 	case "",
 		api.Creating,
 		api.Updating,
+		api.AdminUpdating,
 		api.Failed,
 		api.Succeeded,
 		api.Deleting,

--- a/pkg/fakerp/admin_handlers.go
+++ b/pkg/fakerp/admin_handlers.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/storage"
 
+	internalapi "github.com/openshift/openshift-azure/pkg/api"
 	"github.com/openshift/openshift-azure/pkg/cluster"
 	"github.com/openshift/openshift-azure/pkg/util/cloudprovider"
 	"github.com/openshift/openshift-azure/pkg/util/configblob"
@@ -19,6 +20,7 @@ func (s *Server) handleGetControlPlanePods(w http.ResponseWriter, req *http.Requ
 		s.internalError(w, "Failed to read the internal config")
 		return
 	}
+	s.writeState(internalapi.AdminUpdating)
 	ctx := enrichContext(context.Background())
 	pods, err := s.plugin.GetControlPlanePods(ctx, cs)
 	if err != nil {
@@ -83,6 +85,7 @@ func (s *Server) handleRestore(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	s.writeState(internalapi.AdminUpdating)
 	ctx = enrichContext(context.Background())
 	deployer := GetDeployer(s.log, cs, s.pluginConfig)
 	if err := s.plugin.RecoverEtcdCluster(ctx, cs, deployer, blobName); err != nil {
@@ -100,6 +103,7 @@ func (s *Server) handleRotateSecrets(w http.ResponseWriter, req *http.Request) {
 		s.internalError(w, "Failed to read the internal config")
 		return
 	}
+	s.writeState(internalapi.AdminUpdating)
 	ctx := enrichContext(context.Background())
 	deployer := GetDeployer(s.log, cs, s.pluginConfig)
 	if err := s.plugin.RotateClusterSecrets(ctx, cs, deployer, s.pluginTemplate); err != nil {

--- a/pkg/fakerp/util.go
+++ b/pkg/fakerp/util.go
@@ -26,3 +26,8 @@ func readBlobName(req *http.Request) (string, error) {
 	}
 	return strings.Trim(string(data), "\""), nil
 }
+
+func (s *Server) isAdminRequest(req *http.Request) bool {
+	// TODO: Align with the production RP once it supports the admin API
+	return strings.HasPrefix(req.URL.Path, "/admin")
+}


### PR DESCRIPTION
This adds the `AdminUpdating` provisioning state to the internal api types. This will "allow us as engineers to look up clusters logs and distinguish between a regular update operation and an admin update operation. Also it will be used to block a regular put operation when an admin update operation is ongoing."

closes #1058 

/cc @mjudeikis @Makdaam @jim-minter 