### PR TITLE
remove tcp reset

### DIFF
--- a/pkg/arm/resources.go
+++ b/pkg/arm/resources.go
@@ -343,10 +343,6 @@ func lbKubernetes(pc *api.PluginConfig, cs *api.OpenShiftManagedCluster) *networ
 		Location: to.StringPtr(cs.Location),
 	}
 
-	if pc.TestConfig.RunningUnderTest {
-		(*lb.OutboundRules)[0].EnableTCPReset = to.BoolPtr(true)
-	}
-
 	return lb
 }
 

--- a/pkg/fakerp/admin_handlers.go
+++ b/pkg/fakerp/admin_handlers.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/storage"
 
-	internalapi "github.com/openshift/openshift-azure/pkg/api"
 	"github.com/openshift/openshift-azure/pkg/cluster"
 	"github.com/openshift/openshift-azure/pkg/util/cloudprovider"
 	"github.com/openshift/openshift-azure/pkg/util/configblob"
@@ -20,7 +19,6 @@ func (s *Server) handleGetControlPlanePods(w http.ResponseWriter, req *http.Requ
 		s.internalError(w, "Failed to read the internal config")
 		return
 	}
-	s.writeState(internalapi.AdminUpdating)
 	ctx := enrichContext(context.Background())
 	pods, err := s.plugin.GetControlPlanePods(ctx, cs)
 	if err != nil {
@@ -85,7 +83,6 @@ func (s *Server) handleRestore(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	s.writeState(internalapi.AdminUpdating)
 	ctx = enrichContext(context.Background())
 	deployer := GetDeployer(s.log, cs, s.pluginConfig)
 	if err := s.plugin.RecoverEtcdCluster(ctx, cs, deployer, blobName); err != nil {
@@ -103,7 +100,6 @@ func (s *Server) handleRotateSecrets(w http.ResponseWriter, req *http.Request) {
 		s.internalError(w, "Failed to read the internal config")
 		return
 	}
-	s.writeState(internalapi.AdminUpdating)
 	ctx := enrichContext(context.Background())
 	deployer := GetDeployer(s.log, cs, s.pluginConfig)
 	if err := s.plugin.RotateClusterSecrets(ctx, cs, deployer, s.pluginTemplate); err != nil {

--- a/pluginconfig/pluginconfig-311.yaml
+++ b/pluginconfig/pluginconfig-311.yaml
@@ -12,7 +12,7 @@
   #  key: <Geveva metrics key value. Base64 in YAML, rsa.PrivateKey in struct>
   #  cert: <Geveva metrics certificate value. Format: Base64 in YAML, x509.Certificate struct>
 ## Geneva integration other details
-clusterVersion: v1.1
+clusterVersion: v1.2
 genevaLoggingAccount: ccpopenshiftdiag
 genevaLoggingControlPlaneAccount: RPOpenShiftAccount
 genevaLoggingNamespace: CCPOpenShift


### PR DESCRIPTION
Remove TCP-reset 
This fails our release branches too in test. 
Should not impact MSFT as they should not be running under test. But we do in our tests. 
For now moving my work to run without `RUNNING_UNDER_TEST`

THIS PR IS TO RELEASE BRANCH! NEW Tag will follow.

/cc @jim-minter 