### PR TITLE
Geneva action update cluster with latest plugin config

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -128,6 +128,9 @@ e2e-etcdbackuprecovery:
 e2e-keyrotation:
 	FOCUS="\[KeyRotation\]\[Fake\]" TIMEOUT=70m ./hack/e2e.sh
 
+e2e-updatecluster:
+	FOCUS="\[UpdateCluster\]\[Fake\]" TIMEOUT=70m ./hack/e2e.sh
+
 e2e-scaleupdown:
 	FOCUS="\[ScaleUpDown\]\[Fake\]" TIMEOUT=30m ./hack/e2e.sh
 

--- a/pkg/api/plugin.go
+++ b/pkg/api/plugin.go
@@ -53,7 +53,7 @@ const (
 	PluginStepUpdateWorkerAgentPoolUpdateBlob     PluginStep = "UpdateWorkerAgentPoolUpdateBlob"
 	PluginStepUpdateWorkerAgentPoolDeleteVM       PluginStep = "UpdateWorkerAgentPoolDeleteVM"
 	PluginStepInvalidateClusterSecrets            PluginStep = "InvalidateClusterSecrets"
-	PluginStepRegenerateClusterSecrets            PluginStep = "RegenerateClusterSecrets"
+	PluginStepRegenerateClusterConfig             PluginStep = "RegenerateClusterConfig"
 )
 
 // PluginError error returned by CreateOrUpdate to specify the step that failed.
@@ -125,4 +125,7 @@ type GenevaActions interface {
 
 	// ForceUpdate forces rotates all vms in a cluster
 	ForceUpdate(ctx context.Context, cs *OpenShiftManagedCluster, deployer DeployFn) *PluginError
+
+	// UpdateCluster updates a cluster using the latest plugin config known to plugin
+	UpdateCluster(ctx context.Context, cs *OpenShiftManagedCluster, deployer DeployFn) *PluginError
 }

--- a/pkg/fakerp/routes.go
+++ b/pkg/fakerp/routes.go
@@ -23,4 +23,5 @@ func (s *Server) SetupRoutes() {
 	s.router.Put(filepath.Join("/admin", s.basePath, "/rotate/secrets"), s.handleRotateSecrets)
 	s.router.Get(filepath.Join("/admin", s.basePath, "/status"), s.handleGetControlPlanePods)
 	s.router.Put(filepath.Join("/admin", s.basePath, "/forceUpdate"), s.handleForceUpdate)
+	s.router.Put(filepath.Join("/admin", s.basePath, "/updateCluster"), s.handleUpdateCluster)
 }

