### PR TITLE
Remove hard coded AAD application ID

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,7 +75,7 @@
       right permissions)
       2. Add `$AZURE_AAD_CLIENT_ID` variable with application ID to `env` file.
       3. Create the cluster. `create.sh` script will update your application with
-      required details. This can be done manually with `./hack/aad.sh app-update`
+      required details.
       4. Get your application permissions approved by organization administrator.
       Without approval cluster will start, just login will not work.
 

--- a/cmd/sync/sync.go
+++ b/cmd/sync/sync.go
@@ -39,7 +39,7 @@ func (s *sync) init(ctx context.Context, log *logrus.Entry) error {
 		return err
 	}
 
-	authorizer, err := azureclient.NewAuthorizer(cpc.AadClientID, cpc.AadClientSecret, cpc.TenantID)
+	authorizer, err := azureclient.NewAuthorizer(cpc.AadClientID, cpc.AadClientSecret, cpc.TenantID, "")
 	if err != nil {
 		return err
 	}

--- a/env.example
+++ b/env.example
@@ -1,6 +1,4 @@
-# Set the username, password, subscription, tenant, client IDs (mandatory)
-export AZURE_USERNAME=
-export AZURE_PASSWORD=
+# Set the subscription, tenant, client IDs (mandatory)
 export AZURE_SUBSCRIPTION_ID=
 export AZURE_TENANT_ID=
 export AZURE_CLIENT_ID=

--- a/hack/aad.sh
+++ b/hack/aad.sh
@@ -5,14 +5,9 @@ usage() {
 usage:
 
 $0 app-create name callbackurl
-$0 app-delete appId
-$0 app-update appId callbackurl
 
 Examples:
 aad.sh app-create test-app https://openshift.test.osadev.cloud/oauth2callback/Azure%20AD
-aad.sh app-delete 76a604b8-0896-4ab7-9ef4-xxxxxxxxxx
-aad.sh app-update 76a604b8-0896-4ab7-9ef4-xxxxxxxxxx https://openshift.newtest.osadev.cloud/oauth2callback/Azure%20AD
-
 
 EOF
     exit 1
@@ -68,22 +63,6 @@ Note: For the application to work, an Organization Administrator needs to grant 
       To use this AAD application with OpenShift cluster value below must be present in your env before creating the cluster
       export AZURE_AAD_CLIENT_ID=$AZURE_AAD_CLIENT_ID
 EOF
-    ;;
-
-app-update)
-    if [[ "$#" -ne 3 ]]; then usage; fi
-    AZURE_AAD_CLIENT_SECRET=$(uuidgen)
-    az ad app update --id $2 --reply-urls "$3" --key-type password --password $AZURE_AAD_CLIENT_SECRET
-
-cat <<EOF
-AZURE_AAD_CLIENT_ID=$2
-AZURE_AAD_CLIENT_SECRET=$AZURE_AAD_CLIENT_SECRET
-EOF
-    ;;
-
-app-delete)
-    if [[ "$#" -ne 2 ]]; then usage; fi
-    az ad app delete --id $2
     ;;
 
 *)

--- a/hack/aad.sh
+++ b/hack/aad.sh
@@ -4,10 +4,10 @@ usage() {
     cat <<EOF >&2
 usage:
 
-$0 app-create name callbackurl
+$0 app-create name owner
 
 Examples:
-aad.sh app-create test-app https://openshift.test.osadev.cloud/oauth2callback/Azure%20AD
+$0 app-create user-$USER-aad jminter-team-shared
 
 EOF
     exit 1
@@ -19,19 +19,28 @@ EOF
 # "37f7f235-527c-4136-accd-4a02d197296e" -> sign users in
 # "type": "Role" -> application permission
 # "type": "Scope" -> delegated permission
+
 case "$1" in
 app-create)
