### PR TITLE
Deep e2e test integration

### DIFF
--- a/pkg/fakerp/shared/shared.go
+++ b/pkg/fakerp/shared/shared.go
@@ -3,6 +3,9 @@ package shared
 import (
 	"os"
 	"path/filepath"
+
+	"github.com/openshift/openshift-azure/pkg/api"
+	"github.com/openshift/openshift-azure/pkg/util/managedcluster"
 )
 
 const (
@@ -21,4 +24,13 @@ func IsUpdate() bool {
 		return true
 	}
 	return false
+}
+
+// DiscoverInternalConfig discover and returns the internal config struct
+func DiscoverInternalConfig() (*api.OpenShiftManagedCluster, error) {
+	dataDir, err := FindDirectory(DataDirectory)
+	if err != nil {
+		return nil, err
+	}
+	return managedcluster.ReadConfig(filepath.Join(dataDir, "containerservice.yaml"))
 }

--- a/test/clients/openshift/login.go
+++ b/test/clients/openshift/login.go
@@ -5,27 +5,16 @@ import (
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"fmt"
-	"path/filepath"
 	"strings"
 
 	"k8s.io/client-go/tools/clientcmd/api"
 	"k8s.io/client-go/tools/clientcmd/api/latest"
 
-	fakerp "github.com/openshift/openshift-azure/pkg/fakerp/shared"
+	internalapi "github.com/openshift/openshift-azure/pkg/api"
 	azuretls "github.com/openshift/openshift-azure/pkg/tls"
-	"github.com/openshift/openshift-azure/pkg/util/managedcluster"
 )
 