--- a/pkg/fakerp/shared/shared_test.go
+++ b/pkg/fakerp/shared/shared_test.go
@@ -1,0 +1,93 @@
+package shared
+
+import (
+	"testing"
+
+	"github.com/openshift/openshift-azure/pkg/api"
+)
+
+func TestIsScaleOperation(t *testing.T) {
+	tests := []struct {
+		name     string
+		new      *api.OpenShiftManagedCluster
+		old      *api.OpenShiftManagedCluster
+		expected bool
+	}{
+		{
+			name:     "old and new are the same",
+			new:      &api.OpenShiftManagedCluster{},
+			old:      &api.OpenShiftManagedCluster{},
+			expected: false,
+		},
+		{
+			name: "old and new differ only in the agent pool profile counts",
+			new: &api.OpenShiftManagedCluster{
+				Properties: api.Properties{
+					AgentPoolProfiles: []api.AgentPoolProfile{
+						{Role: api.AgentPoolProfileRoleMaster, Name: "master", Count: 3},
+						{Role: api.AgentPoolProfileRoleCompute, Name: "compute", Count: 10},
+						{Role: api.AgentPoolProfileRoleInfra, Name: "infra", Count: 2},
+					},
+				},
+			},
+			old: &api.OpenShiftManagedCluster{
+				Properties: api.Properties{
+					AgentPoolProfiles: []api.AgentPoolProfile{
+						{Role: api.AgentPoolProfileRoleMaster, Name: "master", Count: 3},
+						{Role: api.AgentPoolProfileRoleCompute, Name: "compute", Count: 2},
+						{Role: api.AgentPoolProfileRoleInfra, Name: "infra", Count: 3},
+					},
+				},
+			},
+			expected: true,
+		},
+		{
+			name: "old and new differ in the agent pool profile counts and other parts of config",
+			new: &api.OpenShiftManagedCluster{
+				Config: api.Config{
+					ImageVersion: "311.61.20190204",
+				},
+				Properties: api.Properties{
+					AgentPoolProfiles: []api.AgentPoolProfile{
+						{Role: api.AgentPoolProfileRoleMaster, Name: "master", Count: 3},
+						{Role: api.AgentPoolProfileRoleCompute, Name: "compute", Count: 5},
+						{Role: api.AgentPoolProfileRoleInfra, Name: "infra", Count: 2},
+					},
+				},
+			},
+			old: &api.OpenShiftManagedCluster{
+				Config: api.Config{
+					ImageVersion: "311.51.20190104",
+				},
+				Properties: api.Properties{
+					AgentPoolProfiles: []api.AgentPoolProfile{
+						{Role: api.AgentPoolProfileRoleMaster, Name: "master", Count: 3},
+						{Role: api.AgentPoolProfileRoleCompute, Name: "compute", Count: 10},
+						{Role: api.AgentPoolProfileRoleInfra, Name: "infra", Count: 3},
+					},
+				},
+			},
+			expected: false,
+		},
+		{
+			name: "old and new have identical agent pool profiles but differ in other parts of config",
+			new: &api.OpenShiftManagedCluster{
+				Config: api.Config{
+					ImageVersion: "311.61.20190204",
+				},
+			},
+			old: &api.OpenShiftManagedCluster{
+				Config: api.Config{
+					ImageVersion: "311.51.20190104",
+				},
+			},
+			expected: false,
+		},
+	}
+
+	for _, test := range tests {
+		if got := IsScaleOperation(test.new, test.old); got != test.expected {
+			t.Errorf("IsScaleOperation() = %v, want %v", got, test.expected)
+		}
+	}
+}

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -209,7 +209,7 @@ func (p *plugin) RotateClusterSecrets(ctx context.Context, cs *api.OpenShiftMana
 	p.log.Info("regenerating config including private keys and secrets")
 	err = p.GenerateConfig(ctx, cs, pluginTemplate)
 	if err != nil {
-		return &api.PluginError{Err: err, Step: api.PluginStepRegenerateClusterSecrets}
+		return &api.PluginError{Err: err, Step: api.PluginStepRegenerateClusterConfig}
 	}
 	p.log.Info("running CreateOrUpdate")
 	if err := p.CreateOrUpdate(ctx, cs, true, deployFn); err != nil {
@@ -262,5 +262,14 @@ func (p *plugin) ForceUpdate(ctx context.Context, cs *api.OpenShiftManagedCluste
 		return err
 	}
 	p.log.Info("force updates successful")
+	return nil
+}
+
+func (p *plugin) UpdateCluster(ctx context.Context, cs *api.OpenShiftManagedCluster, deployFn api.DeployFn) *api.PluginError {
+	p.log.Info("running CreateOrUpdate")
+	if err := p.CreateOrUpdate(ctx, cs, true, deployFn); err != nil {
+		return err
+	}
+	p.log.Info("update cluster with plugin config successful")
 	return nil
 }

--- a/pkg/util/azureclient/openshiftmanagedcluster/admin/client.go
+++ b/pkg/util/azureclient/openshiftmanagedcluster/admin/client.go
@@ -667,6 +667,109 @@ func (client OpenShiftManagedClustersClient) RotateSecretsResponder(resp *http.R
 	return
 }
 
+// OpenShiftManagedClustersUpdateClusterFuture is an abstraction for monitoring and retrieving the results of a
+// long-running operation.
+type OpenShiftManagedClustersUpdateClusterFuture struct {
+	azure.Future
+}
+
+// Result returns the result of the asynchronous operation.
+// If the operation has not completed it will return an error.
+func (future *OpenShiftManagedClustersUpdateClusterFuture) Result(client OpenShiftManagedClustersClient) (ar autorest.Response, err error) {
+	var done bool
+	done, err = future.Done(client)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "containerservice.OpenShiftManagedClustersUpdateClusterFuture", "Result", future.Response(), "Polling failure")
+		return
+	}
+	if !done {
+		err = azure.NewAsyncOpIncompleteError("containerservice.OpenShiftManagedClustersUpdateClusterFuture")
+		return
+	}
+	ar.Response = future.Response()
+	return
+}
+
+// UpdateClusterAndWait updates an OpenShiftManagedCluster with the latest plugin config known to the plugin
+// and waits for the request to complete before returning.
+func (client OpenShiftManagedClustersClient) UpdateClusterAndWait(ctx context.Context, resourceGroupName, resourceName string) (result autorest.Response, err error) {
+	var future OpenShiftManagedClustersUpdateClusterFuture
+	future, err = client.UpdateCluster(ctx, resourceGroupName, resourceName)
+	if err != nil {
+		return
+	}
+	if err = future.WaitForCompletionRef(ctx, client.Client); err != nil {
+		return
+	}
+	return future.Result(client)
+}
+
+// UpdateCluster updates an OpenShiftManagedCluster with the latest plugin config known to the plugin
+// Parameters:
+// resourceGroupName - the name of the Resource group.
+// resourceName - the name of the OpenShiftManagedCluster
+func (client OpenShiftManagedClustersClient) UpdateCluster(ctx context.Context, resourceGroupName, resourceName string) (result OpenShiftManagedClustersUpdateClusterFuture, err error) {
+	req, err := client.UpdateClusterPreparer(ctx, resourceGroupName, resourceName)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "containerservice.OpenShiftManagedClustersClient", "UpdateCluster", nil, "Failure preparing request")
+		return
+	}
+
+	result, err = client.UpdateClusterSender(req)
+	if err != nil {
+		err = autorest.NewErrorWithError(err, "containerservice.OpenShiftManagedClustersClient", "UpdateCluster", result.Response(), "Failure sending request")
+		return
+	}
+
+	return
+}
+
+// UpdateClusterPreparer prepares the UpdateCluster request.
+func (client OpenShiftManagedClustersClient) UpdateClusterPreparer(ctx context.Context, resourceGroupName, resourceName string) (*http.Request, error) {
+	pathParameters := map[string]interface{}{
+		"resourceGroupName": autorest.Encode("path", resourceGroupName),
+		"resourceName":      autorest.Encode("path", resourceName),
+		"subscriptionId":    autorest.Encode("path", client.SubscriptionID),
+	}
+
+	queryParameters := map[string]interface{}{
+		"api-version": api.APIVersion,
+	}
+
+	preparer := autorest.CreatePreparer(
+		autorest.AsContentType("application/json; charset=utf-8"),
+		autorest.AsPut(),
+		autorest.WithBaseURL(client.BaseURI),
+		autorest.WithPathParameters("/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/Microsoft.ContainerService/openShiftManagedClusters/{resourceName}/updateCluster", pathParameters),
+		autorest.WithQueryParameters(queryParameters))
+	return preparer.Prepare((&http.Request{}).WithContext(ctx))
+}
+
+// UpdateClusterSender sends the UpdateCluster request. The method will close the
+// http.Response Body if it receives an error.
+func (client OpenShiftManagedClustersClient) UpdateClusterSender(req *http.Request) (future OpenShiftManagedClustersUpdateClusterFuture, err error) {
+	var resp *http.Response
+	resp, err = autorest.SendWithSender(client, req,
+		azure.DoRetryWithRegistration(client.Client))
+	if err != nil {
+		return
+	}
+	future.Future, err = azure.NewFutureFromResponse(resp)
+	return
+}
+
+// UpdateClusterResponder handles the response to the UpdateCluster request. The method
+// always closes the http.Response Body.
+func (client OpenShiftManagedClustersClient) UpdateClusterResponder(resp *http.Response) (result autorest.Response, err error) {
+	err = autorest.Respond(
+		resp,
+		client.ByInspecting(),
+		azure.WithErrorUnlessStatusCode(http.StatusOK, http.StatusAccepted),
+		autorest.ByClosing())
+	result.Response = resp
+	return
+}
+
 // UpdateTags updates an openshift managed cluster with the specified tags.
 // Parameters:
 // resourceGroupName - the name of the resource group.

