### PR TITLE
Fix makefile for debian-based systems

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,11 @@ COMMIT=$(shell git rev-parse --short HEAD)$(shell [[ $$(git status --porcelain) 
 CLUSTER_VERSION=$(shell awk '/^clusterVersion: /{ print $$2 }' <pluginconfig/pluginconfig-311.yaml)
 # if we are on master branch we should always use dev tag
 $(info CLUSTER_VERSION is ${CLUSTER_VERSION})
-TAG=$(shell if [[ "${CLUSTER_VERSION}" == "v0.0" ]]; then echo "dev"; else echo ${CLUSTER_VERSION}; fi)
+ifeq ($(CLUSTER_VERSION),v0.0)
+  TAG := dev
+else
+  TAG := ${CLUSTER_VERSION}
+endif
 $(info TAG set to ${TAG})
 LDFLAGS="-X main.gitCommit=$(COMMIT)"
 E2E_IMAGE ?= quay.io/openshift-on-azure-dev/e2e-tests:$(TAG)


### PR DESCRIPTION
Before this fix, I saw the following error at the top of every make invocation

```
charles@titan:~/Documents/go/src/github.com/openshift/openshift-azure$ make generate
CLUSTER_VERSION is v0.0
/bin/sh: 1: [[: not found
TAG set to v0.0
go generate ./...
bindata.go
```

/cc @mjudeikis @kwoodson @Makdaam 