### PR TITLE
[wip] Geneva action run command

### DIFF
--- a/pkg/api/plugin.go
+++ b/pkg/api/plugin.go
@@ -4,6 +4,8 @@ package api
 import (
 	"context"
 
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
+
 	plugin "github.com/openshift/openshift-azure/pkg/api/plugin/api"
 )
 
@@ -121,4 +123,16 @@ type GenevaActions interface {
 
 	// GetControlPlanePods fetches a consolidated list of the control plane pods in the cluster
 	GetControlPlanePods(ctx context.Context, oc *OpenShiftManagedCluster) ([]byte, error)
+
+	// RunGenericCommand runs a generic command on a specific VM in a given scale set in the cluster
+	RunGenericCommand(ctx context.Context, oc *OpenShiftManagedCluster, scalesetName, instanceId string, parameters compute.RunCommandInput) ([]byte, error)
+
+	// RestartDocker restarts docker on a specific VM in a given scale set in the cluster
+	RestartDocker(ctx context.Context, oc *OpenShiftManagedCluster, scalesetName, instanceId string) ([]byte, error)
+
+	// RestartKubelet restarts the kubelet on a specific VM in a given scale set in the cluster
+	RestartKubelet(ctx context.Context, oc *OpenShiftManagedCluster, scalesetName, instanceId string) ([]byte, error)
+
+	// RestartNetworkManager restarts network manager on a specific VM in a given scale set in the cluster
+	RestartNetworkManager(ctx context.Context, oc *OpenShiftManagedCluster, scalesetName, instanceId string) ([]byte, error)
 }

--- a/pkg/cluster/runcommand.go
+++ b/pkg/cluster/runcommand.go
@@ -1,0 +1,42 @@
+package cluster
+
+import (
+	"context"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
+	"github.com/Azure/go-autorest/autorest/to"
+
+	"github.com/openshift/openshift-azure/pkg/api"
+)
+
+func (u *simpleUpgrader) RunCommand(ctx context.Context, oc *api.OpenShiftManagedCluster, scaleSetName, instanceId string, parameters compute.RunCommandInput) (compute.RunCommandResult, *api.PluginError) {
+	result, err := u.vmc.RunCommand(ctx, oc.Properties.AzProfile.ResourceGroup, scaleSetName, instanceId, parameters)
+	if err != nil {
+		return result, &api.PluginError{Err: err, Step: "RunGenericCommand"}
+	}
+	return result, nil
+}
+
+func (u *simpleUpgrader) RestartDocker(ctx context.Context, oc *api.OpenShiftManagedCluster, scaleSetName, instanceId string) (compute.RunCommandResult, *api.PluginError) {
+	params := compute.RunCommandInput{
+		CommandID: to.StringPtr("RunShellScript"),
+		Script:    to.StringSlicePtr([]string{"systemctl restart docker.service"}),
+	}
+	return u.RunCommand(ctx, oc, scaleSetName, instanceId, params)
+}
+
+func (u *simpleUpgrader) RestartKubelet(ctx context.Context, oc *api.OpenShiftManagedCluster, scaleSetName, instanceId string) (compute.RunCommandResult, *api.PluginError) {
+	params := compute.RunCommandInput{
+		CommandID: to.StringPtr("RunShellScript"),
+		Script:    to.StringSlicePtr([]string{"systemctl restart atomic-openshift-node.service"}),
+	}
+	return u.RunCommand(ctx, oc, scaleSetName, instanceId, params)
+}
+
+func (u *simpleUpgrader) RestartNetworkManager(ctx context.Context, oc *api.OpenShiftManagedCluster, scaleSetName, instanceId string) (compute.RunCommandResult, *api.PluginError) {
+	params := compute.RunCommandInput{
+		CommandID: to.StringPtr("RunShellScript"),
+		Script:    to.StringSlicePtr([]string{"systemctl restart NetworkManager.service"}),
+	}
+	return u.RunCommand(ctx, oc, scaleSetName, instanceId, params)
+}

