### PR TITLE
Update azure compute api

### DIFF
--- a/pkg/arm/resources.go
+++ b/pkg/arm/resources.go
@@ -7,7 +7,7 @@ import (
 	"sort"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-06-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-07-01/network"
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2015-06-15/storage"
 	"github.com/Azure/go-autorest/autorest/to"
@@ -54,7 +54,7 @@ func fixupAPIVersions(template map[string]interface{}) {
 		var apiVersion string
 		switch typ {
 		case "Microsoft.Compute/virtualMachineScaleSets":
-			apiVersion = "2018-06-01"
+			apiVersion = "2018-10-01"
 		case "Microsoft.Network/loadBalancers",
 			"Microsoft.Network/networkSecurityGroups",
 			"Microsoft.Network/publicIPAddresses",
@@ -502,8 +502,8 @@ func Vmss(pc *api.PluginConfig, cs *api.OpenShiftManagedCluster, app *api.AgentP
 		},
 		VirtualMachineScaleSetProperties: &compute.VirtualMachineScaleSetProperties{
 			UpgradePolicy: &compute.UpgradePolicy{
-				AutoOSUpgradePolicy: &compute.AutoOSUpgradePolicy{
-					DisableAutoRollback: to.BoolPtr(false),
+				AutomaticOSUpgradePolicy: &compute.AutomaticOSUpgradePolicy{
+					DisableAutomaticRollback: to.BoolPtr(false),
 				},
 				Mode: compute.Manual,
 			},

--- a/pkg/cluster/hash.go
+++ b/pkg/cluster/hash.go
@@ -10,7 +10,7 @@ import (
 	"crypto/sha256"
 	"encoding/json"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-06-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
 
 	"github.com/openshift/openshift-azure/pkg/api"
 	"github.com/openshift/openshift-azure/pkg/arm"

--- a/pkg/cluster/ready_test.go
+++ b/pkg/cluster/ready_test.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-06-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/sirupsen/logrus"

--- a/pkg/cluster/scaler/scaler.go
+++ b/pkg/cluster/scaler/scaler.go
@@ -9,7 +9,7 @@ package scaler
 import (
 	"context"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-06-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/sirupsen/logrus"
 

--- a/pkg/cluster/scaler/scaler_test.go
+++ b/pkg/cluster/scaler/scaler_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-06-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/sirupsen/logrus"

--- a/pkg/cluster/update_master.go
+++ b/pkg/cluster/update_master.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"sort"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-06-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
 
 	"github.com/openshift/openshift-azure/pkg/api"
 	"github.com/openshift/openshift-azure/pkg/cluster/kubeclient"

--- a/pkg/cluster/update_master_test.go
+++ b/pkg/cluster/update_master_test.go
@@ -5,7 +5,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-06-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/sirupsen/logrus"

--- a/pkg/cluster/update_worker.go
+++ b/pkg/cluster/update_worker.go
@@ -5,7 +5,7 @@ import (
 	"context"
 	"strings"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-06-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
 	"github.com/Azure/go-autorest/autorest/to"
 
 	"github.com/openshift/openshift-azure/pkg/api"

--- a/pkg/cluster/update_worker_test.go
+++ b/pkg/cluster/update_worker_test.go
@@ -6,7 +6,7 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-06-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/golang/mock/gomock"
 	"github.com/sirupsen/logrus"

--- a/pkg/util/azureclient/compute.go
+++ b/pkg/util/azureclient/compute.go
@@ -3,7 +3,7 @@ package azureclient
 import (
 	"context"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-06-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
 	"github.com/Azure/go-autorest/autorest"
 )
 

--- a/pkg/util/azureclient/compute_addons.go
+++ b/pkg/util/azureclient/compute_addons.go
@@ -76,6 +76,7 @@ type VirtualMachineScaleSetVMsClientAddons interface {
 	Delete(ctx context.Context, resourceGroupName, VMScaleSetName, instanceID string) error
 	List(ctx context.Context, resourceGroupName, virtualMachineScaleSetName, filter, selectParameter, expand string) ([]compute.VirtualMachineScaleSetVM, error)
 	Reimage(ctx context.Context, resourceGroupName, VMScaleSetName, instanceID string, VMScaleSetVMReimageInput *compute.VirtualMachineScaleSetVMReimageParameters) error
+	ReimageAll(ctx context.Context, resourceGroupName string, VMScaleSetName string, instanceID string) (result compute.VirtualMachineScaleSetVMsReimageAllFuture, err error)
 	Restart(ctx context.Context, resourceGroupName, VMScaleSetName, instanceID string) error
 	Start(ctx context.Context, resourceGroupName, VMScaleSetName, instanceID string) error
 }

--- a/pkg/util/azureclient/compute_addons.go
+++ b/pkg/util/azureclient/compute_addons.go
@@ -3,7 +3,7 @@ package azureclient
 import (
 	"context"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-06-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
 )
 
 // NOTE: we should be very sparing and have a high bar for these kind of hacks.

--- a/pkg/util/mocks/mock_azureclient/azureclient.go
+++ b/pkg/util/mocks/mock_azureclient/azureclient.go
@@ -8,7 +8,7 @@ import (
 	context "context"
 	reflect "reflect"
 
-	compute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-06-01/compute"
+	compute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
 	marketplaceordering "github.com/Azure/azure-sdk-for-go/services/marketplaceordering/mgmt/2015-06-01/marketplaceordering"
 	resources "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
 	managedapplications "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-06-01/managedapplications"

--- a/pkg/util/mocks/mock_azureclient/azureclient.go
+++ b/pkg/util/mocks/mock_azureclient/azureclient.go
@@ -242,6 +242,21 @@ func (mr *MockVirtualMachineScaleSetVMsClientMockRecorder) Reimage(arg0, arg1, a
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Reimage", reflect.TypeOf((*MockVirtualMachineScaleSetVMsClient)(nil).Reimage), arg0, arg1, arg2, arg3, arg4)
 }
 
+// ReimageAll mocks base method
+func (m *MockVirtualMachineScaleSetVMsClient) ReimageAll(arg0 context.Context, arg1, arg2, arg3 string) (compute.VirtualMachineScaleSetVMsReimageAllFuture, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ReimageAll", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(compute.VirtualMachineScaleSetVMsReimageAllFuture)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// ReimageAll indicates an expected call of ReimageAll
+func (mr *MockVirtualMachineScaleSetVMsClientMockRecorder) ReimageAll(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ReimageAll", reflect.TypeOf((*MockVirtualMachineScaleSetVMsClient)(nil).ReimageAll), arg0, arg1, arg2, arg3)
+}
+
 // Restart mocks base method
 func (m *MockVirtualMachineScaleSetVMsClient) Restart(arg0 context.Context, arg1, arg2, arg3 string) error {
 	m.ctrl.T.Helper()

--- a/pkg/util/mocks/mock_scaler/scaler.go
+++ b/pkg/util/mocks/mock_scaler/scaler.go
@@ -8,7 +8,7 @@ import (
 	context "context"
 	reflect "reflect"
 
-	compute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-06-01/compute"
+	compute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
 	gomock "github.com/golang/mock/gomock"
 	logrus "github.com/sirupsen/logrus"
 

--- a/test/e2e/specs/realrp/realrp.go
+++ b/test/e2e/specs/realrp/realrp.go
@@ -10,7 +10,7 @@ import (
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
 
-	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-06-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
 	"github.com/Azure/go-autorest/autorest/to"
 
 	"github.com/openshift/openshift-azure/pkg/fakerp/client"


### PR DESCRIPTION
An updated azure compute sdk is required for a few of the proposed geneva action implementations (https://github.com/openshift/openshift-azure/pull/1085 and  https://github.com/openshift/openshift-azure/pull/1091).

This PR updates the compute sdk to `2018-10-01` and also takes a stab at solving the `Reimage` parameter issue which was added [here](https://github.com/openshift/openshift-azure/pull/1064) and was attempted to be solved [here](https://github.com/openshift/openshift-azure/pull/1069). The eventual workaround can be found [here](https://github.com/openshift/openshift-azure/pull/1070)

After getting merged, related open geneva-related PRs (e.g. [this](https://github.com/openshift/openshift-azure/pull/1085)) would need to rebase to pull in the compute updates.

/cc @mjudeikis @Makdaam 