### PR TITLE
Moving docker images from centos to rhel base.

### DIFF
--- a/Dockerfile.azure-controllers
+++ b/Dockerfile.azure-controllers
@@ -1,4 +1,3 @@
-FROM centos:7
-RUN yum -y update
+FROM rhel7
 COPY azure-controllers .
 ENTRYPOINT [ "/azure-controllers" ]

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,4 +1,3 @@
-FROM centos:7
-RUN yum -y update
+FROM rhel7
 COPY e2e .
 ENTRYPOINT [ "/e2e" ]

--- a/Dockerfile.etcdbackup
+++ b/Dockerfile.etcdbackup
@@ -1,4 +1,3 @@
-FROM centos:7
-RUN yum -y update
+FROM rhel7
 COPY etcdbackup .
 ENTRYPOINT [ "/etcdbackup" ]

--- a/Dockerfile.metricsbridge
+++ b/Dockerfile.metricsbridge
@@ -1,4 +1,3 @@
-FROM centos:7
-RUN yum -y update
+FROM rhel7
 COPY metricsbridge .
 ENTRYPOINT [ "/metricsbridge" ]

--- a/Dockerfile.sync
+++ b/Dockerfile.sync
@@ -1,4 +1,3 @@
-FROM centos:7
-RUN yum -y update
+FROM rhel7
 COPY sync .
 ENTRYPOINT [ "/sync" ]


### PR DESCRIPTION
Moving our base images from centos to rhel.  @pweil- sent me a link to origin and their image building here(https://github.com/openshift/origin/blob/master/images/base/Dockerfile.rhel7).  This uses a rhel7 base image which lives on registry.access.redhat.com.

