### PR TITLE
Move writeHelpers to config generator

### DIFF
--- a/pkg/fakerp/admin_handlers.go
+++ b/pkg/fakerp/admin_handlers.go
@@ -118,5 +118,9 @@ func (s *Server) handleRotateSecrets(w http.ResponseWriter, req *http.Request) {
 		s.internalError(w, fmt.Sprintf("Failed to rotate cluster secrets: %v", err))
 		return
 	}
+	err = writeHelpers(cs)
+	if err != nil {
+		s.log.Warnf("could not write helpers: %v", err)
+	}
 	s.log.Info("rotated cluster secrets")
 }


### PR DESCRIPTION
This adds a `WriteHelpers` method to the `Generator` interface in `pkg/config`. The method is called from `plugin.GenerateConfig` which therefore ensures that the plugin's `CreateOrUpdate` or other config altering calls such as `RotateClusterSecrets` result in updated ssh keys, kubeconfigs etc being laid down on the machine. This will allow an operator to ssh into any VM during a key rotation run.

/closes #1167
/cc @mjudeikis @jim-minter @mgahagan73 