### PR TITLE
Force azure image builds onto latest rhel7 image.

### DIFF
--- a/Dockerfile.azure-controllers
+++ b/Dockerfile.azure-controllers
@@ -1,3 +1,3 @@
-FROM registry.access.redhat.com/rhel7
+FROM registry.access.redhat.com/rhel7:latest
 COPY azure-controllers .
 ENTRYPOINT [ "/azure-controllers" ]

--- a/Dockerfile.e2e
+++ b/Dockerfile.e2e
@@ -1,3 +1,3 @@
-FROM registry.access.redhat.com/rhel7
+FROM registry.access.redhat.com/rhel7:latest
 COPY e2e .
 ENTRYPOINT [ "/e2e" ]

--- a/Dockerfile.etcdbackup
+++ b/Dockerfile.etcdbackup
@@ -1,3 +1,3 @@
-FROM registry.access.redhat.com/rhel7
+FROM registry.access.redhat.com/rhel7:latest
 COPY etcdbackup .
 ENTRYPOINT [ "/etcdbackup" ]

--- a/Dockerfile.metricsbridge
+++ b/Dockerfile.metricsbridge
@@ -1,3 +1,3 @@
-FROM registry.access.redhat.com/rhel7
+FROM registry.access.redhat.com/rhel7:latest
 COPY metricsbridge .
 ENTRYPOINT [ "/metricsbridge" ]

--- a/Dockerfile.sync
+++ b/Dockerfile.sync
@@ -1,3 +1,3 @@
-FROM registry.access.redhat.com/rhel7
+FROM registry.access.redhat.com/rhel7:latest
 COPY sync .
 ENTRYPOINT [ "/sync" ]


### PR DESCRIPTION
As a follow on to #1095 and #1121, we need to ensure our images are at a specific patch level in order to keep them up to date.

The issue here is that our images are being built on an older image without the latest packages.  We should either move to a version or use latest.