### PR TITLE
only set customerAdminGroupId field in create manifest when it is actually set

### DIFF
--- a/test/manifests/fakerp/create.yaml
+++ b/test/manifests/fakerp/create.yaml
@@ -10,7 +10,9 @@ properties:
         clientId: {{ Getenv "AZURE_AAD_CLIENT_ID" | quote }}
         secret: {{ Getenv "AZURE_AAD_CLIENT_SECRET" | quote }}
         tenantId: {{ Getenv "AZURE_TENANT_ID" | quote }}
+{{- if ne (Getenv "AZURE_AAD_GROUP_ADMINS_ID") "" }}
         customerAdminGroupId: {{ Getenv "AZURE_AAD_GROUP_ADMINS_ID" | quote }}
+{{- end }}
   networkProfile:
     vnetCidr: 10.0.0.0/8
   masterPoolProfile:


### PR DESCRIPTION
```release-note
NONE
```