### PR TITLE
Fix e2e test error messages

### DIFF
--- a/test/e2e/specs/end_user.go
+++ b/test/e2e/specs/end_user.go
@@ -25,7 +25,7 @@ var _ = Describe("Openshift on Azure end user e2e tests [EndUser][Fake]", func()
 		ctx := context.Background()
 		By("creating test app")
 		namespace, errs := cli.CreateTestApp(ctx)
-		Expect(len(errs)).To(Equal(0))
+		Expect(errs).To(BeEmpty())
 		defer func() {
 			By("deleting test app")
 			_ = cli.DeleteTestApp(ctx, namespace)
@@ -33,11 +33,11 @@ var _ = Describe("Openshift on Azure end user e2e tests [EndUser][Fake]", func()
 
 		By("validating test app")
 		errs = cli.ValidateTestApp(ctx, namespace)
-		Expect(len(errs)).To(Equal(0))
+		Expect(errs).To(BeEmpty())
 	})
 
 	It("should validate the cluster", func() {
 		errs := cli.ValidateCluster(context.Background())
-		Expect(len(errs)).To(Equal(0))
+		Expect(errs).To(BeEmpty())
 	})
 })

--- a/test/e2e/specs/fakerp/etcdrecovery.go
+++ b/test/e2e/specs/fakerp/etcdrecovery.go
@@ -167,6 +167,6 @@ var _ = Describe("Etcd Recovery E2E tests [EtcdRecovery][Fake][LongRunning]", fu
 
 		By("Validating the cluster")
 		errs := cli.ValidateCluster(context.Background())
-		Expect(len(errs)).To(Equal(0))
+		Expect(errs).To(BeEmpty())
 	})
 })

--- a/test/e2e/specs/fakerp/keyrotation.go
+++ b/test/e2e/specs/fakerp/keyrotation.go
@@ -78,6 +78,6 @@ var _ = Describe("Key Rotation E2E tests [KeyRotation][Fake][LongRunning]", func
 
 		By("Validating the cluster")
 		errs := cli.ValidateCluster(context.Background())
-		Expect(len(errs)).To(Equal(0))
+		Expect(errs).To(BeEmpty())
 	})
 })

--- a/test/e2e/specs/scaleupdown.go
+++ b/test/e2e/specs/scaleupdown.go
@@ -139,7 +139,7 @@ var _ = Describe("Scale Up/Down E2E tests [ScaleUpDown][Fake][LongRunning]", fun
 
 		By("Validating the cluster")
 		errs := occli.ValidateCluster(context.Background())
-		Expect(len(errs)).To(Equal(0))
+		Expect(errs).To(BeEmpty())
 
 		By("Fetching the scale down manifest")
 		external, err = azurecli.OpenShiftManagedClusters.Get(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
@@ -171,7 +171,7 @@ var _ = Describe("Scale Up/Down E2E tests [ScaleUpDown][Fake][LongRunning]", fun
 
 		By("Validating the cluster")
 		errs = occli.ValidateCluster(context.Background())
-		Expect(len(errs)).To(Equal(0))
+		Expect(errs).To(BeEmpty())
 	})
 })
 


### PR DESCRIPTION
This changes the error checks in our e2e tests from `Expect(len(errs)).To(Equal(0))` to `Expect(errs).To(BeEmpty())`

/cc @mjudeikis @jim-minter @kwoodson @thekad 