### PR TITLE
[wip] Add ILB for masters

### DIFF
--- a/pkg/arm/arm.go
+++ b/pkg/arm/arm.go
@@ -50,6 +50,7 @@ func (g *simpleGenerator) Generate(ctx context.Context, cs *api.OpenShiftManaged
 			vnet(cs),
 			eipAPIServer(cs),
 			elbAPIServer(&g.pluginConfig, cs),
+			ilbAPIServer(&g.pluginConfig, cs),
 			storageRegistry(cs),
 			nsgMaster(cs),
 		},

--- a/pkg/arm/arm.go
+++ b/pkg/arm/arm.go
@@ -48,8 +48,8 @@ func (g *simpleGenerator) Generate(ctx context.Context, cs *api.OpenShiftManaged
 		ContentVersion: "1.0.0.0",
 		Resources: []interface{}{
 			vnet(cs),
-			ipAPIServer(cs),
-			lbAPIServer(&g.pluginConfig, cs),
+			eipAPIServer(cs),
+			elbAPIServer(&g.pluginConfig, cs),
 			storageRegistry(cs),
 			nsgMaster(cs),
 		},

--- a/pkg/arm/resources_test.go
+++ b/pkg/arm/resources_test.go
@@ -27,17 +27,17 @@ func TestFixupDepends(t *testing.T) {
 		{
 			name: "have deps, but missing resources",
 			resources: []interface{}{
-				lbAPIServer(&api.PluginConfig{}, cs),
+				elbAPIServer(&api.PluginConfig{}, cs),
 			},
 			expect: []string{},
 		},
 		{
 			name: "have deps and dependent resources",
 			resources: []interface{}{
-				ipAPIServer(cs),
-				lbAPIServer(&api.PluginConfig{}, cs),
+				eipAPIServer(cs),
+				elbAPIServer(&api.PluginConfig{}, cs),
 			},
-			expect: []string{"/subscriptions/sess/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/ip-apiserver"},
+			expect: []string{"/subscriptions/sess/resourceGroups/rg/providers/Microsoft.Network/publicIPAddresses/eip-apiserver"},
 		},
 	}
 	for _, tt := range tests {
@@ -58,7 +58,7 @@ func TestFixupDepends(t *testing.T) {
 		}
 
 		fixupDepends(&cs.Properties.AzProfile, azuretemplate)
-		res := jsonpath.MustCompile("$.resources[?(@.name='lb-apiserver')]").MustGetObject(azuretemplate)
+		res := jsonpath.MustCompile("$.resources[?(@.name='elb-apiserver')]").MustGetObject(azuretemplate)
 		deps, found := res["dependsOn"].([]string)
 		if !found && len(tt.expect) > 0 {
 			t.Fatalf("expected %v, got %v", tt.expect, deps)


### PR DESCRIPTION
Tried to add ILB for master to solve TLS issue.
Some issues from this:
* ILB has hardcoded internal IP address (static)
* ILB as per my current understanding does not support internal DNS names, so we would be responsible for creating and managing something like this.
* we might want to add new subnet for LB to be safe as now I hardcoded last IP address from the current subnet (`/24`). 

Stopped here so we can discuss further. 

cc @jim-minter @asalkeld 
