### PR TITLE
Allow RP credentials to be used in plugin

### DIFF
--- a/pkg/api/plugin.go
+++ b/pkg/api/plugin.go
@@ -11,10 +11,11 @@ import (
 type ContextKey string
 
 const (
-	ContextKeyClientID     ContextKey = "ClientID"
-	ContextKeyClientSecret ContextKey = "ClientSecret"
-	ContextKeyTenantID     ContextKey = "TenantID"
-	ContextAcceptLanguages ContextKey = "AcceptLanguages"
+	ContextKeyCloudProviderClientID     ContextKey = "ClientID"
+	ContextKeyCloudProviderClientSecret ContextKey = "ClientSecret"
+	ContextKeyCloudProviderTenantID     ContextKey = "TenantID"
+	ContextKeyClientAuthorizer          ContextKey = "ClientAuthorizer"
+	ContextAcceptLanguages              ContextKey = "AcceptLanguages"
 )
 
 type PluginStep string

--- a/pkg/cluster/types.go
+++ b/pkg/cluster/types.go
@@ -78,7 +78,7 @@ func (u *simpleUpgrader) CreateClients(ctx context.Context, cs *api.OpenShiftMan
 		},
 	}
 
-	authorizer, err := azureclient.NewAuthorizerFromContext(ctx)
+	authorizer, err := azureclient.GetAuthorizerFromContext(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/fakerp/admin_handlers.go
+++ b/pkg/fakerp/admin_handlers.go
@@ -19,7 +19,11 @@ func (s *Server) handleGetControlPlanePods(w http.ResponseWriter, req *http.Requ
 		s.internalError(w, "Failed to read the internal config")
 		return
 	}
-	ctx := enrichContext(context.Background())
+	ctx, err := enrichContext(context.Background())
+	if err != nil {
+		s.internalError(w, fmt.Sprintf("Failed to enrich context: %v", err))
+		return
+	}
 	pods, err := s.plugin.GetControlPlanePods(ctx, cs)
 	if err != nil {
 		s.internalError(w, fmt.Sprintf("Failed to fetch control plane pods: %v", err))
@@ -83,7 +87,11 @@ func (s *Server) handleRestore(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	ctx = enrichContext(context.Background())
+	ctx, err = enrichContext(context.Background())
+	if err != nil {
+		s.internalError(w, fmt.Sprintf("Failed to enrich context: %v", err))
+		return
+	}
 	deployer := GetDeployer(s.log, cs, s.pluginConfig)
 	if err := s.plugin.RecoverEtcdCluster(ctx, cs, deployer, blobName); err != nil {
 		s.internalError(w, fmt.Sprintf("Failed to recover cluster: %v", err))
@@ -100,7 +108,11 @@ func (s *Server) handleRotateSecrets(w http.ResponseWriter, req *http.Request) {
 		s.internalError(w, "Failed to read the internal config")
 		return
 	}
-	ctx := enrichContext(context.Background())
+	ctx, err := enrichContext(context.Background())
+	if err != nil {
+		s.internalError(w, fmt.Sprintf("Failed to enrich context: %v", err))
+		return
+	}
 	deployer := GetDeployer(s.log, cs, s.pluginConfig)
 	if err := s.plugin.RotateClusterSecrets(ctx, cs, deployer, s.pluginTemplate); err != nil {
 		s.internalError(w, fmt.Sprintf("Failed to rotate cluster secrets: %v", err))

--- a/pkg/fakerp/customer_handlers.go
+++ b/pkg/fakerp/customer_handlers.go
@@ -23,10 +23,13 @@ import (
 
 func (s *Server) handleDelete(w http.ResponseWriter, req *http.Request) {
 	// simulate Context with property bag
-	ctx := enrichContext(context.Background())
+	ctx, err := enrichContext(context.Background())
+	if err != nil {
+		s.internalError(w, fmt.Sprintf("Failed to enrich context: %v", err))
+		return
+	}
 
-	// TODO: Get the azure credentials from the request headers
-	authorizer, err := azureclient.NewAuthorizer(os.Getenv("AZURE_CLIENT_ID"), os.Getenv("AZURE_CLIENT_SECRET"), os.Getenv("AZURE_TENANT_ID"))
+	authorizer, err := azureclient.GetAuthorizerFromContext(ctx)
 	if err != nil {
 		s.internalError(w, fmt.Sprintf("Failed to determine request credentials: %v", err))
 		return
@@ -136,7 +139,11 @@ func (s *Server) handlePut(w http.ResponseWriter, req *http.Request) {
 
 	// simulate Context with property bag
 	// TODO: Populate context from request header
-	ctx := enrichContext(context.Background())
+	ctx, err := enrichContext(context.Background())
+	if err != nil {
+		s.internalError(w, fmt.Sprintf("Failed to enrich context: %v", err))
+		return
+	}
 
 	// apply the request
 	cs, err = createOrUpdate(ctx, s.log, cs, oldCs, s.pluginConfig, isAdminRequest)

--- a/pkg/fakerp/dns.go
+++ b/pkg/fakerp/dns.go
@@ -15,7 +15,7 @@ import (
 // CreateOCPDNS creates the dns zone for the cluster, updates the main zone in dnsResourceGroup and returns
 // the generated publicSubdomain, routerPrefix
 func CreateOCPDNS(ctx context.Context, subscriptionID, resourceGroup, location, dnsResourceGroup, dnsDomain, zoneName, routerCName string, noTags bool) error {
-	authorizer, err := azureclient.NewAuthorizerFromContext(ctx)
+	authorizer, err := azureclient.GetAuthorizerFromContext(ctx)
 	if err != nil {
 		return err
 	}
@@ -115,7 +115,7 @@ func CreateOCPDNS(ctx context.Context, subscriptionID, resourceGroup, location, 
 }
 
 func DeleteOCPDNS(ctx context.Context, subscriptionID, resourceGroup, dnsResourceGroup, dnsDomain string) error {
-	authorizer, err := azureclient.NewAuthorizerFromContext(ctx)
+	authorizer, err := azureclient.GetAuthorizerFromContext(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/fakerp/fakerp.go
+++ b/pkg/fakerp/fakerp.go
@@ -26,7 +26,7 @@ import (
 func GetDeployer(log *logrus.Entry, cs *api.OpenShiftManagedCluster, config *api.PluginConfig) api.DeployFn {
 	return func(ctx context.Context, azuretemplate map[string]interface{}) error {
 		log.Info("applying arm template deployment")
-		authorizer, err := azureclient.NewAuthorizerFromContext(ctx)
+		authorizer, err := azureclient.GetAuthorizerFromContext(ctx)
 		if err != nil {
 			return err
 		}
@@ -185,7 +185,7 @@ func acceptMarketplaceAgreement(ctx context.Context, log *logrus.Entry, cs *api.
 		return nil
 	}
 
-	authorizer, err := azureclient.NewAuthorizerFromContext(ctx)
+	authorizer, err := azureclient.GetAuthorizerFromContext(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/util/azureclient/azureclient.go
+++ b/pkg/util/azureclient/azureclient.go
@@ -11,6 +11,7 @@ package azureclient
 
 import (
 	"context"
+	"fmt"
 	"net/http"
 	"net/http/httputil"
 	"os"
@@ -83,7 +84,15 @@ func NewAuthorizerFromUsernamePassword(username, password, clientID, tenantID, r
 }
 
 func NewAuthorizerFromContext(ctx context.Context) (autorest.Authorizer, error) {
-	return NewAuthorizer(ctx.Value(api.ContextKeyClientID).(string), ctx.Value(api.ContextKeyClientSecret).(string), ctx.Value(api.ContextKeyTenantID).(string))
+	return NewAuthorizer(ctx.Value(api.ContextKeyCloudProviderClientID).(string), ctx.Value(api.ContextKeyCloudProviderClientSecret).(string), ctx.Value(api.ContextKeyCloudProviderTenantID).(string))
+}
+
+func GetAuthorizerFromContext(ctx context.Context) (autorest.Authorizer, error) {
+	authorizer, ok := ctx.Value(api.ContextKeyClientAuthorizer).(autorest.Authorizer)
+	if !ok {
+		return nil, fmt.Errorf("failed to get authorizer, not found within context")
+	}
+	return authorizer, nil
 }
 
 func NewAuthorizerFromEnvironment() (autorest.Authorizer, error) {


### PR DESCRIPTION
The Authorizer comes in from the RP and is passed to the plugin for
subsequent requests. Before, the autorest.Authorizer object was created
using credentials harvested by the plugin.

In this PR, the fakerp package is also altered in order to pass along an
RP generated autorest.Authorizer mocked by enrichContext(). Otherwise,
the internal communication of the credentials is done via the
GetAuthorizerFromContext() routine.

Signed-off-by: Yannick Cote <ycote@redhat.com>