### PR TITLE
remove deepcopy otherwise sas uri not available when vmss are rotated

### DIFF
--- a/pkg/arm/arm.go
+++ b/pkg/arm/arm.go
@@ -99,8 +99,6 @@ func enrichCSSASURIs(storageClient storage.Client, cs *api.OpenShiftManagedClust
 }
 
 func (g *simpleGenerator) Generate(ctx context.Context, cs *api.OpenShiftManagedCluster, backupBlob string, isUpdate bool, suffix string) (map[string]interface{}, error) {
-	cs = cs.DeepCopy()
-
 	err := enrichCSSASURIs(g.storageClient, cs)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
```release-note
resolve bug whereby SAS URIs were not being calculated correctly during the vmss rotation procedure
```

fixes #1314