### PR TITLE
add a convention for how we name storage accounts

### DIFF
--- a/pkg/config/generate.go
+++ b/pkg/config/generate.go
@@ -366,19 +366,19 @@ func (g *simpleGenerator) Generate(cs *api.OpenShiftManagedCluster, template *pl
 	}
 
 	if len(c.RegistryStorageAccount) == 0 {
-		if c.RegistryStorageAccount, err = random.StorageAccountName(); err != nil {
+		if c.RegistryStorageAccount, err = random.StorageAccountName("sareg"); err != nil {
 			return
 		}
 	}
 
 	if len(c.AzureFileStorageAccount) == 0 {
-		if c.AzureFileStorageAccount, err = random.StorageAccountName(); err != nil {
+		if c.AzureFileStorageAccount, err = random.StorageAccountName("safil"); err != nil {
 			return
 		}
 	}
 
 	if len(c.ConfigStorageAccount) == 0 {
-		if c.ConfigStorageAccount, err = random.StorageAccountName(); err != nil {
+		if c.ConfigStorageAccount, err = random.StorageAccountName("sacfg"); err != nil {
 			return
 		}
 	}

--- a/pkg/fakerp/fakerp.go
+++ b/pkg/fakerp/fakerp.go
@@ -261,11 +261,10 @@ func enrich(cs *api.OpenShiftManagedCluster) error {
 			return err
 		}
 	} else {
-		vaultURL, err = random.FQDN("vault.azure.net", 24)
+		vaultURL, err = random.VaultURL("kv-")
 		if err != nil {
 			return err
 		}
-		vaultURL = "https://" + vaultURL
 	}
 
 	cs.Properties.APICertProfile.KeyVaultSecretURL = vaultURL + "/secrets/" + vaultKeyNamePublicHostname

--- a/pkg/util/random/random.go
+++ b/pkg/util/random/random.go
@@ -56,6 +56,15 @@ func StorageAccountName(prefix string) (string, error) {
 	return prefix + name, nil
 }
 
+// VaultURL returns a random string suitable for use as an Azure key vault URL
+func VaultURL(prefix string) (string, error) {
+	fqdn, err := FQDN("vault.azure.net", 24-len(prefix))
+	if err != nil {
+		return "", err
+	}
+	return "https://" + prefix + fqdn, nil
+}
+
 // FQDN returns a random fully qualified domain name within a given parent
 // domain
 func FQDN(parentDomain string, n int) (string, error) {

--- a/pkg/util/random/random.go
+++ b/pkg/util/random/random.go
@@ -48,8 +48,12 @@ func Bytes(n int) ([]byte, error) {
 
 // StorageAccountName returns a random string suitable for use as an Azure
 // storage account name
-func StorageAccountName() (string, error) {
-	return LowerCaseAlphanumericString(24)
+func StorageAccountName(prefix string) (string, error) {
+	name, err := LowerCaseAlphanumericString(24 - len(prefix))
+	if err != nil {
+		return "", err
+	}
+	return prefix + name, nil
 }
 
 // FQDN returns a random fully qualified domain name within a given parent


### PR DESCRIPTION
At least for now, let's continue to use tags to determine which storage account is which, but this might help whoever browses the portal.

```release-note
NONE
```