--- a/pkg/util/managedcluster/managedcluster.go
+++ b/pkg/util/managedcluster/managedcluster.go
@@ -11,6 +11,7 @@ import (
 	"k8s.io/client-go/tools/clientcmd/api/v1"
 
 	"github.com/openshift/openshift-azure/pkg/api"
+	pluginapi "github.com/openshift/openshift-azure/pkg/api/plugin/api"
 )
 
 // ReadConfig returns a config object from a config file
@@ -38,4 +39,67 @@ func RestConfigFromV1Config(kc *v1.Config) (*rest.Config, error) {
 
 	kubeconfig := clientcmd.NewDefaultClientConfig(c, &clientcmd.ConfigOverrides{})
 	return kubeconfig.ClientConfig()
+}
+
+// PluginTemplate returns the plugin template which was used to create the cluster specified by cs
+func PluginTemplate(cs *api.OpenShiftManagedCluster) *pluginapi.Config {
+	return &pluginapi.Config{
+		ClusterVersion:                       cs.Config.ClusterVersion,
+		ImageOffer:                           cs.Config.ImageOffer,
+		ImagePublisher:                       cs.Config.ImagePublisher,
+		ImageSKU:                             cs.Config.ImageSKU,
+		ImageVersion:                         cs.Config.ImageVersion,
+		GenevaLoggingSector:                  cs.Config.GenevaLoggingSector,
+		GenevaLoggingNamespace:               cs.Config.GenevaLoggingNamespace,
+		GenevaLoggingAccount:                 cs.Config.GenevaLoggingAccount,
+		GenevaMetricsAccount:                 cs.Config.GenevaMetricsAccount,
+		GenevaMetricsEndpoint:                cs.Config.GenevaMetricsEndpoint,
+		GenevaLoggingControlPlaneAccount:     cs.Config.GenevaLoggingControlPlaneAccount,
+		GenevaLoggingControlPlaneEnvironment: cs.Config.GenevaLoggingControlPlaneEnvironment,
+		GenevaLoggingControlPlaneRegion:      cs.Config.GenevaLoggingControlPlaneRegion,
+		Certificates: pluginapi.CertificateConfig{
+			GenevaLogging: pluginapi.CertKeyPair{
+				Key:  cs.Config.Certificates.GenevaLogging.Key,
+				Cert: cs.Config.Certificates.GenevaLogging.Cert,
+			},
+			GenevaMetrics: pluginapi.CertKeyPair{
+				Key:  cs.Config.Certificates.GenevaMetrics.Key,
+				Cert: cs.Config.Certificates.GenevaMetrics.Cert,
+			},
+		},
+		Images: pluginapi.ImageConfig{
+			ImagePullSecret:              cs.Config.Images.ImagePullSecret,
+			GenevaImagePullSecret:        cs.Config.Images.GenevaImagePullSecret,
+			Format:                       cs.Config.Images.Format,
+			ClusterMonitoringOperator:    cs.Config.Images.ClusterMonitoringOperator,
+			AzureControllers:             cs.Config.Images.AzureControllers,
+			PrometheusOperatorBase:       cs.Config.Images.PrometheusOperatorBase,
+			PrometheusBase:               cs.Config.Images.PrometheusBase,
+			PrometheusConfigReloaderBase: cs.Config.Images.PrometheusConfigReloaderBase,
+			ConfigReloaderBase:           cs.Config.Images.ConfigReloaderBase,
+			AlertManagerBase:             cs.Config.Images.AlertManagerBase,
+			NodeExporterBase:             cs.Config.Images.NodeExporterBase,
+			GrafanaBase:                  cs.Config.Images.GrafanaBase,
+			KubeStateMetricsBase:         cs.Config.Images.KubeStateMetricsBase,
+			KubeRbacProxyBase:            cs.Config.Images.KubeRbacProxyBase,
+			OAuthProxyBase:               cs.Config.Images.OAuthProxyBase,
+			MasterEtcd:                   cs.Config.Images.MasterEtcd,
+			ControlPlane:                 cs.Config.Images.ControlPlane,
+			Node:                         cs.Config.Images.Node,
+			ServiceCatalog:               cs.Config.Images.ServiceCatalog,
+			Sync:                         cs.Config.Images.Sync,
+			TemplateServiceBroker:        cs.Config.Images.TemplateServiceBroker,
+			Registry:                     cs.Config.Images.Registry,
+			Router:                       cs.Config.Images.Router,
+			RegistryConsole:              cs.Config.Images.RegistryConsole,
+			AnsibleServiceBroker:         cs.Config.Images.AnsibleServiceBroker,
+			WebConsole:                   cs.Config.Images.WebConsole,
+			Console:                      cs.Config.Images.Console,
+			EtcdBackup:                   cs.Config.Images.EtcdBackup,
+			GenevaLogging:                cs.Config.Images.GenevaLogging,
+			GenevaTDAgent:                cs.Config.Images.GenevaTDAgent,
+			GenevaStatsd:                 cs.Config.Images.GenevaStatsd,
+			MetricsBridge:                cs.Config.Images.MetricsBridge,
+		},
+	}
 }

