### PR TITLE
Delete _data dir from make delete

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,6 +37,7 @@ create:
 
 delete:
 	./hack/delete.sh ${RESOURCEGROUP}
+	rm -rf _data
 
 azure-controllers: generate
 	go build -ldflags ${LDFLAGS} ./cmd/azure-controllers


### PR DESCRIPTION
This deletes the _data directory after `make delete` is called to delete a cluster

/cc @mjudeikis @kwoodson 