### PR TITLE
prevent update from succeeding unless cluster version matches v2.5

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -41,10 +41,14 @@ func NewPlugin(log *logrus.Entry, pluginConfig *api.PluginConfig) (api.Plugin, [
 	}, nil
 }
 
-func (p *plugin) Validate(ctx context.Context, new, old *api.OpenShiftManagedCluster, externalOnly bool) []error {
+func (p *plugin) Validate(ctx context.Context, new, old *api.OpenShiftManagedCluster, externalOnly bool) (errs []error) {
 	p.log.Info("validating internal data models")
 	validator := validate.NewAPIValidator(p.config.TestConfig.RunningUnderTest)
-	return validator.Validate(new, old, externalOnly)
+	errs = validator.Validate(new, old, externalOnly)
+	if old != nil && old.Config.ClusterVersion != "v2.5" {
+		errs = append(errs, fmt.Errorf(`cluster with version %q cannot be updated by resource provider with version "v2.5"`, old.Config.ClusterVersion))
+	}
+	return
 }
 
 func (p *plugin) ValidateAdmin(ctx context.Context, new, old *api.OpenShiftManagedCluster) []error {


### PR DESCRIPTION
```release-note
prevent update from succeeding unless cluster version matches v2.5
```