### PR TITLE
metricsbridge - adding an option to calculate rate of a metric

### DIFF
--- a/cmd/metricsbridge/metricsbridge.go
+++ b/cmd/metricsbridge/metricsbridge.go
@@ -54,8 +54,9 @@ type config struct {
 	StatsdSocket       string        `json:"statsdSocket,omitempty"`
 
 	Queries []struct {
-		Name  string `json:"name,omitempty"`
-		Query string `json:"query,omitempty"`
+		Name          string `json:"name,omitempty"`
+		Query         string `json:"query,omitempty"`
+		CalculateRate bool   `json:"calculate_rate,omitempty"`
 	} `json:"queries,omitempty"`
 
 	Account   string `json:"account,omitempty"`
@@ -213,7 +214,14 @@ func (c *config) runOnce(ctx context.Context) error {
 	var metricsCount int
 
 	for _, query := range c.Queries {
-		value, err := c.prometheus.Query(ctx, query.Query, time.Time{})
+		var prometheusQuery string
+		if query.CalculateRate {
+			//query for rate of change
+			prometheusQuery = fmt.Sprintf("(%s - %s offset 1m) or (%s unless %s offset 1m)", query.Query, query.Query, query.Query, query.Query)
+		} else {
+			prometheusQuery = query.Query
+		}
+		value, err := c.prometheus.Query(ctx, prometheusQuery, time.Time{})
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Adding calculating of the metric's rate of change (for counter metrics).
This can be activated for a given metric by setting calculate_rate to true.

My suggestion is that the new metric should have a '_rate' suffix instead of the '_total' suffix.

Example definition in the configmap:
```
    - query: 'container_cpu_user_seconds_total{namespace=~"default|openshift|openshift-.+|kube-.+|", container_name!="", container_name!="POD"}'
      calculate_rate: true
      name: 'container_cpu_user_seconds_rate'
```
I'll open the configmap PR after the new image of metricsbridge is built.

the query to Prometheus is replaced with:
(%s - %s offset 1m) or (%s unless %s offset 1m)

How it behaves:
In case there is a current value and a value 1 min ago (for the same value of dimensions/labels) calculates the difference vs. value 1 minute ago. 

In case there is no value 1 minute ago the second part of the or comes into play and it sends the current value. 

If there is no current value it sends no samples.

```release-note
- adds rate calculation to metricsbridge
```
