### PR TITLE
Geneva action force-rotate cluster

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -130,6 +130,9 @@ e2e-keyrotation:
 e2e-scaleupdown:
 	FOCUS="\[ScaleUpDown\]\[Fake\]" TIMEOUT=30m ./hack/e2e.sh
 
+e2e-forceupdate:
+	FOCUS="\[ForceUpdate\]\[Fake\]" TIMEOUT=70m ./hack/e2e.sh
+
 e2e-vnet:
 	FOCUS="\[Vnet\]\[Real\]" TIMEOUT=70m ./hack/e2e.sh
 

--- a/pkg/api/plugin.go
+++ b/pkg/api/plugin.go
@@ -21,6 +21,7 @@ const (
 	PluginStepDeploy                              PluginStep = "Deploy"
 	PluginStepInitialize                          PluginStep = "Initialize"
 	PluginStepInitializeUpdateBlob                PluginStep = "InitializeUpdateBlob"
+	PluginStepResetUpdateBlob                     PluginStep = "ResetUpdateBlob"
 	PluginStepClientCreation                      PluginStep = "ClientCreation"
 	PluginStepScaleSetDelete                      PluginStep = "ScaleSetDelete"
 	PluginStepGenerateARM                         PluginStep = "GenerateARM"
@@ -121,4 +122,7 @@ type GenevaActions interface {
 
 	// GetControlPlanePods fetches a consolidated list of the control plane pods in the cluster
 	GetControlPlanePods(ctx context.Context, oc *OpenShiftManagedCluster) ([]byte, error)
+
+	// ForceUpdate forces rotates all vms in a cluster
+	ForceUpdate(ctx context.Context, cs *OpenShiftManagedCluster, deployer DeployFn) *PluginError
 }

--- a/pkg/cluster/initialize.go
+++ b/pkg/cluster/initialize.go
@@ -76,3 +76,8 @@ func (u *simpleUpgrader) InitializeUpdateBlob(cs *api.OpenShiftManagedCluster, s
 	}
 	return u.updateBlobService.Write(blob)
 }
+
+func (u *simpleUpgrader) ResetUpdateBlob(cs *api.OpenShiftManagedCluster) error {
+	blob := updateblob.NewUpdateBlob()
+	return u.updateBlobService.Write(blob)
+}

--- a/pkg/cluster/types.go
+++ b/pkg/cluster/types.go
@@ -42,6 +42,7 @@ type Upgrader interface {
 	UpdateWorkerAgentPool(ctx context.Context, cs *api.OpenShiftManagedCluster, app *api.AgentPoolProfile, suffix string) *api.PluginError
 	EtcdRestoreDeleteMasterScaleSet(ctx context.Context, cs *api.OpenShiftManagedCluster) *api.PluginError
 	EtcdRestoreDeleteMasterScaleSetHashes(ctx context.Context, cs *api.OpenShiftManagedCluster) *api.PluginError
+	ResetUpdateBlob(cs *api.OpenShiftManagedCluster) error
 }
 
 type simpleUpgrader struct {

--- a/pkg/fakerp/admin_handlers.go
+++ b/pkg/fakerp/admin_handlers.go
@@ -124,3 +124,23 @@ func (s *Server) handleRotateSecrets(w http.ResponseWriter, req *http.Request) {
 	}
 	s.log.Info("rotated cluster secrets")
 }
+
+// handleForceUpdate handles admin requests for the force updates of clusters
+func (s *Server) handleForceUpdate(w http.ResponseWriter, req *http.Request) {
+	cs := s.read()
+	if cs == nil {
+		s.internalError(w, "Failed to read the internal config")
+		return
+	}
+	ctx, err := enrichContext(context.Background())
+	if err != nil {
+		s.internalError(w, fmt.Sprintf("Failed to enrich context: %v", err))
+		return
+	}
+	deployer := GetDeployer(s.log, cs, s.pluginConfig)
+	if err := s.plugin.ForceUpdate(ctx, cs, deployer); err != nil {
+		s.internalError(w, fmt.Sprintf("Failed to force update cluster: %v", err))
+		return
+	}
+	s.log.Info("force-updated cluster")
+}

