### PR TITLE
Ignore certain files from codecov analysis

### DIFF
--- a/.codecov.yml
+++ b/.codecov.yml
@@ -24,3 +24,7 @@ comment:
   layout: "header, diff"
   behavior: default
   require_changes: no
+
+ignore:
+  - "**/bindata.go"
+


### PR DESCRIPTION
Ignores the generated `bindata.go` files from codecov analysis

/cc @jim-minter 