### PR TITLE
Bubbling up errors properly

### DIFF
--- a/test/e2e/standard/cluster.go
+++ b/test/e2e/standard/cluster.go
@@ -387,9 +387,15 @@ func (sc *SanityChecker) checkCanUseAzureFileStorage(ctx context.Context) error 
 			RestartPolicy: corev1.RestartPolicyNever,
 		},
 	})
+	if err != nil {
+		return err
+	}
 	By("Created pod")
 	By(fmt.Sprintf("Waiting for pod %s to finish", podName))
 	err = wait.PollImmediate(2*time.Second, 10*time.Minute, ready.PodHasPhase(sc.Client.Admin.CoreV1.Pods(namespace), podName, corev1.PodSucceeded))
+	if err != nil {
+		return err
+	}
 	By(fmt.Sprintf("Pod %s finished", podName))
 
 	return nil


### PR DESCRIPTION
Noticed during my demo I was not propagating the errors up in the last
couple of steps, fixing that now

```release-note
NONE
```