### PR TITLE
etcd - move to path for checks

### DIFF
--- a/cmd/tlsproxy/tlsproxy.go
+++ b/cmd/tlsproxy/tlsproxy.go
@@ -116,7 +116,7 @@ func (c *config) Run() error {
 		req.RequestURI = ""
 		req.Host = ""
 
-		if !c.whitelistRegexp.MatchString(req.URL.String()) || req.Method != http.MethodGet {
+		if !c.whitelistRegexp.MatchString(req.URL.Path) || req.Method != http.MethodGet {
 			http.Error(rw, http.StatusText(http.StatusForbidden), http.StatusForbidden)
 			return
 		}


### PR DESCRIPTION
Allows us to have more granular control and more strict regexp.
Currently does not work if we want to use `^sutff` regexp

/cc @Makdaam @jim-minter 

```release-notes
NONE
```