-func login(username string) (*api.Config, error) {
-	dataDir, err := fakerp.FindDirectory(fakerp.DataDirectory)
-	if err != nil {
-		return nil, err
-	}
-	cs, err := managedcluster.ReadConfig(filepath.Join(dataDir, "containerservice.yaml"))
-	if err != nil {
-		return nil, err
-	}
-
+func login(username string, cs *internalapi.OpenShiftManagedCluster) (*api.Config, error) {
 	var organization []string
 	switch username {
 	case "customer-cluster-admin":

--- a/test/e2e/specs/customer_admin.go
+++ b/test/e2e/specs/customer_admin.go
@@ -13,25 +13,23 @@ import (
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/openshift/openshift-azure/pkg/util/randomstring"
-	"github.com/openshift/openshift-azure/test/clients/openshift"
+	"github.com/openshift/openshift-azure/test/e2e/standard"
 )
 
 var _ = Describe("Openshift on Azure customer-admin e2e tests [CustomerAdmin][Fake]", func() {
 	var (
-		cli      *openshift.Client
-		admincli *openshift.Client
+		cli *standard.SanityChecker
 	)
 
 	BeforeEach(func() {
 		var err error
-		cli, err = openshift.NewEndUserClient()
-		Expect(err).ToNot(HaveOccurred())
-		admincli, err = openshift.NewCustomerAdminClient()
-		Expect(err).ToNot(HaveOccurred())
+		cli, err = standard.NewDefaultSanityChecker()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cli).ToNot(BeNil())
 	})
 
 	It("should not read nodes", func() {
-		_, err := admincli.CoreV1.Nodes().Get("master-000000", metav1.GetOptions{})
+		_, err := cli.Client.CustomerAdmin.CoreV1.Nodes().Get("master-000000", metav1.GetOptions{})
 		Expect(kerrors.IsForbidden(err)).To(Equal(true))
 	})
 
@@ -40,12 +38,12 @@ var _ = Describe("Openshift on Azure customer-admin e2e tests [CustomerAdmin][Fa
 		namespace, err := randomstring.RandomString("abcdefghijklmnopqrstuvwxyz0123456789", 5)
 		Expect(err).ToNot(HaveOccurred())
 		namespace = "e2e-test-" + namespace
-		err = cli.CreateProject(namespace)
+		err = cli.Client.EndUser.CreateProject(namespace)
 		Expect(err).ToNot(HaveOccurred())
-		defer cli.CleanupProject(namespace)
+		defer cli.Client.EndUser.CleanupProject(namespace)
 
 		err = wait.PollImmediate(2*time.Second, 5*time.Minute, func() (bool, error) {
-			rb, err := admincli.RbacV1.RoleBindings(namespace).Get("osa-customer-admin", metav1.GetOptions{})
+			rb, err := cli.Client.CustomerAdmin.RbacV1.RoleBindings(namespace).Get("osa-customer-admin", metav1.GetOptions{})
 			if err != nil {
 				// still waiting for namespace
 				if kerrors.IsNotFound(err) {
@@ -66,32 +64,29 @@ var _ = Describe("Openshift on Azure customer-admin e2e tests [CustomerAdmin][Fa
 		})
 		Expect(err).ToNot(HaveOccurred())
 		// get namespace created by user
-		_, err = admincli.ProjectV1.Projects().Get(namespace, metav1.GetOptions{})
+		_, err = cli.Client.CustomerAdmin.ProjectV1.Projects().Get(namespace, metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
-		// attempt to delete namespace
-		err = admincli.ProjectV1.Projects().Delete(namespace, &metav1.DeleteOptions{})
-		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should not list infra namespace secrets", func() {
 		// list all secrets in a namespace. should not see any in openshift-azure-logging
-		_, err := admincli.CoreV1.Secrets("openshift-azure-logging").List(metav1.ListOptions{})
+		_, err := cli.Client.CustomerAdmin.CoreV1.Secrets("openshift-azure-logging").List(metav1.ListOptions{})
 		Expect(kerrors.IsForbidden(err)).To(Equal(true))
 	})
 
 	It("should not list default namespace secrets", func() {
 		// list all secrets in a namespace. should not see any in default
-		_, err := admincli.CoreV1.Secrets("default").List(metav1.ListOptions{})
+		_, err := cli.Client.CustomerAdmin.CoreV1.Secrets("default").List(metav1.ListOptions{})
 		Expect(kerrors.IsForbidden(err)).To(Equal(true))
 	})
 
 	It("should not able to query groups", func() {
-		_, err := admincli.UserV1.Groups().Get("customer-admins", metav1.GetOptions{})
+		_, err := cli.Client.CustomerAdmin.UserV1.Groups().Get("customer-admins", metav1.GetOptions{})
 		Expect(kerrors.IsForbidden(err)).To(Equal(true))
 	})
 
 	It("should not be able to escalate privileges", func() {
-		_, err := admincli.RbacV1.ClusterRoleBindings().Create(&rbacv1.ClusterRoleBinding{
+		_, err := cli.Client.CustomerAdmin.RbacV1.ClusterRoleBindings().Create(&rbacv1.ClusterRoleBinding{
 			ObjectMeta: metav1.ObjectMeta{
 				Name: "test-cluster-admin",
 			},

--- a/test/e2e/specs/end_user.go
+++ b/test/e2e/specs/end_user.go
@@ -2,267 +2,42 @@ package specs
 
 import (
 	"context"
-	"fmt"
-	"io/ioutil"
-	"regexp"
-	"strconv"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/sirupsen/logrus"
-	apiappsv1 "k8s.io/api/apps/v1"
-	"k8s.io/api/core/v1"
-	corev1 "k8s.io/api/core/v1"
-	policy "k8s.io/api/policy/v1beta1"
-	rbacv1 "k8s.io/api/rbac/v1"
-	kerrors "k8s.io/apimachinery/pkg/api/errors"
-	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/intstr"
-	"k8s.io/apimachinery/pkg/util/wait"
-
-	"github.com/openshift/openshift-azure/pkg/util/randomstring"
-	"github.com/openshift/openshift-azure/pkg/util/ready"
-	waitutil "github.com/openshift/openshift-azure/pkg/util/wait"
-	"github.com/openshift/openshift-azure/test/clients/openshift"
+	"github.com/openshift/openshift-azure/test/e2e/standard"
 )
 
 var _ = Describe("Openshift on Azure end user e2e tests [EndUser][Fake]", func() {
 	var (
-		cli       *openshift.Client
-		namespace string
-		logger    *logrus.Logger = logrus.New()
-		log       *logrus.Entry  = logrus.NewEntry(logger)
+		cli *standard.SanityChecker
 	)
 
 	BeforeEach(func() {
 		var err error
-		cli, err = openshift.NewEndUserClient()
-		Expect(err).ToNot(HaveOccurred())
-
-		namespace, err = randomstring.RandomString("abcdefghijklmnopqrstuvwxyz0123456789", 5)
-		Expect(err).ToNot(HaveOccurred())
-		namespace = "e2e-test-" + namespace
-		err = cli.CreateProject(namespace)
-		Expect(err).ToNot(HaveOccurred())
+		cli, err = standard.NewDefaultSanityChecker()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cli).ToNot(BeNil())
 	})
 
-	AfterEach(func() {
-		if CurrentGinkgoTestDescription().Failed {
-			if err := cli.DumpInfo(namespace); err != nil {
-				fmt.Fprint(GinkgoWriter, err)
-			}
-		}
-		err := cli.CleanupProject(namespace)
-		Expect(err).ToNot(HaveOccurred())
+	It("should create and validate test apps", func() {
+		ctx := context.Background()
+		By("creating test app")
+		namespace, errs := cli.CreateTestApp(ctx)
+		Expect(len(errs)).To(Equal(0))
+		defer func() {
+			By("deleting test app")
+			_ = cli.DeleteTestApp(ctx, namespace)
+		}()
+
+		By("validating test app")
+		errs = cli.ValidateTestApp(ctx, namespace)
+		Expect(len(errs)).To(Equal(0))
 	})
 
-	It("should disallow PDB mutations", func() {
-		maxUnavailable := intstr.FromInt(1)
-		selector, err := metav1.ParseToLabelSelector("key=value")
-		Expect(err).NotTo(HaveOccurred())
-
-		pdb := &policy.PodDisruptionBudget{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "test",
-			},
-			Spec: policy.PodDisruptionBudgetSpec{
-				MaxUnavailable: &maxUnavailable,
-				Selector:       selector,
-			},
-		}
-
-		_, err = cli.PolicyV1beta1.PodDisruptionBudgets(namespace).Create(pdb)
-		Expect(kerrors.IsForbidden(err)).To(Equal(true))
-	})
-
-	It("should deploy a template and ensure a given text is in the contents", func() {
-		tpl := "nginx-example"
-		By(fmt.Sprintf("instantiating the template and getting the route (%v)", time.Now()))
-		// instantiate the template
-		err := cli.InstantiateTemplate(tpl, namespace)
-		Expect(err).NotTo(HaveOccurred())
-		route, err := cli.RouteV1.Routes(namespace).Get(tpl, metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred())
-		// make sure only 1 ingress point is returned
-		Expect(len(route.Status.Ingress)).To(Equal(1))
-		host := route.Status.Ingress[0].Host
-		url := fmt.Sprintf("http://%s", host)
-
-		// Curl the endpoint and search for a string
-		By(fmt.Sprintf("hitting the route and checking the contents (%v)", time.Now()))
-		timeout, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer cancel()
-		resp, err := waitutil.ForHTTPStatusOk(timeout, log, nil, url)
-		Expect(err).NotTo(HaveOccurred())
-		defer resp.Body.Close()
-		contents, err := ioutil.ReadAll(resp.Body)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(string(contents)).Should(ContainSubstring("Welcome to your static nginx application on OpenShift"))
-	})
-
-	It("should not crud infra resources", func() {
-		// attempt to read secrets
-		_, err := cli.CoreV1.Secrets("default").List(metav1.ListOptions{})
-		Expect(kerrors.IsForbidden(err)).To(Equal(true))
-
-		// attempt to list pods
-		_, err = cli.CoreV1.Pods("default").List(metav1.ListOptions{})
-		Expect(kerrors.IsForbidden(err)).To(Equal(true))
-
-		// attempt to fetch pod by name
-		_, err = cli.CoreV1.Pods("kube-system").Get("api-master-000000", metav1.GetOptions{})
-		Expect(kerrors.IsForbidden(err)).To(Equal(true))
-
-		// attempt to escalate privileges
-		_, err = cli.RbacV1.ClusterRoleBindings().Create(&rbacv1.ClusterRoleBinding{
-			ObjectMeta: metav1.ObjectMeta{
-				Name: "test-escalate-cluster-admin",
-			},
-			Subjects: []rbacv1.Subject{
-				{
-					Kind: "User",
-					Name: "enduser",
-				},
-			},
-			RoleRef: rbacv1.RoleRef{
-				Name: "cluster-admin",
-				Kind: "ClusterRole",
-			},
-		})
-		Expect(kerrors.IsForbidden(err)).To(Equal(true))
-
-		// attempt to delete clusterrolebindings
-		err = cli.RbacV1.ClusterRoleBindings().Delete("cluster-admin", &metav1.DeleteOptions{})
-		Expect(kerrors.IsForbidden(err)).To(Equal(true))
-
-		// attempt to delete clusterrole
-		err = cli.RbacV1.ClusterRoles().Delete("cluster-admin", &metav1.DeleteOptions{})
-		Expect(kerrors.IsForbidden(err)).To(Equal(true))
-
-		// attempt to fetch pod logs
-		req := cli.CoreV1.Pods("kube-system").GetLogs("sync-master-000000", &v1.PodLogOptions{})
-		result := req.Do()
-		fmt.Println(result.Error().Error())
-		Expect(result.Error().Error()).To(ContainSubstring("pods \"sync-master-000000\" is forbidden: User \"enduser\" cannot get pods/log in the namespace \"kube-system\""))
-	})
-
-	It("should deploy a template with persistent storage and test failure modes", func() {
-		prevCounter := 0
-
-		loopHTTPGet := func(url string, regex *regexp.Regexp, times int) error {
-			timeout, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-			defer cancel()
-
-			for i := 0; i < times; i++ {
-				resp, err := waitutil.ForHTTPStatusOk(timeout, log, nil, url)
-				if err != nil {
-					return err
-				}
-
-				contents, err := ioutil.ReadAll(resp.Body)
-				if err != nil {
-					return err
-				}
-				matches := regex.FindStringSubmatch(string(contents))
-				if matches == nil {
-					return fmt.Errorf("no matches found for %s", regex)
-				}
-
-				currCounter, err := strconv.Atoi(matches[1])
-				if err != nil {
-					return err
-				}
-				if currCounter <= prevCounter {
-					return fmt.Errorf("visit counter didn't increment: %d should be > than %d", currCounter, prevCounter)
-				}
-				prevCounter = currCounter
-			}
-			return nil
-		}
-
-		// instantiate the template
-		tpl := "django-psql-persistent"
-		By(fmt.Sprintf("instantiating the template and getting the route (%v)", time.Now()))
-		err := cli.InstantiateTemplate(tpl, namespace)
-		Expect(err).NotTo(HaveOccurred())
-
-		// Pull the route ingress from the namespace and make sure only 1 ingress point is returned
-		route, err := cli.RouteV1.Routes(namespace).Get(tpl, metav1.GetOptions{})
-		Expect(err).NotTo(HaveOccurred())
-		Expect(len(route.Status.Ingress)).To(Equal(1))
-
-		// hit the ingress 3 times before killing the DB
-		host := route.Status.Ingress[0].Host
-		url := fmt.Sprintf("http://%s", host)
-		regex := regexp.MustCompile(`Page views:\s*(\d+)`)
-		By(fmt.Sprintf("hitting the route 3 times, expecting counter to increment (%v)", time.Now()))
-		err = loopHTTPGet(url, regex, 3)
-		Expect(err).NotTo(HaveOccurred())
-
-		// Find the database deploymentconfig and scale down to 0, then back up to 1
-		dcName := "postgresql"
-		for _, i := range []int32{0, 1} {
-			By(fmt.Sprintf("searching for the database deploymentconfig (%v)", time.Now()))
-			dc, err := cli.OAppsV1.DeploymentConfigs(namespace).Get(dcName, metav1.GetOptions{})
-			Expect(err).NotTo(HaveOccurred())
-
-			By(fmt.Sprintf("scaling the database deploymentconfig to %d (%v)", i, time.Now()))
-			dc.Spec.Replicas = int32(i)
-			_, err = cli.OAppsV1.DeploymentConfigs(namespace).Update(dc)
-			Expect(err).NotTo(HaveOccurred())
-
-			By(fmt.Sprintf("waiting for database deploymentconfig to reflect %d replicas (%v)", i, time.Now()))
-			waitErr := wait.PollImmediate(2*time.Second, 10*time.Minute, ready.DeploymentConfigIsReady(cli.OAppsV1.DeploymentConfigs(namespace), dcName))
-			Expect(waitErr).NotTo(HaveOccurred())
-		}
-
-		// hit it again, will hit 3 times as specified initially
-		By(fmt.Sprintf("hitting the route again, expecting counter to increment from last (%v)", time.Now()))
-		err = loopHTTPGet(url, regex, 3)
-		Expect(err).NotTo(HaveOccurred())
-	})
-
-	It("should be able to deploy a registry.redhat.io image", func() {
-		// nginx 1.14 is in private registry only (so far)
-		deploymentName := "redis-32-rhel7"
-		privateImage := fmt.Sprintf("registry.redhat.io/rhscl/%s", deploymentName)
-		By(fmt.Sprintf("building deployment spec for %s (%v)", privateImage, time.Now()))
-		deployment := &apiappsv1.Deployment{
-			ObjectMeta: metav1.ObjectMeta{
-				Name:      deploymentName,
-				Namespace: namespace,
-			},
-			Spec: apiappsv1.DeploymentSpec{
-				Selector: &metav1.LabelSelector{
-					MatchLabels: map[string]string{
-						"app": deploymentName,
-					},
-				},
-				Template: corev1.PodTemplateSpec{
-					ObjectMeta: metav1.ObjectMeta{
-						Name: deploymentName,
-						Labels: map[string]string{
-							"app": deploymentName,
-						},
-					},
-					Spec: corev1.PodSpec{
-						Containers: []corev1.Container{
-							{
-								Name:  deploymentName,
-								Image: privateImage,
-							},
-						},
-					},
-				},
-			},
-		}
-		By(fmt.Sprintf("creating deployment (%v)", time.Now()))
-		_, err := cli.AppsV1.Deployments(namespace).Create(deployment)
-		Expect(err).NotTo(HaveOccurred())
-		By(fmt.Sprintf("waiting for deployment to be ready (%v)", time.Now()))
-		err = wait.PollImmediate(2*time.Second, 5*time.Minute, ready.DeploymentIsReady(cli.AppsV1.Deployments(namespace), deploymentName))
-		Expect(err).NotTo(HaveOccurred())
+	It("should validate the cluster", func() {
+		errs := cli.ValidateCluster(context.Background())
+		Expect(len(errs)).To(Equal(0))
 	})
 })

--- a/test/e2e/specs/fakerp/admin.go
+++ b/test/e2e/specs/fakerp/admin.go
@@ -7,97 +7,34 @@ import (
 	"os"
 	"reflect"
 	"strings"
-	"time"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
 	"github.com/ghodss/yaml"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/openshift/openshift-azure/pkg/cluster/updateblob"
 	"github.com/openshift/openshift-azure/pkg/jsonpath"
-	"github.com/openshift/openshift-azure/pkg/util/ready"
 	"github.com/openshift/openshift-azure/test/clients/azure"
-	"github.com/openshift/openshift-azure/test/clients/openshift"
+	"github.com/openshift/openshift-azure/test/e2e/standard"
 )
 
 var _ = Describe("Openshift on Azure admin e2e tests [AzureClusterReader][Fake]", func() {
 	var (
-		cli *openshift.Client
+		cli *standard.SanityChecker
 	)
 
 	BeforeEach(func() {
 		var err error
-		cli, err = openshift.NewAzureClusterReaderClient()
-		Expect(err).ToNot(HaveOccurred())
-	})
-
-	It("should label nodes correctly", func() {
-		labels := map[string]map[string]string{
-			"master": {
-				"node-role.kubernetes.io/master": "true",
-				"openshift-infra":                "apiserver",
-			},
-			"compute": {
-				"node-role.kubernetes.io/compute": "true",
-			},
-			"infra": {
-				"node-role.kubernetes.io/infra": "true",
-			},
-		}
-		list, err := cli.CoreV1.Nodes().List(metav1.ListOptions{})
+		cli, err = standard.NewDefaultSanityChecker()
 		Expect(err).NotTo(HaveOccurred())
-
-		for _, node := range list.Items {
-			kind := strings.Split(node.Name, "-")[0]
-			Expect(labels).To(HaveKey(kind))
-			for k, v := range labels[kind] {
-				Expect(node.Labels).To(HaveKeyWithValue(k, v))
-			}
-		}
-	})
-
-	// check prometheus-operator and related components readiness
-	It("should start cluster-monitoring-operator correctly", func() {
-		err := wait.Poll(2*time.Second, 20*time.Minute, ready.DeploymentIsReady(cli.AppsV1.Deployments("openshift-monitoring"), "cluster-monitoring-operator"))
-		Expect(err).ToNot(HaveOccurred())
-	})
-
-	It("should start prometheus-operator correctly", func() {
-		err := wait.Poll(2*time.Second, 20*time.Minute, ready.DeploymentIsReady(cli.AppsV1.Deployments("openshift-monitoring"), "prometheus-operator"))
-		Expect(err).ToNot(HaveOccurred())
-	})
-
-	It("should start grafana correctly", func() {
-		err := wait.Poll(2*time.Second, 20*time.Minute, ready.DeploymentIsReady(cli.AppsV1.Deployments("openshift-monitoring"), "grafana"))
-		Expect(err).ToNot(HaveOccurred())
-	})
-
-	It("should start prometheus correctly", func() {
-		err := wait.Poll(2*time.Second, 20*time.Minute, ready.StatefulSetIsReady(cli.AppsV1.StatefulSets("openshift-monitoring"), "prometheus-k8s"))
-		Expect(err).ToNot(HaveOccurred())
-	})
-
-	It("should start alert manager correctly", func() {
-		err := wait.Poll(2*time.Second, 20*time.Minute, ready.StatefulSetIsReady(cli.AppsV1.StatefulSets("openshift-monitoring"), "alertmanager-main"))
-		Expect(err).ToNot(HaveOccurred())
-	})
-
-	It("should start node-exporter correctly", func() {
-		err := wait.Poll(2*time.Second, 20*time.Minute, ready.DaemonSetIsReady(cli.AppsV1.DaemonSets("openshift-monitoring"), "node-exporter"))
-		Expect(err).ToNot(HaveOccurred())
-	})
-
-	It("should start metrics-bridge correctly", func() {
-		err := wait.Poll(2*time.Second, 20*time.Minute, ready.DeploymentIsReady(cli.AppsV1.Deployments("openshift-azure-monitoring"), "metrics-bridge"))
-		Expect(err).ToNot(HaveOccurred())
+		Expect(cli).ToNot(BeNil())
 	})
 
 	It("should run the correct image", func() {
 		// e2e check should ensure that no reg-aws images are running on box
-		pods, err := cli.CoreV1.Pods("").List(metav1.ListOptions{})
+		pods, err := cli.Client.AzureClusterReader.CoreV1.Pods("").List(metav1.ListOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
 		for _, pod := range pods.Items {
@@ -107,7 +44,7 @@ var _ = Describe("Openshift on Azure admin e2e tests [AzureClusterReader][Fake]"
 		}
 
 		// fetch master-000000 and determine the OS type
-		master0, _ := cli.CoreV1.Nodes().Get("master-000000", metav1.GetOptions{})
+		master0, _ := cli.Client.AzureClusterReader.CoreV1.Nodes().Get("master-000000", metav1.GetOptions{})
 		Expect(err).ToNot(HaveOccurred())
 
 		// set registryPrefix to appropriate string based upon master's OS type
@@ -120,7 +57,7 @@ var _ = Describe("Openshift on Azure admin e2e tests [AzureClusterReader][Fake]"
 
 		// Check all Configmaps for image format matches master's OS type
 		// format: registry.access.redhat.com/openshift3/ose-${component}:${version}
-		configmaps, err := cli.CoreV1.ConfigMaps("openshift-node").List(metav1.ListOptions{})
+		configmaps, err := cli.Client.AzureClusterReader.CoreV1.ConfigMaps("openshift-node").List(metav1.ListOptions{})
 		Expect(err).ToNot(HaveOccurred())
 		var nodeConfig map[string]interface{}
 		for _, configmap := range configmaps.Items {

--- a/test/e2e/specs/fakerp/prometheus.go
+++ b/test/e2e/specs/fakerp/prometheus.go
@@ -14,7 +14,7 @@ import (
 	"github.com/openshift/openshift-azure/pkg/api"
 	"github.com/openshift/openshift-azure/pkg/fakerp/shared"
 	"github.com/openshift/openshift-azure/pkg/util/managedcluster"
-	"github.com/openshift/openshift-azure/test/clients/openshift"
+	"github.com/openshift/openshift-azure/test/e2e/standard"
 )
 
 type target struct {
@@ -36,14 +36,15 @@ type targetsResponse struct {
 
 var _ = Describe("Prometheus E2E tests [Prometheus][EveryPR]", func() {
 	var (
-		cli *openshift.Client
+		cli *standard.SanityChecker
 		cs  *api.OpenShiftManagedCluster
 	)
 
 	BeforeEach(func() {
 		var err error
-		cli, err = openshift.NewAdminClient()
+		cli, err = standard.NewDefaultSanityChecker()
 		Expect(err).NotTo(HaveOccurred())
+		Expect(cli).NotTo(BeNil())
 
 		dataDir, err := shared.FindDirectory(shared.DataDirectory)
 		Expect(err).NotTo(HaveOccurred())
@@ -52,10 +53,10 @@ var _ = Describe("Prometheus E2E tests [Prometheus][EveryPR]", func() {
 	})
 
 	It("should register all the necessary prometheus targets", func() {
-		token, err := cli.GetServiceAccountToken("openshift-monitoring", "prometheus-k8s")
+		token, err := cli.Client.Admin.GetServiceAccountToken("openshift-monitoring", "prometheus-k8s")
 		Expect(err).NotTo(HaveOccurred())
 
-		route, err := cli.RouteV1.Routes("openshift-monitoring").Get("prometheus-k8s", meta_v1.GetOptions{})
+		route, err := cli.Client.Admin.RouteV1.Routes("openshift-monitoring").Get("prometheus-k8s", meta_v1.GetOptions{})
 		Expect(err).NotTo(HaveOccurred())
 
 		req, err := http.NewRequest(http.MethodGet, "https://"+route.Spec.Host+"/api/v1/targets", nil)

--- a/test/e2e/standard/cluster.go
+++ b/test/e2e/standard/cluster.go
@@ -1,0 +1,229 @@
+package standard
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	. "github.com/onsi/ginkgo"
+
+	apiappsv1 "k8s.io/api/apps/v1"
+	"k8s.io/api/core/v1"
+	corev1 "k8s.io/api/core/v1"
+	policy "k8s.io/api/policy/v1beta1"
+	rbacv1 "k8s.io/api/rbac/v1"
+	kerrors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/intstr"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/openshift/openshift-azure/pkg/util/ready"
+)
+
+func (sc *SanityChecker) checkMonitoringStackHealth(ctx context.Context) error {
+	err := wait.Poll(2*time.Second, 20*time.Minute, ready.DeploymentIsReady(sc.Client.AzureClusterReader.AppsV1.Deployments("openshift-monitoring"), "cluster-monitoring-operator"))
+	if err != nil {
+		return err
+	}
+	err = wait.Poll(2*time.Second, 20*time.Minute, ready.DeploymentIsReady(sc.Client.AzureClusterReader.AppsV1.Deployments("openshift-monitoring"), "prometheus-operator"))
+	if err != nil {
+		return err
+	}
+	err = wait.Poll(2*time.Second, 20*time.Minute, ready.DeploymentIsReady(sc.Client.AzureClusterReader.AppsV1.Deployments("openshift-monitoring"), "grafana"))
+	if err != nil {
+		return err
+	}
+	err = wait.Poll(2*time.Second, 20*time.Minute, ready.StatefulSetIsReady(sc.Client.AzureClusterReader.AppsV1.StatefulSets("openshift-monitoring"), "prometheus-k8s"))
+	if err != nil {
+		return err
+	}
+	err = wait.Poll(2*time.Second, 20*time.Minute, ready.StatefulSetIsReady(sc.Client.AzureClusterReader.AppsV1.StatefulSets("openshift-monitoring"), "alertmanager-main"))
+	if err != nil {
+		return err
+	}
+	err = wait.Poll(2*time.Second, 20*time.Minute, ready.DaemonSetIsReady(sc.Client.AzureClusterReader.AppsV1.DaemonSets("openshift-monitoring"), "node-exporter"))
+	if err != nil {
+		return err
+	}
+	err = wait.Poll(2*time.Second, 20*time.Minute, ready.DeploymentIsReady(sc.Client.AzureClusterReader.AppsV1.Deployments("openshift-azure-monitoring"), "metrics-bridge"))
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (sc *SanityChecker) checkNodesLabelledCorrectly(ctx context.Context) error {
+	labels := map[string]map[string]string{
+		"master": {
+			"node-role.kubernetes.io/master": "true",
+			"openshift-infra":                "apiserver",
+		},
+		"compute": {
+			"node-role.kubernetes.io/compute": "true",
+		},
+		"infra": {
+			"node-role.kubernetes.io/infra": "true",
+		},
+	}
+	list, err := sc.Client.AzureClusterReader.CoreV1.Nodes().List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	for _, node := range list.Items {
+		kind := strings.Split(node.Name, "-")[0]
+		if _, ok := labels[kind]; !ok {
+			return fmt.Errorf("map does not have key %s", kind)
+		}
+		for k, v := range labels[kind] {
+			if val, ok := node.Labels[k]; !ok || val != v {
+				return fmt.Errorf("map does not have key %s", kind)
+			}
+		}
+	}
+	return nil
+}
+
+func (sc *SanityChecker) checkDisallowsPdbMutations(ctx context.Context) error {
+	namespace, err := sc.createProject(ctx)
+	if err != nil {
+		return err
+	}
+	defer sc.deleteProject(ctx, namespace)
+
+	maxUnavailable := intstr.FromInt(1)
+	selector, err := metav1.ParseToLabelSelector("key=value")
+	if err != nil {
+		return err
+	}
+	pdb := &policy.PodDisruptionBudget{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test",
+		},
+		Spec: policy.PodDisruptionBudgetSpec{
+			MaxUnavailable: &maxUnavailable,
+			Selector:       selector,
+		},
+	}
+	_, err = sc.Client.EndUser.PolicyV1beta1.PodDisruptionBudgets(namespace).Create(pdb)
+	if kerrors.IsForbidden(err) != true {
+		return err
+	}
+	return nil
+}
+
+func (sc *SanityChecker) checkCannotAccessInfraResources(ctx context.Context) error {
+	// attempt to read secrets
+	_, err := sc.Client.EndUser.CoreV1.Secrets("default").List(metav1.ListOptions{})
+	if kerrors.IsForbidden(err) != true {
+		return err
+	}
+
+	// attempt to list pods
+	_, err = sc.Client.EndUser.CoreV1.Pods("default").List(metav1.ListOptions{})
+	if kerrors.IsForbidden(err) != true {
+		return err
+	}
+
+	// attempt to fetch pod by name
+	_, err = sc.Client.EndUser.CoreV1.Pods("kube-system").Get("api-master-000000", metav1.GetOptions{})
+	if kerrors.IsForbidden(err) != true {
+		return err
+	}
+
+	// attempt to escalate privileges
+	_, err = sc.Client.EndUser.RbacV1.ClusterRoleBindings().Create(&rbacv1.ClusterRoleBinding{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "test-escalate-cluster-admin",
+		},
+		Subjects: []rbacv1.Subject{
+			{
+				Kind: "User",
+				Name: "enduser",
+			},
+		},
+		RoleRef: rbacv1.RoleRef{
+			Name: "cluster-admin",
+			Kind: "ClusterRole",
+		},
+	})
+	if kerrors.IsForbidden(err) != true {
+		return err
+	}
+
+	// attempt to delete clusterrolebindings
+	err = sc.Client.EndUser.RbacV1.ClusterRoleBindings().Delete("cluster-admin", &metav1.DeleteOptions{})
+	if kerrors.IsForbidden(err) != true {
+		return err
+	}
+
+	// attempt to delete clusterrole
+	err = sc.Client.EndUser.RbacV1.ClusterRoles().Delete("cluster-admin", &metav1.DeleteOptions{})
+	if kerrors.IsForbidden(err) != true {
+		return err
+	}
+
+	// attempt to fetch pod logs
+	req := sc.Client.EndUser.CoreV1.Pods("kube-system").GetLogs("sync-master-000000", &v1.PodLogOptions{})
+	result := req.Do()
+	errmsg := result.Error().Error()
+	expected := "pods \"sync-master-000000\" is forbidden: User \"enduser\" cannot get pods/log in the namespace \"kube-system\""
+	if !strings.Contains(errmsg, expected) {
+		return fmt.Errorf("could not find expected string in error message [expected: %s, msg: %s]", expected, errmsg)
+	}
+	return nil
+}
+
+func (sc *SanityChecker) checkCanDeployRedhatIoImages(ctx context.Context) error {
+	namespace, err := sc.createProject(ctx)
+	if err != nil {
+		return err
+	}
+	defer sc.deleteProject(ctx, namespace)
+
+	// nginx 1.14 is in private registry only (so far)
+	deploymentName := "redis-32-rhel7"
+	privateImage := fmt.Sprintf("registry.redhat.io/rhscl/%s", deploymentName)
+	By(fmt.Sprintf("building deployment spec for %s (%v)", privateImage, time.Now()))
+	deployment := &apiappsv1.Deployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      deploymentName,
+			Namespace: namespace,
+		},
+		Spec: apiappsv1.DeploymentSpec{
+			Selector: &metav1.LabelSelector{
+				MatchLabels: map[string]string{
+					"app": deploymentName,
+				},
+			},
+			Template: corev1.PodTemplateSpec{
+				ObjectMeta: metav1.ObjectMeta{
+					Name: deploymentName,
+					Labels: map[string]string{
+						"app": deploymentName,
+					},
+				},
+				Spec: corev1.PodSpec{
+					Containers: []corev1.Container{
+						{
+							Name:  deploymentName,
+							Image: privateImage,
+						},
+					},
+				},
+			},
+		},
+	}
+	By(fmt.Sprintf("creating deployment (%v)", time.Now()))
+	_, err = sc.Client.EndUser.AppsV1.Deployments(namespace).Create(deployment)
+	if err != nil {
+		return err
+	}
+	By(fmt.Sprintf("waiting for deployment to be ready (%v)", time.Now()))
+	err = wait.PollImmediate(2*time.Second, 5*time.Minute, ready.DeploymentIsReady(sc.Client.EndUser.AppsV1.Deployments(namespace), deploymentName))
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/test/e2e/standard/sanitychecker.go
+++ b/test/e2e/standard/sanitychecker.go
@@ -1,0 +1,157 @@
+package standard
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+
+	internalapi "github.com/openshift/openshift-azure/pkg/api"
+	shared "github.com/openshift/openshift-azure/pkg/fakerp/shared"
+	"github.com/openshift/openshift-azure/pkg/util/randomstring"
+	"github.com/openshift/openshift-azure/test/clients/openshift"
+	testlogger "github.com/openshift/openshift-azure/test/util/log"
+)
+
+type TestError struct {
+	Bucket string
+	Err    error
+}
+
+var _ error = &TestError{}
+
+func (te *TestError) Error() string {
+	return te.Bucket + ": " + te.Err.Error()
+}
+
+type DeepTestInterface interface {
+	CreateTestApp(ctx context.Context) (interface{}, []*TestError)
+	ValidateTestApp(ctx context.Context, cookie interface{}) []*TestError
+	ValidateCluster(ctx context.Context) []*TestError
+	DeleteTestApp(ctx context.Context, cookie interface{}) []*TestError
+}
+
+type SanityChecker struct {
+	log    *logrus.Entry
+	cs     *internalapi.OpenShiftManagedCluster
+	Client *openshift.ClientSet
+}
+
+var _ DeepTestInterface = &SanityChecker{}
+
+// NewSanityChecker creates a new deep test sanity checker for OpenshiftManagedCluster resources.
+func NewSanityChecker(log *logrus.Entry, cs *internalapi.OpenShiftManagedCluster) (*SanityChecker, error) {
+	scc := &SanityChecker{
+		log: log,
+		cs:  cs,
+	}
+	var err error
+	scc.Client, err = openshift.NewClientSet(cs)
+	if err != nil {
+		return nil, err
+	}
+	return scc, nil
+}
+
+func NewDefaultSanityChecker() (*SanityChecker, error) {
+	log := testlogger.GetTestLogger()
+	cs, err := shared.DiscoverInternalConfig()
+	if err != nil {
+		return nil, err
+	}
+	return NewSanityChecker(log, cs)
+}
+
+func (sc *SanityChecker) CreateTestApp(ctx context.Context) (interface{}, []*TestError) {
+	var errs []*TestError
+	sc.log.Debugf("creating openshift project for test apps")
+	namespace, err := sc.createProject(ctx)
+	if err != nil {
+		sc.log.Error(err)
+		errs = append(errs, &TestError{Err: err, Bucket: "createProject"})
+		return nil, errs
+	}
+	sc.log.Debugf("creating stateful test app in %s", namespace)
+	err = sc.createStatefulApp(ctx, namespace)
+	if err != nil {
+		sc.log.Error(err)
+		errs = append(errs, &TestError{Err: err, Bucket: "createStatefulApp"})
+	}
+	return namespace, errs
+}
+
+func (sc *SanityChecker) ValidateTestApp(ctx context.Context, cookie interface{}) (errs []*TestError) {
+	namespace := cookie.(string)
+	sc.log.Debugf("validating stateful test app in %s", namespace)
+	err := sc.validateStatefulApp(ctx, namespace)
+	if err != nil {
+		sc.log.Error(err)
+		errs = append(errs, &TestError{Err: err, Bucket: "validateStatefulApp"})
+	}
+	return
+}
+
+func (sc *SanityChecker) ValidateCluster(ctx context.Context) (errs []*TestError) {
+	sc.log.Debugf("validating that nodes are labelled correctly")
+	err := sc.checkNodesLabelledCorrectly(ctx)
+	if err != nil {
+		sc.log.Error(err)
+		errs = append(errs, &TestError{Err: err, Bucket: "checkNodesLabelledCorrectly"})
+	}
+	sc.log.Debugf("validating that all monitoring components are healthy")
+	err = sc.checkMonitoringStackHealth(ctx)
+	if err != nil {
+		sc.log.Error(err)
+		errs = append(errs, &TestError{Err: err, Bucket: "checkMonitoringStackHealth"})
+	}
+	sc.log.Debugf("validating that pod disruption budgets are immutable")
+	err = sc.checkDisallowsPdbMutations(ctx)
+	if err != nil {
+		sc.log.Error(err)
+		errs = append(errs, &TestError{Err: err, Bucket: "checkDisallowsPdbMutations"})
+	}
+	sc.log.Debugf("validating that an end user cannot access infrastructure components")
+	err = sc.checkCannotAccessInfraResources(ctx)
+	if err != nil {
+		sc.log.Error(err)
+		errs = append(errs, &TestError{Err: err, Bucket: "checkCannotAccessInfraResources"})
+	}
+	sc.log.Debugf("validating that the cluster can pull redhat.io images")
+	err = sc.checkCanDeployRedhatIoImages(ctx)
+	if err != nil {
+		sc.log.Error(err)
+		errs = append(errs, &TestError{Err: err, Bucket: "checkCanDeployRedhatIoImages"})
+	}
+	return
+}
+
+func (sc *SanityChecker) DeleteTestApp(ctx context.Context, cookie interface{}) []*TestError {
+	var errs []*TestError
+	sc.log.Debugf("deleting openshift project for test apps")
+	err := sc.deleteProject(ctx, cookie.(string))
+	if err != nil {
+		sc.log.Error(err)
+		errs = append(errs, &TestError{Err: err, Bucket: "deleteProject"})
+	}
+	return errs
+}
+
+func (sc *SanityChecker) createProject(ctx context.Context) (string, error) {
+	template, err := randomstring.RandomString("abcdefghijklmnopqrstuvwxyz0123456789", 5)
+	if err != nil {
+		return "", err
+	}
+	namespace := "e2e-test-" + template
+	err = sc.Client.EndUser.CreateProject(namespace)
+	if err != nil {
+		return "", err
+	}
+	return namespace, nil
+}
+
+func (sc *SanityChecker) deleteProject(ctx context.Context, namespace string) error {
+	err := sc.Client.EndUser.CleanupProject(namespace)
+	if err != nil {
+		return err
+	}
+	return nil
+}

--- a/test/e2e/standard/testapps.go
+++ b/test/e2e/standard/testapps.go
@@ -1,0 +1,155 @@
+package standard
+
+import (
+	"context"
+	"fmt"
+	"io/ioutil"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/util/wait"
+
+	"github.com/openshift/openshift-azure/pkg/util/ready"
+	waitutil "github.com/openshift/openshift-azure/pkg/util/wait"
+)
+
+const (
+	statelessApp = "nginx-example"
+	statefulApp  = "django-psql-persistent"
+)
+
+func (sc *SanityChecker) createStatefulApp(ctx context.Context, namespace string) error {
+	sc.log.Debugf("instantiating %s template", statefulApp)
+	err := sc.Client.EndUser.InstantiateTemplate(statefulApp, namespace)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (sc *SanityChecker) createStatelessApp(ctx context.Context, namespace string) error {
+	sc.log.Debugf("instantiating %s template", statelessApp)
+	err := sc.Client.EndUser.InstantiateTemplate(statelessApp, namespace)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (sc *SanityChecker) validateStatefulApp(ctx context.Context, namespace string) error {
+	prevCounter := 0
+	loopHTTPGet := func(url string, regex *regexp.Regexp, times int) error {
+		timeout, cancel := context.WithTimeout(ctx, 30*time.Second)
+		defer cancel()
+
+		for i := 0; i < times; i++ {
+			resp, err := waitutil.ForHTTPStatusOk(timeout, sc.log, nil, url)
+			if err != nil {
+				return err
+			}
+
+			contents, err := ioutil.ReadAll(resp.Body)
+			if err != nil {
+				return err
+			}
+			matches := regex.FindStringSubmatch(string(contents))
+			if matches == nil {
+				return fmt.Errorf("no matches found for %s", regex)
+			}
+
+			currCounter, err := strconv.Atoi(matches[1])
+			if err != nil {
+				return err
+			}
+			if currCounter <= prevCounter {
+				return fmt.Errorf("visit counter didn't increment: %d should be > than %d", currCounter, prevCounter)
+			}
+			prevCounter = currCounter
+		}
+		return nil
+	}
+	// Pull the route ingress from the namespace
+	route, err := sc.Client.EndUser.RouteV1.Routes(namespace).Get(statefulApp, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	// make sure only 1 ingress point is returned
+	length := len(route.Status.Ingress)
+	if length != 1 {
+		return fmt.Errorf("expected only 1 ingress point, got %d", length)
+	}
+
+	// hit the ingress 3 times before killing the DB
+	host := route.Status.Ingress[0].Host
+	url := fmt.Sprintf("http://%s", host)
+	regex := regexp.MustCompile(`Page views:\s*(\d+)`)
+	sc.log.Debugf("hitting the route 3 times, expecting counter to increment")
+	err = loopHTTPGet(url, regex, 3)
+	if err != nil {
+		return err
+	}
+
+	// Find the database deploymentconfig and scale down to 0, then back up to 1
+	dcName := "postgresql"
+	for _, i := range []int32{0, 1} {
+		sc.log.Debugf("searching for the database deploymentconfig")
+		dc, err := sc.Client.EndUser.OAppsV1.DeploymentConfigs(namespace).Get(dcName, metav1.GetOptions{})
+		if err != nil {
+			return err
+		}
+		sc.log.Debugf("scaling the database deploymentconfig to %d", i)
+		dc.Spec.Replicas = int32(i)
+		_, err = sc.Client.EndUser.OAppsV1.DeploymentConfigs(namespace).Update(dc)
+		if err != nil {
+			return err
+		}
+		sc.log.Debugf("waiting for database deploymentconfig to reflect %d replicas", i)
+		waitErr := wait.PollImmediate(2*time.Second, 10*time.Minute, ready.DeploymentConfigIsReady(sc.Client.EndUser.OAppsV1.DeploymentConfigs(namespace), dcName))
+		if waitErr != nil {
+			return waitErr
+		}
+	}
+	// hit it again, will hit 3 times as specified initially
+	sc.log.Debugf("hitting the route again, expecting counter to increment from last")
+	err = loopHTTPGet(url, regex, 3)
+	if err != nil {
+		return err
+	}
+	return nil
+}
+
+func (sc *SanityChecker) validateStatelessApp(ctx context.Context, namespace string) error {
+	route, err := sc.Client.EndUser.RouteV1.Routes(namespace).Get(statelessApp, metav1.GetOptions{})
+	if err != nil {
+		return err
+	}
+	// make sure only 1 ingress point is returned
+	length := len(route.Status.Ingress)
+	if length != 1 {
+		return fmt.Errorf("expected only 1 ingress point, got %d", length)
+	}
+	host := route.Status.Ingress[0].Host
+	url := fmt.Sprintf("http://%s", host)
+
+	// Curl the endpoint and search for a string
+	sc.log.Debugf("hitting the route %s and verifying the response", url)
+	timeout, cancel := context.WithTimeout(ctx, 30*time.Second)
+	defer cancel()
+	resp, err := waitutil.ForHTTPStatusOk(timeout, sc.log, nil, url)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+	contents, err := ioutil.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+	expected := "Welcome to your static nginx application on OpenShift"
+	if !strings.Contains(string(contents), expected) {
+		return fmt.Errorf("did not find expected string in response")
+	}
+	return nil
+}


### PR DESCRIPTION
This work enables MSFT to call functions to "sanity check" a cluster as part of their e2e tests.

*Notable Changes*

* A new deep test interface in `test/clients/interface.go`
* A new deep test client in `test/clients/openshift/client.go`
* The deep test client wraps all the previous openshift clients we used for e2e tests
* A new deep test client can be created with `NewClient(log *logrus.Entry, cs *internalapi.OpenShiftManagedCluster)`
  * If developing against the fake rp (RH), sensible defaults will be set for log and cs when you call `NewClient(nil, nil)`
  * If developing against the real rp (MSFT), you can provide your log and cs and call `NewClient(log, cs)`
* Conforming to the deep test interface, the deep client provides the following methods
  * `CreateTestApp(ctx context.Context) (interface{}, []*TestError)` - creates a test app and returns the project where it was created
  * `ValidateTestApp(ctx context.Context, cookie interface{}) []*TestError` - validates functionality of the deployed test app
  * `DeleteTestApp(ctx context.Context, cookie interface{}) []*TestError` - deletes the test app and its project
  * `ValidateCluster(ctx context.Context) []*TestError` - validates cluster functionality
* Update-based e2e tests can optionally call a combination of `Create/ValidateTestApp`, perform updates and then call `ValidateCluster`
* It is still possible to granularly reference the internal user-specific clients e.g. `Client.EndUser` or `Client.AzureClusterReader`

This is part of AZURE-222

closes #811 

/cc @mjudeikis @jim-minter @kwoodson @thekad @Makdaam 