--- a/pkg/fakerp/routes.go
+++ b/pkg/fakerp/routes.go
@@ -22,4 +22,5 @@ func (s *Server) SetupRoutes() {
 	s.router.Put(filepath.Join("/admin", s.basePath, "/restore"), s.handleRestore)
 	s.router.Put(filepath.Join("/admin", s.basePath, "/rotate/secrets"), s.handleRotateSecrets)
 	s.router.Get(filepath.Join("/admin", s.basePath, "/status"), s.handleGetControlPlanePods)
+	s.router.Put(filepath.Join("/admin", s.basePath, "/forceUpdate"), s.handleForceUpdate)
 }

--- a/pkg/util/azureclient/openshiftmanagedcluster/admin/client.go
+++ b/pkg/util/azureclient/openshiftmanagedcluster/admin/client.go
@@ -256,6 +256,109 @@ func (client OpenShiftManagedClustersClient) DeleteResponder(resp *http.Response
 	return
 }
 
+// OpenShiftManagedClustersForceUpdateFuture is an abstraction for monitoring and retrieving the results of a
+// long-running operation.
+type OpenShiftManagedClustersForceUpdateFuture struct {
+	azure.Future
+}
+
+// Result returns the result of the asynchronous operation.
+// If the operation has not completed it will return an error.
+func (future *OpenShiftManagedClustersForceUpdateFuture) Result(client OpenShiftManagedClustersClient) (ar autorest.Response, err error) {
+	var done bool
+	done, err = future.Done(client)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "containerservice.OpenShiftManagedClustersForceUpdateFuture", "Result", future.Response(), "Polling failure")
+		return
+	}
+	if !done {
+		err = azure.NewAsyncOpIncompleteError("containerservice.OpenShiftManagedClustersForceUpdateFuture")
+		return
+	}
+	ar.Response = future.Response()
+	return
+}
+
+// ForceUpdateAndWait zeroes the update hash to force an update to an OpenShiftManagedCluster
+// and waits for the request to complete before returning.
+func (client OpenShiftManagedClustersClient) ForceUpdateAndWait(ctx context.Context, resourceGroupName, resourceName string) (result autorest.Response, err error) {
+	var future OpenShiftManagedClustersForceUpdateFuture
+	future, err = client.ForceUpdate(ctx, resourceGroupName, resourceName)
+	if err != nil {
+		return
+	}
+	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return
+	}
+	return future.Result(client)
+}
+
+// ForceUpdate zeroes the update hash to force an update to an OpenShiftManagedCluster
+// Parameters:
+// resourceGroupName - the name of the Resource group.
+// resourceName - the name of the OpenShiftManagedCluster
+func (client OpenShiftManagedClustersClient) ForceUpdate(ctx context.Context, resourceGroupName, resourceName string) (result OpenShiftManagedClustersForceUpdateFuture, err error) {
+	req, err := client.ForceUpdatePreparer(ctx, resourceGroupName, resourceName)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "containerservice.OpenShiftManagedClustersClient", "ForceUpdate", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = client.ForceUpdateSender(req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "containerservice.OpenShiftManagedClustersClient", "ForceUpdate", result.Response(), "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// ForceUpdatePreparer prepares the ForceUpdate request.
+func (client OpenShiftManagedClustersClient) ForceUpdatePreparer(ctx context.Context, resourceGroupName, resourceName string) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"resourceGroupName": autorest.Encode("path", resourceGroupName),
+		"resourceName":      autorest.Encode("path", resourceName),
+		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
+	}
+
+	queryParameters := map[string]interface{}{
+		"api-version": api.APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/openShiftManagedClusters/{resourceName}/forceUpdate", pathParameters),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// ForceUpdateSender sends the ForceUpdate request. The method will close the
+// http.Response Body if it receives an error.
+func (client OpenShiftManagedClustersClient) ForceUpdateSender(req *http.Request) (future OpenShiftManagedClustersForceUpdateFuture, err error) {
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
+	return
+}
+
+// ForceUpdateResponder handles the response to the ForceUpdate request. The method
+// always closes the http.Response Body.
+func (client OpenShiftManagedClustersClient) ForceUpdateResponder(resp *http.Response) (result autorest.Response, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
+		autorest.ByClosing())
+	result.Response = resp
+	return
+}
+
 // Get gets the details of the managed openshift cluster with a specified resource group and name.
 // Parameters:
 // resourceGroupName - the name of the resource group.

--- a/pkg/util/mocks/mock_cluster/types.go
+++ b/pkg/util/mocks/mock_cluster/types.go
@@ -189,3 +189,17 @@ func (mr *MockUpgraderMockRecorder) EtcdRestoreDeleteMasterScaleSetHashes(ctx, c
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "EtcdRestoreDeleteMasterScaleSetHashes", reflect.TypeOf((*MockUpgrader)(nil).EtcdRestoreDeleteMasterScaleSetHashes), ctx, cs)
 }
