### PR TITLE
rollback use of UpdateStatus

### DIFF
--- a/pkg/fakerp/admin_handlers.go
+++ b/pkg/fakerp/admin_handlers.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/storage"
 
-	internalapi "github.com/openshift/openshift-azure/pkg/api"
 	"github.com/openshift/openshift-azure/pkg/cluster"
 	"github.com/openshift/openshift-azure/pkg/util/cloudprovider"
 	"github.com/openshift/openshift-azure/pkg/util/configblob"
@@ -20,7 +19,6 @@ func (s *Server) handleGetControlPlanePods(w http.ResponseWriter, req *http.Requ
 		s.internalError(w, "Failed to read the internal config")
 		return
 	}
-	s.writeState(internalapi.AdminUpdating)
 	ctx := enrichContext(context.Background())
 	pods, err := s.plugin.GetControlPlanePods(ctx, cs)
 	if err != nil {
@@ -85,7 +83,6 @@ func (s *Server) handleRestore(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	s.writeState(internalapi.AdminUpdating)
 	ctx = enrichContext(context.Background())
 	deployer := GetDeployer(s.log, cs, s.pluginConfig)
 	if err := s.plugin.RecoverEtcdCluster(ctx, cs, deployer, blobName); err != nil {
@@ -103,7 +100,6 @@ func (s *Server) handleRotateSecrets(w http.ResponseWriter, req *http.Request) {
 		s.internalError(w, "Failed to read the internal config")
 		return
 	}
-	s.writeState(internalapi.AdminUpdating)
 	ctx := enrichContext(context.Background())
 	deployer := GetDeployer(s.log, cs, s.pluginConfig)
 	if err := s.plugin.RotateClusterSecrets(ctx, cs, deployer, s.pluginTemplate); err != nil {


### PR DESCRIPTION
Remove/rollback `adminUpdate` state as this sets "provisioningState" inside containerservices.yaml and if test is running in the wrong order, this is causing next tests to rotate nodes.

Example:
A subset of tests ran before and now we have modified provisioning state (local and cluster) so it will trigger node rollout.
```
→ diff _data/containerservice.yaml _data/containerservice.yaml_bckp                                                                                                                                                
178d177                                                                                                                                                                                                            
<   provisioningState: AdminUpdating     
```

Need to check which test is causing these statues to leak and fix. We should be able to reset status, or have status "Running/Healthy".

Overall wrong setting and unsetting of status is causing flakes. 