--- a/pkg/cluster/types.go
+++ b/pkg/cluster/types.go
@@ -12,6 +12,7 @@ import (
 	"crypto/x509"
 	"net/http"
 
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
 	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/openshift-azure/pkg/api"
@@ -42,6 +43,10 @@ type Upgrader interface {
 	UpdateWorkerAgentPool(ctx context.Context, cs *api.OpenShiftManagedCluster, app *api.AgentPoolProfile, suffix string) *api.PluginError
 	EtcdRestoreDeleteMasterScaleSet(ctx context.Context, cs *api.OpenShiftManagedCluster) *api.PluginError
 	EtcdRestoreDeleteMasterScaleSetHashes(ctx context.Context, cs *api.OpenShiftManagedCluster) *api.PluginError
+	RunCommand(ctx context.Context, oc *api.OpenShiftManagedCluster, scaleSetName, instanceId string, parameters compute.RunCommandInput) (compute.RunCommandResult, *api.PluginError)
+	RestartDocker(ctx context.Context, oc *api.OpenShiftManagedCluster, scaleSetName, instanceId string) (compute.RunCommandResult, *api.PluginError)
+	RestartKubelet(ctx context.Context, oc *api.OpenShiftManagedCluster, scaleSetName, instanceId string) (compute.RunCommandResult, *api.PluginError)
+	RestartNetworkManager(ctx context.Context, oc *api.OpenShiftManagedCluster, scaleSetName, instanceId string) (compute.RunCommandResult, *api.PluginError)
 }
 
 type simpleUpgrader struct {

--- a/pkg/fakerp/routes.go
+++ b/pkg/fakerp/routes.go
@@ -22,4 +22,8 @@ func (s *Server) SetupRoutes() {
 	s.router.Put(filepath.Join("/admin", s.basePath, "/restore"), s.handleRestore)
 	s.router.Put(filepath.Join("/admin", s.basePath, "/rotate/secrets"), s.handleRotateSecrets)
 	s.router.Get(filepath.Join("/admin", s.basePath, "/status"), s.handleGetControlPlanePods)
+	s.router.Put(filepath.Join("/admin", s.basePath, "/restartDocker/{scaleSetName}/{instanceId}"), s.handleRestartDocker)
+	s.router.Put(filepath.Join("/admin", s.basePath, "/restartKubelet/{scaleSetName}/{instanceId}"), s.handleRestartKubelet)
+	s.router.Put(filepath.Join("/admin", s.basePath, "/restartNetworkManager/{scaleSetName}/{instanceId}"), s.handleRestartNetworkManager)
+	s.router.Put(filepath.Join("/admin", s.basePath, "/runCommand/{scaleSetName}/{instanceId}"), s.handleRunCommand)
 }

--- a/pkg/fakerp/util.go
+++ b/pkg/fakerp/util.go
@@ -1,10 +1,13 @@
 package fakerp
 
 import (
+	"encoding/json"
 	"fmt"
 	"io/ioutil"
 	"net/http"
 	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
 )
 
 func (s *Server) badRequest(w http.ResponseWriter, msg string) {
@@ -25,6 +28,16 @@ func readBlobName(req *http.Request) (string, error) {
 		return "", fmt.Errorf("failed to read request body: %v", err)
 	}
 	return strings.Trim(string(data), "\""), nil
+}
+
+func readCommandInput(req *http.Request) (*compute.RunCommandInput, error) {
+	data, err := ioutil.ReadAll(req.Body)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read request body: %v", err)
+	}
+	var params *compute.RunCommandInput
+	err = json.Unmarshal(data, params)
+	return params, err
 }
 
 func (s *Server) isAdminRequest(req *http.Request) bool {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"time"
 
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
 	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/openshift-azure/pkg/api"
@@ -239,4 +240,60 @@ func (p *plugin) GetControlPlanePods(ctx context.Context, oc *api.OpenShiftManag
 		return nil, err
 	}
 	return json.Marshal(pods)
+}
+
+func (p *plugin) RunGenericCommand(ctx context.Context, oc *api.OpenShiftManagedCluster, scalesetName, instanceId string, parameters compute.RunCommandInput) ([]byte, error) {
+	p.log.Info("creating clients")
+	err := p.clusterUpgrader.CreateClients(ctx, oc, true)
+	if err != nil {
+		return nil, err
+	}
+	p.log.Infof("running command %v on %s in %s", parameters, instanceId, scalesetName)
+	result, err := p.clusterUpgrader.RunCommand(ctx, oc, scalesetName, instanceId, parameters)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(result)
+}
+
+func (p *plugin) RestartDocker(ctx context.Context, oc *api.OpenShiftManagedCluster, scalesetName, instanceId string) ([]byte, error) {
+	p.log.Info("creating clients")
+	err := p.clusterUpgrader.CreateClients(ctx, oc, true)
+	if err != nil {
+		return nil, err
+	}
+	p.log.Infof("restarting docker on %s in %s", instanceId, scalesetName)
+	result, err := p.clusterUpgrader.RestartDocker(ctx, oc, scalesetName, instanceId)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(result)
+}
+
+func (p *plugin) RestartKubelet(ctx context.Context, oc *api.OpenShiftManagedCluster, scalesetName, instanceId string) ([]byte, error) {
+	p.log.Info("creating clients")
+	err := p.clusterUpgrader.CreateClients(ctx, oc, true)
+	if err != nil {
+		return nil, err
+	}
+	p.log.Infof("restarting kubelet on %s in %s", instanceId, scalesetName)
+	result, err := p.clusterUpgrader.RestartKubelet(ctx, oc, scalesetName, instanceId)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(result)
+}
+
+func (p *plugin) RestartNetworkManager(ctx context.Context, oc *api.OpenShiftManagedCluster, scalesetName, instanceId string) ([]byte, error) {
+	p.log.Info("creating clients")
+	err := p.clusterUpgrader.CreateClients(ctx, oc, true)
+	if err != nil {
+		return nil, err
+	}
+	p.log.Infof("restarting network manager on %s in %s", instanceId, scalesetName)
+	result, err := p.clusterUpgrader.RestartNetworkManager(ctx, oc, scalesetName, instanceId)
+	if err != nil {
+		return nil, err
+	}
+	return json.Marshal(result)
 }

--- a/pkg/util/azureclient/compute.go
+++ b/pkg/util/azureclient/compute.go
@@ -36,6 +36,7 @@ func (c *virtualMachineScaleSetsClient) Client() autorest.Client {
 // VirtualMachineScaleSetVMsClient is a minimal interface for azure VirtualMachineScaleSetVMsClient
 type VirtualMachineScaleSetVMsClient interface {
 	VirtualMachineScaleSetVMsClientAddons
+	Client
 }
 
 type virtualMachineScaleSetVMsClient struct {

--- a/pkg/util/azureclient/compute_addons.go
+++ b/pkg/util/azureclient/compute_addons.go
@@ -76,9 +76,9 @@ type VirtualMachineScaleSetVMsClientAddons interface {
 	Delete(ctx context.Context, resourceGroupName, VMScaleSetName, instanceID string) error
 	List(ctx context.Context, resourceGroupName, virtualMachineScaleSetName, filter, selectParameter, expand string) ([]compute.VirtualMachineScaleSetVM, error)
 	Reimage(ctx context.Context, resourceGroupName, VMScaleSetName, instanceID string, VMScaleSetVMReimageInput *compute.VirtualMachineScaleSetVMReimageParameters) error
-	ReimageAll(ctx context.Context, resourceGroupName string, VMScaleSetName string, instanceID string) (result compute.VirtualMachineScaleSetVMsReimageAllFuture, err error)
 	Restart(ctx context.Context, resourceGroupName, VMScaleSetName, instanceID string) error
 	Start(ctx context.Context, resourceGroupName, VMScaleSetName, instanceID string) error
+	RunCommand(ctx context.Context, resourceGroupName string, VMScaleSetName string, instanceID string, parameters compute.RunCommandInput) (compute.RunCommandResult, error)
 }
 
 func (c *virtualMachineScaleSetVMsClient) Deallocate(ctx context.Context, resourceGroupName, VMScaleSetName, instanceID string) error {
@@ -143,4 +143,18 @@ func (c *virtualMachineScaleSetVMsClient) Start(ctx context.Context, resourceGro
 	}
 
 	return future.WaitForCompletionRef(ctx, c.VirtualMachineScaleSetVMsClient.Client)
+}
+
+func (c *virtualMachineScaleSetVMsClient) RunCommand(ctx context.Context, resourceGroupName string, VMScaleSetName string, instanceID string, parameters compute.RunCommandInput) (compute.RunCommandResult, error) {
+	var result compute.RunCommandResult
+	future, err := c.VirtualMachineScaleSetVMsClient.RunCommand(ctx, resourceGroupName, VMScaleSetName, instanceID, parameters)
+	if err != nil {
+		return result, err
+	}
+	err = future.WaitForCompletionRef(ctx, c.VirtualMachineScaleSetVMsClient.Client)
+
+	if err != nil {
+		return result, err
+	}
+	return future.Result(c.VirtualMachineScaleSetVMsClient)
 }

--- a/pkg/util/mocks/mock_azureclient/azureclient.go
+++ b/pkg/util/mocks/mock_azureclient/azureclient.go
@@ -185,6 +185,20 @@ func (m *MockVirtualMachineScaleSetVMsClient) EXPECT() *MockVirtualMachineScaleS
 	return m.recorder
 }
 
+// Client mocks base method
+func (m *MockVirtualMachineScaleSetVMsClient) Client() autorest.Client {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Client")
+	ret0, _ := ret[0].(autorest.Client)
+	return ret0
+}
+
+// Client indicates an expected call of Client
+func (mr *MockVirtualMachineScaleSetVMsClientMockRecorder) Client() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Client", reflect.TypeOf((*MockVirtualMachineScaleSetVMsClient)(nil).Client))
+}
+
 // Deallocate mocks base method
 func (m *MockVirtualMachineScaleSetVMsClient) Deallocate(arg0 context.Context, arg1, arg2, arg3 string) error {
 	m.ctrl.T.Helper()
@@ -242,21 +256,6 @@ func (mr *MockVirtualMachineScaleSetVMsClientMockRecorder) Reimage(arg0, arg1, a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reimage", reflect.TypeOf((*MockVirtualMachineScaleSetVMsClient)(nil).Reimage), arg0, arg1, arg2, arg3, arg4)
 }
 
-// ReimageAll mocks base method
-func (m *MockVirtualMachineScaleSetVMsClient) ReimageAll(arg0 context.Context, arg1, arg2, arg3 string) (compute.VirtualMachineScaleSetVMsReimageAllFuture, error) {
-	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "ReimageAll", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(compute.VirtualMachineScaleSetVMsReimageAllFuture)
-	ret1, _ := ret[1].(error)
-	return ret0, ret1
-}
-
-// ReimageAll indicates an expected call of ReimageAll
-func (mr *MockVirtualMachineScaleSetVMsClientMockRecorder) ReimageAll(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
-	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReimageAll", reflect.TypeOf((*MockVirtualMachineScaleSetVMsClient)(nil).ReimageAll), arg0, arg1, arg2, arg3)
-}
-
 // Restart mocks base method
 func (m *MockVirtualMachineScaleSetVMsClient) Restart(arg0 context.Context, arg1, arg2, arg3 string) error {
 	m.ctrl.T.Helper()
@@ -269,6 +268,21 @@ func (m *MockVirtualMachineScaleSetVMsClient) Restart(arg0 context.Context, arg1
 func (mr *MockVirtualMachineScaleSetVMsClientMockRecorder) Restart(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Restart", reflect.TypeOf((*MockVirtualMachineScaleSetVMsClient)(nil).Restart), arg0, arg1, arg2, arg3)
+}
+
+// RunCommand mocks base method
+func (m *MockVirtualMachineScaleSetVMsClient) RunCommand(arg0 context.Context, arg1, arg2, arg3 string, arg4 compute.RunCommandInput) (compute.RunCommandResult, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RunCommand", arg0, arg1, arg2, arg3, arg4)
+	ret0, _ := ret[0].(compute.RunCommandResult)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// RunCommand indicates an expected call of RunCommand
+func (mr *MockVirtualMachineScaleSetVMsClientMockRecorder) RunCommand(arg0, arg1, arg2, arg3, arg4 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunCommand", reflect.TypeOf((*MockVirtualMachineScaleSetVMsClient)(nil).RunCommand), arg0, arg1, arg2, arg3, arg4)
 }
 
 // Start mocks base method

--- a/pkg/util/mocks/mock_cluster/types.go
+++ b/pkg/util/mocks/mock_cluster/types.go
@@ -8,6 +8,7 @@ import (
 	context "context"
 	reflect "reflect"
 
+	compute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
 	gomock "github.com/golang/mock/gomock"
 
 	api "github.com/openshift/openshift-azure/pkg/api"
@@ -188,4 +189,64 @@ func (m *MockUpgrader) EtcdRestoreDeleteMasterScaleSetHashes(ctx context.Context
 func (mr *MockUpgraderMockRecorder) EtcdRestoreDeleteMasterScaleSetHashes(ctx, cs interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EtcdRestoreDeleteMasterScaleSetHashes", reflect.TypeOf((*MockUpgrader)(nil).EtcdRestoreDeleteMasterScaleSetHashes), ctx, cs)
+}
+
+// RunCommand mocks base method
+func (m *MockUpgrader) RunCommand(ctx context.Context, oc *api.OpenShiftManagedCluster, scaleSetName, instanceId string, parameters compute.RunCommandInput) (compute.RunCommandResult, *api.PluginError) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RunCommand", ctx, oc, scaleSetName, instanceId, parameters)
+	ret0, _ := ret[0].(compute.RunCommandResult)
+	ret1, _ := ret[1].(*api.PluginError)
+	return ret0, ret1
+}
+
+// RunCommand indicates an expected call of RunCommand
+func (mr *MockUpgraderMockRecorder) RunCommand(ctx, oc, scaleSetName, instanceId, parameters interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RunCommand", reflect.TypeOf((*MockUpgrader)(nil).RunCommand), ctx, oc, scaleSetName, instanceId, parameters)
+}
+
+// RestartDocker mocks base method
+func (m *MockUpgrader) RestartDocker(ctx context.Context, oc *api.OpenShiftManagedCluster, scaleSetName, instanceId string) (compute.RunCommandResult, *api.PluginError) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RestartDocker", ctx, oc, scaleSetName, instanceId)
+	ret0, _ := ret[0].(compute.RunCommandResult)
+	ret1, _ := ret[1].(*api.PluginError)
+	return ret0, ret1
+}
+
+// RestartDocker indicates an expected call of RestartDocker
+func (mr *MockUpgraderMockRecorder) RestartDocker(ctx, oc, scaleSetName, instanceId interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestartDocker", reflect.TypeOf((*MockUpgrader)(nil).RestartDocker), ctx, oc, scaleSetName, instanceId)
+}
+
+// RestartKubelet mocks base method
+func (m *MockUpgrader) RestartKubelet(ctx context.Context, oc *api.OpenShiftManagedCluster, scaleSetName, instanceId string) (compute.RunCommandResult, *api.PluginError) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RestartKubelet", ctx, oc, scaleSetName, instanceId)
+	ret0, _ := ret[0].(compute.RunCommandResult)
+	ret1, _ := ret[1].(*api.PluginError)
+	return ret0, ret1
+}
+
+// RestartKubelet indicates an expected call of RestartKubelet
+func (mr *MockUpgraderMockRecorder) RestartKubelet(ctx, oc, scaleSetName, instanceId interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestartKubelet", reflect.TypeOf((*MockUpgrader)(nil).RestartKubelet), ctx, oc, scaleSetName, instanceId)
+}
+
+// RestartNetworkManager mocks base method
+func (m *MockUpgrader) RestartNetworkManager(ctx context.Context, oc *api.OpenShiftManagedCluster, scaleSetName, instanceId string) (compute.RunCommandResult, *api.PluginError) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "RestartNetworkManager", ctx, oc, scaleSetName, instanceId)
+	ret0, _ := ret[0].(compute.RunCommandResult)
+	ret1, _ := ret[1].(*api.PluginError)
+	return ret0, ret1
+}
+
+// RestartNetworkManager indicates an expected call of RestartNetworkManager
+func (mr *MockUpgraderMockRecorder) RestartNetworkManager(ctx, oc, scaleSetName, instanceId interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "RestartNetworkManager", reflect.TypeOf((*MockUpgrader)(nil).RestartNetworkManager), ctx, oc, scaleSetName, instanceId)
 }


### PR DESCRIPTION
This work implements a geneva action that allows an admin to run a generic command on a given virtual machine within a given scale set in a cluster. 

This is part of AZURE-257

/cc @mjudeikis @Makdaam @thekad @kwoodson