+
+// ResetUpdateBlob mocks base method
+func (m *MockUpgrader) ResetUpdateBlob(cs *api.OpenShiftManagedCluster) error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "ResetUpdateBlob", cs)
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// ResetUpdateBlob indicates an expected call of ResetUpdateBlob
+func (mr *MockUpgraderMockRecorder) ResetUpdateBlob(cs interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ResetUpdateBlob", reflect.TypeOf((*MockUpgrader)(nil).ResetUpdateBlob), cs)
+}

--- a/test/e2e/specs/fakerp/forceupdate.go
+++ b/test/e2e/specs/fakerp/forceupdate.go
@@ -1,0 +1,67 @@
+package fakerp
+
+import (
+	"context"
+	"net/http"
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/openshift-azure/pkg/cluster/updateblob"
+	"github.com/openshift/openshift-azure/test/clients/azure"
+	"github.com/openshift/openshift-azure/test/e2e/standard"
+)
+
+var _ = Describe("Force Update E2E tests [ForceUpdate][Fake][LongRunning]", func() {
+	var (
+		azurecli *azure.Client
+		cli      *standard.SanityChecker
+	)
+
+	BeforeEach(func() {
+		var err error
+		azurecli, err = azure.NewClientFromEnvironment(true)
+		Expect(err).NotTo(HaveOccurred())
+		cli, err = standard.NewDefaultSanityChecker()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cli).NotTo(BeNil())
+	})
+
+	It("should be possible for an SRE to force update a cluster", func() {
+		By("Reading the update blob before the force update")
+		ubs, err := updateblob.NewBlobService(azurecli.BlobStorage)
+		Expect(err).ToNot(HaveOccurred())
+		before, err := ubs.Read()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(before).NotTo(BeNil())
+		Expect(len(before.InstanceHashes)).To(BeEquivalentTo(3)) // one per master instance
+		Expect(len(before.ScalesetHashes)).To(BeEquivalentTo(2)) // one per worker scaleset
+
+		By("Executing force update on the cluster.")
+		update, err := azurecli.OpenShiftManagedClustersAdmin.ForceUpdateAndWait(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(update.StatusCode).To(Equal(http.StatusOK))
+		Expect(update).NotTo(BeNil())
+
+		By("Reading the update blob after the force update")
+		after, err := ubs.Read()
+		Expect(err).ToNot(HaveOccurred())
+		Expect(after).NotTo(BeNil())
+
+		By("Verifying that the instance hashes of the update blob are identical (masters)")
+		for key, val := range before.InstanceHashes {
+			Expect(after.InstanceHashes).To(HaveKey(key))
+			Expect(val).To(Equal(after.InstanceHashes[key]))
+		}
+
+		By("Verifying that the scaleset hashes of the update blob are different (workers)")
+		for key := range before.ScalesetHashes {
+			Expect(after.ScalesetHashes).NotTo(HaveKey(key))
+		}
+
+		By("Validating the cluster")
+		errs := cli.ValidateCluster(context.Background())
+		Expect(errs).To(BeEmpty())
+	})
+})


### PR DESCRIPTION
This work implements a geneva action that allows an admin to force-update a cluster by resetting/zeroing the cluster's update blob prior to calling update.

This is part of AZURE-257

/cc @mjudeikis @Makdaam @thekad @jim-minter 