### PR TITLE
remove tcp reset

### DIFF
--- a/pkg/arm/resources.go
+++ b/pkg/arm/resources.go
@@ -343,10 +343,6 @@ func lbKubernetes(pc *api.PluginConfig, cs *api.OpenShiftManagedCluster) *networ
 		Location: to.StringPtr(cs.Location),
 	}
 
-	if pc.TestConfig.RunningUnderTest {
-		(*lb.OutboundRules)[0].EnableTCPReset = to.BoolPtr(true)
-	}
-
 	return lb
 }
 


### PR DESCRIPTION
Error in new deployment now:
```
azure_loadbalancer.go:806] reconcileLoadBalancer: reconcileLoadBalancer for service(default/router): lb(kubernetes) - updating                                                                                                                                             
azure_backoff.go:364] processHTTPRetryResponse: backoff failure, will retry, HTTP response=400, err=network.LoadBalancersClient#CreateOrUpdate: Failure sending request: StatusCode=400 -- Original Error: Code="EnableTcpResetCannotBeSpecifiedForApiVersion" Message="Spe
cified api-version 2017-09-01 does not meet the minimum required api-version 2018-07-01 for EnableTcpReset property." Details=[]                                                                                                                                                                                                                              
azure_loadbalancer.go:809] reconcileLoadBalancer for service(default/router) abort backoff: lb(kubernetes) - updating 
```

Looks like running-under-test and old cloud controller sdk version is giving as a hard day :/ 
I suspect old API got deprecated in azure side

@jim-minter 