### PR TITLE
[wip] E2E test to validate azure-file PV support

### DIFF
--- a/pkg/config/generate.go
+++ b/pkg/config/generate.go
@@ -13,6 +13,7 @@ import (
 	api "github.com/openshift/openshift-azure/pkg/api"
 	pluginapi "github.com/openshift/openshift-azure/pkg/api/plugin/api"
 	"github.com/openshift/openshift-azure/pkg/tls"
+	"github.com/openshift/openshift-azure/pkg/util/randomstring"
 )
 
 func (g *simpleGenerator) Generate(cs *api.OpenShiftManagedCluster, template *pluginapi.Config) (err error) {
@@ -385,33 +386,33 @@ func (g *simpleGenerator) Generate(cs *api.OpenShiftManagedCluster, template *pl
 	}
 
 	if len(c.RegistryStorageAccount) == 0 {
-		if c.RegistryStorageAccount, err = randomStorageAccountName(); err != nil {
+		if c.RegistryStorageAccount, err = randomstring.RandomStorageAccountName(); err != nil {
 			return
 		}
 	}
 
 	if len(c.ConfigStorageAccount) == 0 {
-		if c.ConfigStorageAccount, err = randomStorageAccountName(); err != nil {
+		if c.ConfigStorageAccount, err = randomstring.RandomStorageAccountName(); err != nil {
 			return
 		}
 	}
 
 	if len(c.RegistryConsoleOAuthSecret) == 0 {
 		var pass string
-		if pass, err = randomString(64); err != nil {
+		if pass, err = randomstring.RandomASCIIString(64); err != nil {
 			return err
 		}
 		c.RegistryConsoleOAuthSecret = fmt.Sprintf("user%s", pass)
 	}
 
 	if len(c.ConsoleOAuthSecret) == 0 {
-		if c.ConsoleOAuthSecret, err = randomString(64); err != nil {
+		if c.ConsoleOAuthSecret, err = randomstring.RandomASCIIString(64); err != nil {
 			return err
 		}
 	}
 
 	if len(c.RouterStatsPassword) == 0 {
-		if c.RouterStatsPassword, err = randomString(10); err != nil {
+		if c.RouterStatsPassword, err = randomstring.RandomASCIIString(10); err != nil {
 			return
 		}
 	}

--- a/pkg/config/util.go
+++ b/pkg/config/util.go
@@ -10,7 +10,6 @@ import (
 	"k8s.io/client-go/tools/clientcmd/api/v1"
 
 	"github.com/openshift/openshift-azure/pkg/tls"
-	"github.com/openshift/openshift-azure/pkg/util/randomstring"
 )
 
 func makeKubeConfig(clientKey *rsa.PrivateKey, clientCert, caCert *x509.Certificate, endpoint, username, namespace string) (*v1.Config, error) {
@@ -72,12 +71,4 @@ func randomBytes(n int) ([]byte, error) {
 		return nil, err
 	}
 	return b, nil
-}
-
-func randomStorageAccountName() (string, error) {
-	return randomstring.RandomString("abcdefghijklmnopqrstuvwxyz0123456789", 24)
-}
-
-func randomString(length int) (string, error) {
-	return randomstring.RandomString("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789", length)
 }

--- a/pkg/util/azureclient/storage.go
+++ b/pkg/util/azureclient/storage.go
@@ -14,7 +14,7 @@ type AccountsClient interface {
 	AccountsClientAddons
 	Client
 	Delete(context context.Context, resourceGroup, accountName string) (autorest.Response, error)
-	GetOrCreate(context context.Context, resourceGroup, accountName string, createParams storage.AccountCreateParameters) (*storage.Account, error)
+	GetProperties(context context.Context, resourceGroup, accountName string) (storage.Account, error)
 }
 
 func (a *accountsClient) Client() autorest.Client {
@@ -35,26 +35,4 @@ func NewAccountsClient(ctx context.Context, subscriptionID string, authorizer au
 	return &accountsClient{
 		AccountsClient: client,
 	}
-}
-
-// GetOrCreate will create the account if it doesn't exist, or return the account if already there
-func (c *accountsClient) GetOrCreate(ctx context.Context, resourceGroup, accountName string, createParams storage.AccountCreateParameters) (*storage.Account, error) {
-	var acct storage.Account
-	future, outerErr := c.AccountsClient.Create(ctx, resourceGroup, accountName, createParams)
-	if outerErr != nil {
-		acct, innerErr := c.AccountsClient.GetProperties(ctx, resourceGroup, accountName)
-		if innerErr != nil {
-			return nil, innerErr
-		}
-		return &acct, nil
-	}
-	err := future.WaitForCompletionRef(ctx, c.AccountsClient.Client)
-	if err != nil {
-		return nil, err
-	}
-	acct, err = c.AccountsClient.GetProperties(ctx, resourceGroup, accountName)
-	if err != nil {
-		return nil, err
-	}
-	return &acct, nil
 }

--- a/pkg/util/azureclient/storage.go
+++ b/pkg/util/azureclient/storage.go
@@ -13,6 +13,8 @@ type AccountsClient interface {
 	ListByResourceGroup(context context.Context, resourceGroup string) (storage.AccountListResult, error)
 	AccountsClientAddons
 	Client
+	Delete(context context.Context, resourceGroup, accountName string) (autorest.Response, error)
+	GetOrCreate(context context.Context, resourceGroup, accountName string, createParams storage.AccountCreateParameters) (*storage.Account, error)
 }
 
 func (a *accountsClient) Client() autorest.Client {
@@ -33,4 +35,26 @@ func NewAccountsClient(ctx context.Context, subscriptionID string, authorizer au
 	return &accountsClient{
 		AccountsClient: client,
 	}
+}
+
+// GetOrCreate will create the account if it doesn't exist, or return the account if already there
+func (c *accountsClient) GetOrCreate(ctx context.Context, resourceGroup, accountName string, createParams storage.AccountCreateParameters) (*storage.Account, error) {
+	var acct storage.Account
+	future, outerErr := c.AccountsClient.Create(ctx, resourceGroup, accountName, createParams)
+	if outerErr != nil {
+		acct, innerErr := c.AccountsClient.GetProperties(ctx, resourceGroup, accountName)
+		if innerErr != nil {
+			return nil, innerErr
+		}
+		return &acct, nil
+	}
+	err := future.WaitForCompletionRef(ctx, c.AccountsClient.Client)
+	if err != nil {
+		return nil, err
+	}
+	acct, err = c.AccountsClient.GetProperties(ctx, resourceGroup, accountName)
+	if err != nil {
+		return nil, err
+	}
+	return &acct, nil
 }

--- a/pkg/util/azureclient/storage/storage.go
+++ b/pkg/util/azureclient/storage/storage.go
@@ -19,6 +19,7 @@ const (
 // Client is a minimal interface for azure Client
 type Client interface {
 	GetBlobService() BlobStorageClient
+	GetFileService() FileServiceClient
 }
 
 type client struct {
@@ -43,6 +44,10 @@ func (c *client) GetBlobService() BlobStorageClient {
 	return &blobStorageClient{BlobStorageClient: c.Client.GetBlobService()}
 }
 
+func (c *client) GetFileService() FileServiceClient {
+	return &fileServiceClient{FileServiceClient: c.Client.GetFileService()}
+}
+
 // BlobStorageClient is a minimal interface for azure BlobStorageClient
 type BlobStorageClient interface {
 	GetContainerReference(name string) Container
@@ -54,8 +59,23 @@ type blobStorageClient struct {
 
 var _ BlobStorageClient = &blobStorageClient{}
 
+// FileServiceClient is a minimal interface for azure FileServiceClient
+type FileServiceClient interface {
+	GetShareReference(name string) Share
+}
+
+type fileServiceClient struct {
+	storage.FileServiceClient
+}
+
+var _ FileServiceClient = &fileServiceClient{}
+
 func (c *blobStorageClient) GetContainerReference(name string) Container {
 	return &container{Container: c.BlobStorageClient.GetContainerReference(name)}
+}
+
+func (c *fileServiceClient) GetShareReference(name string) Share {
+	return &share{Share: c.FileServiceClient.GetShareReference(name)}
 }
 
 // Container is a minimal interface for azure Container
@@ -92,3 +112,18 @@ type blob struct {
 }
 
 var _ Blob = &blob{}
+
+// Share is a minimal interface for azure Blob
+type Share interface {
+	Exists() (bool, error)
+	Create(options *storage.FileRequestOptions) error
+	CreateIfNotExists(options *storage.FileRequestOptions) (bool, error)
+	Delete(options *storage.FileRequestOptions) error
+	DeleteIfExists(options *storage.FileRequestOptions) (bool, error)
+}
+
+type share struct {
+	*storage.Share
+}
+
+var _ Share = &share{}

--- a/pkg/util/mocks/mock_azureclient/azureclient.go
+++ b/pkg/util/mocks/mock_azureclient/azureclient.go
@@ -634,19 +634,19 @@ func (mr *MockAccountsClientMockRecorder) Delete(arg0, arg1, arg2 interface{}) *
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockAccountsClient)(nil).Delete), arg0, arg1, arg2)
 }
 
-// GetOrCreate mocks base method
-func (m *MockAccountsClient) GetOrCreate(arg0 context.Context, arg1, arg2 string, arg3 storage.AccountCreateParameters) (*storage.Account, error) {
+// GetProperties mocks base method
+func (m *MockAccountsClient) GetProperties(arg0 context.Context, arg1, arg2 string) (storage.Account, error) {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "GetOrCreate", arg0, arg1, arg2, arg3)
-	ret0, _ := ret[0].(*storage.Account)
+	ret := m.ctrl.Call(m, "GetProperties", arg0, arg1, arg2)
+	ret0, _ := ret[0].(storage.Account)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
-// GetOrCreate indicates an expected call of GetOrCreate
-func (mr *MockAccountsClientMockRecorder) GetOrCreate(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+// GetProperties indicates an expected call of GetProperties
+func (mr *MockAccountsClientMockRecorder) GetProperties(arg0, arg1, arg2 interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrCreate", reflect.TypeOf((*MockAccountsClient)(nil).GetOrCreate), arg0, arg1, arg2, arg3)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetProperties", reflect.TypeOf((*MockAccountsClient)(nil).GetProperties), arg0, arg1, arg2)
 }
 
 // ListByResourceGroup mocks base method

--- a/pkg/util/mocks/mock_azureclient/azureclient.go
+++ b/pkg/util/mocks/mock_azureclient/azureclient.go
@@ -619,6 +619,36 @@ func (mr *MockAccountsClientMockRecorder) Create(arg0, arg1, arg2, arg3 interfac
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Create", reflect.TypeOf((*MockAccountsClient)(nil).Create), arg0, arg1, arg2, arg3)
 }
 
+// Delete mocks base method
+func (m *MockAccountsClient) Delete(arg0 context.Context, arg1, arg2 string) (autorest.Response, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Delete", arg0, arg1, arg2)
+	ret0, _ := ret[0].(autorest.Response)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Delete indicates an expected call of Delete
+func (mr *MockAccountsClientMockRecorder) Delete(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockAccountsClient)(nil).Delete), arg0, arg1, arg2)
+}
+
+// GetOrCreate mocks base method
+func (m *MockAccountsClient) GetOrCreate(arg0 context.Context, arg1, arg2 string, arg3 storage.AccountCreateParameters) (*storage.Account, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetOrCreate", arg0, arg1, arg2, arg3)
+	ret0, _ := ret[0].(*storage.Account)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetOrCreate indicates an expected call of GetOrCreate
+func (mr *MockAccountsClientMockRecorder) GetOrCreate(arg0, arg1, arg2, arg3 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetOrCreate", reflect.TypeOf((*MockAccountsClient)(nil).GetOrCreate), arg0, arg1, arg2, arg3)
+}
+
 // ListByResourceGroup mocks base method
 func (m *MockAccountsClient) ListByResourceGroup(arg0 context.Context, arg1 string) (storage.AccountListResult, error) {
 	m.ctrl.T.Helper()

--- a/pkg/util/mocks/mock_azureclient/mock_storage/storage.go
+++ b/pkg/util/mocks/mock_azureclient/mock_storage/storage.go
@@ -51,6 +51,20 @@ func (mr *MockClientMockRecorder) GetBlobService() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetBlobService", reflect.TypeOf((*MockClient)(nil).GetBlobService))
 }
 
+// GetFileService mocks base method
+func (m *MockClient) GetFileService() storage0.FileServiceClient {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetFileService")
+	ret0, _ := ret[0].(storage0.FileServiceClient)
+	return ret0
+}
+
+// GetFileService indicates an expected call of GetFileService
+func (mr *MockClientMockRecorder) GetFileService() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFileService", reflect.TypeOf((*MockClient)(nil).GetFileService))
+}
+
 // MockBlobStorageClient is a mock of BlobStorageClient interface
 type MockBlobStorageClient struct {
 	ctrl     *gomock.Controller

--- a/pkg/util/randomstring/randomstring.go
+++ b/pkg/util/randomstring/randomstring.go
@@ -5,6 +5,7 @@ import (
 	"math/big"
 )
 
+// RandomString returns a randomized string from a set of characters of the given length
 func RandomString(letterBytes string, length int) (string, error) {
 	b := make([]byte, length)
 	for i := range b {
@@ -16,4 +17,14 @@ func RandomString(letterBytes string, length int) (string, error) {
 	}
 
 	return string(b), nil
+}
+
+// RandomStorageAccountName returns a valid randomized storage account name
+func RandomStorageAccountName() (string, error) {
+	return RandomString("abcdefghijklmnopqrstuvwxyz0123456789", 24)
+}
+
+// RandomASCIIString returns a random string of the given length from the basic ASCII char map
+func RandomASCIIString(length int) (string, error) {
+	return RandomString("abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789", length)
 }

--- a/pkg/util/ready/ready.go
+++ b/pkg/util/ready/ready.go
@@ -141,6 +141,21 @@ func PodIsReady(cli corev1client.PodInterface, name string) func() (bool, error)
 	}
 }
 
+// PodReachesPhase will return true when the pod's phase matches the requested phase
+func PodReachesPhase(cli corev1client.PodInterface, name string, phase corev1.PodPhase) func() (bool, error) {
+	return func() (bool, error) {
+		node, err := cli.Get(name, metav1.GetOptions{})
+		switch {
+		case errors.IsNotFound(err):
+			return false, nil
+		case err != nil:
+			return false, err
+		}
+
+		return node.Status.Phase == phase, nil
+	}
+}
+
 func BatchIsReady(cli batchv1client.JobInterface, name string) func() (bool, error) {
 	return func() (bool, error) {
 		job, err := cli.Get(name, metav1.GetOptions{})

--- a/pkg/util/ready/ready.go
+++ b/pkg/util/ready/ready.go
@@ -141,8 +141,8 @@ func PodIsReady(cli corev1client.PodInterface, name string) func() (bool, error)
 	}
 }
 
-// PodReachesPhase will return true when the pod's phase matches the requested phase
-func PodReachesPhase(cli corev1client.PodInterface, name string, phase corev1.PodPhase) func() (bool, error) {
+// PodHasPhase will return true when the pod's phase matches the requested phase
+func PodHasPhase(cli corev1client.PodInterface, name string, phase corev1.PodPhase) func() (bool, error) {
 	return func() (bool, error) {
 		node, err := cli.Get(name, metav1.GetOptions{})
 		switch {

--- a/test/clients/azure/client.go
+++ b/test/clients/azure/client.go
@@ -38,6 +38,7 @@ type Client struct {
 	ActivityLogs                     azureclient.ActivityLogsClient
 	Applications                     azureclient.ApplicationsClient
 	BlobStorage                      storage.BlobStorageClient
+	FileService                      storage.FileServiceClient
 	OpenShiftManagedClusters         externalapi.OpenShiftManagedClustersClient
 	OpenShiftManagedClustersAdmin    adminapi.OpenShiftManagedClustersClient
 	VirtualMachineScaleSets          azureclient.VirtualMachineScaleSetsClient
@@ -47,6 +48,7 @@ type Client struct {
 	VirtualNetworks                  azureclient.VirtualNetworksClient
 	VirtualNetworksPeerings          azureclient.VirtualNetworksPeeringsClient
 	Groups                           azureclient.GroupsClient
+	Config                           *cloudprovider.Config
 }
 
 // NewClientFromEnvironment creates a new azure client from environment variables.
@@ -69,9 +71,10 @@ func NewClientFromEnvironment(setStorageClient bool) (*Client, error) {
 	}
 	subscriptionID := cfg.SubscriptionID
 
-	var storageClient storage.BlobStorageClient
+	var blobStorageClient storage.BlobStorageClient
+	// var fileServiceClient storage.FileServiceClient
 	if setStorageClient {
-		storageClient, err = configblob.GetService(context.Background(), cfg)
+		blobStorageClient, err = configblob.GetService(context.Background(), cfg)
 		if err != nil {
 			return nil, err
 		}
@@ -102,7 +105,7 @@ func NewClientFromEnvironment(setStorageClient bool) (*Client, error) {
 		Accounts:                         azureclient.NewAccountsClient(ctx, subscriptionID, authorizer),
 		ActivityLogs:                     azureclient.NewActivityLogsClient(ctx, subscriptionID, authorizer),
 		Applications:                     azureclient.NewApplicationsClient(ctx, subscriptionID, authorizer),
-		BlobStorage:                      storageClient,
+		BlobStorage:                      blobStorageClient,
 		OpenShiftManagedClusters:         rpc,
 		OpenShiftManagedClustersAdmin:    rpcAdmin,
 		VirtualMachineScaleSets:          azureclient.NewVirtualMachineScaleSetsClient(ctx, subscriptionID, authorizer),
@@ -112,5 +115,6 @@ func NewClientFromEnvironment(setStorageClient bool) (*Client, error) {
 		VirtualNetworks:                  azureclient.NewVirtualNetworkClient(ctx, subscriptionID, authorizer),
 		VirtualNetworksPeerings:          azureclient.NewVirtualNetworksPeeringsClient(ctx, subscriptionID, authorizer),
 		Groups:                           azureclient.NewGroupsClient(ctx, subscriptionID, authorizer),
+		Config:                           cfg,
 	}, nil
 }

--- a/test/clients/azure/client.go
+++ b/test/clients/azure/client.go
@@ -38,7 +38,6 @@ type Client struct {
 	ActivityLogs                     azureclient.ActivityLogsClient
 	Applications                     azureclient.ApplicationsClient
 	BlobStorage                      storage.BlobStorageClient
-	FileService                      storage.FileServiceClient
 	OpenShiftManagedClusters         externalapi.OpenShiftManagedClustersClient
 	OpenShiftManagedClustersAdmin    adminapi.OpenShiftManagedClustersClient
 	VirtualMachineScaleSets          azureclient.VirtualMachineScaleSetsClient
@@ -48,7 +47,6 @@ type Client struct {
 	VirtualNetworks                  azureclient.VirtualNetworksClient
 	VirtualNetworksPeerings          azureclient.VirtualNetworksPeeringsClient
 	Groups                           azureclient.GroupsClient
-	Config                           *cloudprovider.Config
 }
 
 // NewClientFromEnvironment creates a new azure client from environment variables.
@@ -71,10 +69,9 @@ func NewClientFromEnvironment(setStorageClient bool) (*Client, error) {
 	}
 	subscriptionID := cfg.SubscriptionID
 
-	var blobStorageClient storage.BlobStorageClient
-	// var fileServiceClient storage.FileServiceClient
+	var storageClient storage.BlobStorageClient
 	if setStorageClient {
-		blobStorageClient, err = configblob.GetService(context.Background(), cfg)
+		storageClient, err = configblob.GetService(context.Background(), cfg)
 		if err != nil {
 			return nil, err
 		}
@@ -105,7 +102,7 @@ func NewClientFromEnvironment(setStorageClient bool) (*Client, error) {
 		Accounts:                         azureclient.NewAccountsClient(ctx, subscriptionID, authorizer),
 		ActivityLogs:                     azureclient.NewActivityLogsClient(ctx, subscriptionID, authorizer),
 		Applications:                     azureclient.NewApplicationsClient(ctx, subscriptionID, authorizer),
-		BlobStorage:                      blobStorageClient,
+		BlobStorage:                      storageClient,
 		OpenShiftManagedClusters:         rpc,
 		OpenShiftManagedClustersAdmin:    rpcAdmin,
 		VirtualMachineScaleSets:          azureclient.NewVirtualMachineScaleSetsClient(ctx, subscriptionID, authorizer),
@@ -115,6 +112,5 @@ func NewClientFromEnvironment(setStorageClient bool) (*Client, error) {
 		VirtualNetworks:                  azureclient.NewVirtualNetworkClient(ctx, subscriptionID, authorizer),
 		VirtualNetworksPeerings:          azureclient.NewVirtualNetworksPeeringsClient(ctx, subscriptionID, authorizer),
 		Groups:                           azureclient.NewGroupsClient(ctx, subscriptionID, authorizer),
-		Config:                           cfg,
 	}, nil
 }

--- a/test/e2e/specs/fakerp/admin.go
+++ b/test/e2e/specs/fakerp/admin.go
@@ -322,7 +322,7 @@ var _ = Describe("Openshift on Azure admin e2e tests [AzureClusterReader][Fake]"
 			Expect(err).NotTo(HaveOccurred())
 			By("Created a simple pod to run dd")
 			By("Waiting for pod to succeed")
-			err = wait.PollImmediate(2*time.Second, 10*time.Minute, ready.PodReachesPhase(cli.Client.Admin.CoreV1.Pods(namespace), podName, corev1.PodSucceeded))
+			err = wait.PollImmediate(2*time.Second, 10*time.Minute, ready.PodHasPhase(cli.Client.Admin.CoreV1.Pods(namespace), podName, corev1.PodSucceeded))
 			Expect(err).NotTo(HaveOccurred())
 			By("Pod succeeded")
 


### PR DESCRIPTION
* Added (basic) Share support to our azureclient wrapper
* Added support to create and delete storage accounts to our azureclient wrapper
* Added a util function to be PollImmediate() to check the phase of a pod
* Create an E2E test that:
  * Creates a storage account
  * Creates a file share inside the storage account
  * Creates a project in the cluster
  * Creates a secret inside the project
  * Creates PersistentVolume and PersistentVolumeClaim with support for azure-file
  * Run a simple Pod with the azure file share mounted, write something to the volume, expect it to pass