--- a/test/e2e/specs/fakerp/updatecluster.go
+++ b/test/e2e/specs/fakerp/updatecluster.go
@@ -1,0 +1,49 @@
+package fakerp
+
+import (
+	"context"
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/openshift-azure/test/clients/azure"
+	"github.com/openshift/openshift-azure/test/e2e/standard"
+)
+
+var _ = Describe("Update cluster with latest plugin config E2E tests [UpdateCluster][Fake][LongRunning]", func() {
+	var (
+		azurecli *azure.Client
+		cli      *standard.SanityChecker
+	)
+
+	BeforeEach(func() {
+		var err error
+		azurecli, err = azure.NewClientFromEnvironment(false)
+		Expect(err).NotTo(HaveOccurred())
+		cli, err = standard.NewDefaultSanityChecker()
+		Expect(err).NotTo(HaveOccurred())
+		Expect(cli).NotTo(BeNil())
+	})
+
+	It("should be possible for an SRE to update a cluster using the latest plugin config", func() {
+		By("Reading the cluster state")
+		before, err := azurecli.OpenShiftManagedClustersAdmin.Get(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(before).NotTo(BeNil())
+
+		By("Executing update on the cluster")
+		update, err := azurecli.OpenShiftManagedClustersAdmin.UpdateClusterAndWait(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(update).NotTo(BeNil())
+
+		By("Reading the cluster state after the update")
+		after, err := azurecli.OpenShiftManagedClustersAdmin.Get(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(after).NotTo(BeNil())
+
+		By("Validating the cluster")
+		errs := cli.ValidateCluster(context.Background())
+		Expect(errs).To(BeEmpty())
+	})
+})


### PR DESCRIPTION
This work implements a geneva action that allows an admin to update a cluster using the latest plugin config known to the rp.

This is part of AZURE-257

/cc @mjudeikis @Makdaam @y-cote  @kwoodson 