-    if [[ "$#" -ne 3 ]]; then usage; fi
+    if [[ "$#" -ne 3 ]]; then
+        usage
+    fi
+
+    OWNER_ID=$(az ad sp list --display-name "$3" --query [0].objectId --output tsv)
+    if [[ "$OWNER_ID" == "" ]]; then
+        echo "owner $3 not found" >&2
+        exit 1
+    fi
 
     AZURE_AAD_CLIENT_SECRET=$(uuidgen)
     AZURE_AAD_CLIENT_ID=$(az ad app create \
         --display-name "$2" \
-        --homepage "$3" \
-        --identifier-uris "$3" \
+        --homepage http://localhost/ \
+        --identifier-uris http://localhost/ \
         --key-type password \
         --password "$AZURE_AAD_CLIENT_SECRET" \
         --query appId \
-        --reply-urls "$3" \
+        --reply-urls http://localhost/ \
         --required-resource-accesses @- <<'EOF' | tr -d '"'
 [
     {
@@ -51,17 +60,16 @@ app-create)
 EOF
 )
 
-    cat <<EOF
-AZURE_AAD_CLIENT_ID=$AZURE_AAD_CLIENT_ID
+    az ad app owner add --id $AZURE_AAD_CLIENT_ID --owner-object-id $OWNER_ID
 
-EOF
+    cat >&2 <<EOF
+Note: ask an administrator to grant your application's permissions.  Until this
+      is done the application will not work.
 
-cat >&2 <<EOF
-Note: For the application to work, an Organization Administrator needs to grant permissions first.
-      Once it is approved, it can be reused for other clusters using app-update functionality
+To use this application with an OpenShift cluster, add the following line to
+your env file and source it:
 
-      To use this AAD application with OpenShift cluster value below must be present in your env before creating the cluster
-      export AZURE_AAD_CLIENT_ID=$AZURE_AAD_CLIENT_ID
+export AZURE_AAD_CLIENT_ID=$AZURE_AAD_CLIENT_ID
 EOF
     ;;
 

--- a/pkg/controllers/customeradmin/group_mapping.go
+++ b/pkg/controllers/customeradmin/group_mapping.go
@@ -7,12 +7,12 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
 	"github.com/Azure/go-autorest/autorest/azure"
-	"github.com/Azure/go-autorest/autorest/azure/auth"
 	"github.com/openshift/api/user/v1"
 	"github.com/sirupsen/logrus"
 	meta_v1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 
 	"github.com/openshift/openshift-azure/pkg/api"
+	"github.com/openshift/openshift-azure/pkg/util/azureclient"
 )
 
 // fromMSGraphGroup syncs the values from the given aad group into kubeGroup
