### PR TITLE
ILB creation issue

### DIFF
--- a/pkg/config/derive.go
+++ b/pkg/config/derive.go
@@ -107,6 +107,8 @@ func (derived) CloudProviderConf(cs *api.OpenShiftManagedCluster) ([]byte, error
 		Location:          cs.Location,
 		SecurityGroupName: "nsg-worker",
 		VMType:            "vmss",
+		SubnetName:        "default",
+		VnetName:          "vnet",
 	})
 }
 

--- a/pkg/config/derive_test.go
+++ b/pkg/config/derive_test.go
@@ -40,9 +40,11 @@ loadBalancerSku: standard
 location: eastus
 resourceGroup: rg
 securityGroupName: nsg-worker
+subnetName: default
 subscriptionId: sub
 tenantId: tenant
 vmType: vmss
+vnetName: vnet
 `),
 		},
 	}

--- a/pkg/util/cloudprovider/cloudprovider.go
+++ b/pkg/util/cloudprovider/cloudprovider.go
@@ -17,6 +17,8 @@ type Config struct {
 	LoadBalancerSku   string `json:"loadBalancerSku,omitempty"`
 	SecurityGroupName string `json:"securityGroupName,omitempty"`
 	VMType            string `json:"vmType,omitempty"`
+	SubnetName        string `json:"subnetName,omitempty"`
+	VnetName          string `json:"vnetName,omitempty"`
 }
 
 // Load returns Config unmarshalled from the file provided


### PR DESCRIPTION
fixes: https://github.com/openshift/openshift-azure/issues/1087

When creating internal LB this is the query to Azure: 
```
[resourceId('Microsoft.Network/virtualNetworks/subnets', parameters('vnetName'), parameters('subnetname'))]",
```

Our cloud provider does not have `vnetName` and ` subnetName` set so we ended with "" values.
And so the error:
```
 Subnet "" not found with message: "network.SubnetsClient#Get: Failure responding to request: StatusCode=404 -- Original Error: autorest/azure: Service returned an error. Status=404 Code=\"ResourceNotFound\" Message=\"The Resource 'Microsoft.Network/virtualNetworks/subnets' under resource group '5786a402-a88d-4cac-b8f9-ae2a4226a531' was not found.\""
```

This should solve this. Will raise follow-up issue to tide-up constants for vnet names and subnet names as now we hardcode them all around the place. 

/cc @jim-minter @charlesakalugwu @asalkeld 
 @amanohar Let me know how you want to approach this fix. I can produce new release with this cherry. 