@@ -44,10 +44,7 @@ func fromMSGraphGroup(log *logrus.Entry, kubeGroup *v1.Group, kubeGroupName stri
 //   Application permissions:
 //      Read all groups
 func newAADGroupsClient(config api.AADIdentityProvider) (*graphrbac.GroupsClient, error) {
-	c := auth.NewClientCredentialsConfig(config.ClientID, config.Secret, config.TenantID)
-	c.Resource = azure.PublicCloud.GraphEndpoint
-
-	authorizer, err := c.Authorizer()
+	authorizer, err := azureclient.NewAuthorizer(config.ClientID, config.Secret, config.TenantID, azure.PublicCloud.GraphEndpoint)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/fakerp/client/aad.go
+++ b/pkg/fakerp/client/aad.go
@@ -21,14 +21,7 @@ func UpdateAADAppSecret(ctx context.Context, appClient azureclient.RBACApplicati
 	if err != nil {
 		return "", fmt.Errorf("failed listing applications: %v", err)
 	}
-	var apps []graphrbac.Application
-	for pages.NotDone() {
-		apps = append(apps, pages.Values()...)
-		err = pages.Next()
-		if err != nil {
-			return "", fmt.Errorf("failed iterating applications: %v", err)
-		}
-	}
+	apps := pages.Values()
 	if len(apps) != 1 {
 		return "", fmt.Errorf("found %d applications, should be 1", len(apps))
 	}

--- a/pkg/fakerp/client/config.go
+++ b/pkg/fakerp/client/config.go
@@ -23,8 +23,6 @@ var supportedRegions = []string{
 }
 
 type Config struct {
-	Username        string `envconfig:"AZURE_USERNAME"`
-	Password        string `envconfig:"AZURE_PASSWORD"`
 	SubscriptionID  string `envconfig:"AZURE_SUBSCRIPTION_ID" required:"true"`
 	TenantID        string `envconfig:"AZURE_TENANT_ID" required:"true"`
 	ClientID        string `envconfig:"AZURE_CLIENT_ID" required:"true"`

--- a/pkg/fakerp/client/groups.go
+++ b/pkg/fakerp/client/groups.go
@@ -13,7 +13,7 @@ import (
 // CreateResourceGroup creates a resource group and returns whether the
 // resource group was actually created or not and any error encountered.
 func CreateResourceGroup(conf *Config) (bool, error) {
-	authorizer, err := azureclient.NewAuthorizer(conf.ClientID, conf.ClientSecret, conf.TenantID)
+	authorizer, err := azureclient.NewAuthorizer(conf.ClientID, conf.ClientSecret, conf.TenantID, "")
 	if err != nil {
 		return false, err
 	}

--- a/pkg/util/azureclient/azureclient.go
+++ b/pkg/util/azureclient/azureclient.go
@@ -71,12 +71,8 @@ func setupClient(ctx context.Context, client *autorest.Client, authorizer autore
 	// client.Sender = &loggingSender{client.Sender}
 }
 
-func NewAuthorizer(clientID, clientSecret, tenantID string) (autorest.Authorizer, error) {
-	return auth.NewClientCredentialsConfig(clientID, clientSecret, tenantID).Authorizer()
-}
-
-func NewAuthorizerFromUsernamePassword(username, password, clientID, tenantID, resource string) (autorest.Authorizer, error) {
-	config := auth.NewUsernamePasswordConfig(username, password, clientID, tenantID)
+func NewAuthorizer(clientID, clientSecret, tenantID, resource string) (autorest.Authorizer, error) {
+	config := auth.NewClientCredentialsConfig(clientID, clientSecret, tenantID)
 	if resource != "" {
 		config.Resource = resource
 	}
@@ -92,5 +88,5 @@ func GetAuthorizerFromContext(ctx context.Context) (autorest.Authorizer, error) 
 }
 
 func NewAuthorizerFromEnvironment() (autorest.Authorizer, error) {
-	return auth.NewClientCredentialsConfig(os.Getenv("AZURE_CLIENT_ID"), os.Getenv("AZURE_CLIENT_SECRET"), os.Getenv("AZURE_TENANT_ID")).Authorizer()
+	return NewAuthorizer(os.Getenv("AZURE_CLIENT_ID"), os.Getenv("AZURE_CLIENT_SECRET"), os.Getenv("AZURE_TENANT_ID"), "")
 }

--- a/pkg/util/configblob/container.go
+++ b/pkg/util/configblob/container.go
@@ -23,7 +23,7 @@ import (
 // It returns the blob storage interface to the storage account containing the
 // config blob, etcd backups, etc.
 func GetService(ctx context.Context, cpc *cloudprovider.Config) (azureclientstorage.BlobStorageClient, error) {
-	authorizer, err := azureclient.NewAuthorizer(cpc.AadClientID, cpc.AadClientSecret, cpc.TenantID)
+	authorizer, err := azureclient.NewAuthorizer(cpc.AadClientID, cpc.AadClientSecret, cpc.TenantID, "")
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
remove hack/aad.sh app-{update,delete} - these are no longer used

Remove hard coded AAD application ID
* jminter-team-shared app now has permissions to modify AAD apps it owns
* hence can remove hard coded AAD application ID
* removes need to store AZURE_USERNAME and AZURE_PASSWORD in cleartext, hooray!
* newly created AAD apps must be marked as owned by jminter-team-shared: updated aad.sh app-create to do that