### PR TITLE
Add 3.2 ref to pluginconfig

### DIFF
--- a/pluginconfig/pluginconfig-311.yaml
+++ b/pluginconfig/pluginconfig-311.yaml
@@ -54,6 +54,46 @@ versions:
       tlsProxy: quay.io/openshift-on-azure/tlsproxy:latest
       metricsBridge: quay.io/openshift-on-azure/metricsbridge:latest
       sync: quay.io/openshift-on-azure/sync:latest
+  v3.2:
+    ## Node image and version configurables
+    imageOffer: osa
+    imagePublisher: redhat
+    imageSku: osa_311
+    imageVersion: 311.82.20190311
+    images:
+      alertManager: registry.access.redhat.com/openshift3/prometheus-alertmanager:v3.11.82
+      ansibleServiceBroker: registry.access.redhat.com/openshift3/ose-ansible-service-broker:v3.11.82
+      azureControllers: quay.io/openshift-on-azure/azure-controllers:v3.2
+      clusterMonitoringOperator: registry.access.redhat.com/openshift3/ose-cluster-monitoring-operator:v3.11.82
+      configReloader: registry.access.redhat.com/openshift3/ose-configmap-reloader:v3.11.82
+      console: registry.access.redhat.com/openshift3/ose-console:v3.11.82
+      controlPlane: registry.access.redhat.com/openshift3/ose-control-plane:v3.11.82
+      etcdBackup: quay.io/openshift-on-azure/etcdbackup:v3.2
+      httpd: registry.access.redhat.com/rhscl/httpd-24-rhel7:2.4-85
+      startup: quay.io/openshift-on-azure/startup:v3.2
+      tlsProxy: quay.io/openshift-on-azure/tlsproxy:v3.2
+      format: registry.access.redhat.com/openshift3/ose-${component}:${version}
+      genevaLogging: osarpint.azurecr.io/acs/mdsd:master.20190228.1
+      genevaStatsd: osarpint.azurecr.io/acs/mdm:git-a909a2e76
+      genevaTDAgent: osarpint.azurecr.io/acs/td-agent:master.20190228.1
+      grafana: registry.access.redhat.com/openshift3/grafana:v3.11.82
+      kubeRbacProxy: registry.access.redhat.com/openshift3/ose-kube-rbac-proxy:v3.11.82
+      kubeStateMetrics: registry.access.redhat.com/openshift3/ose-kube-state-metrics:v3.11.82
+      masterEtcd: registry.access.redhat.com/rhel7/etcd:3.2.22
+      metricsBridge: quay.io/openshift-on-azure/metricsbridge:v3.2
+      node: registry.access.redhat.com/openshift3/ose-node:v3.11.82
+      nodeExporter: registry.access.redhat.com/openshift3/prometheus-node-exporter:v3.11.82
+      oAuthProxy: registry.access.redhat.com/openshift3/oauth-proxy:v3.11.82
+      prometheus: registry.access.redhat.com/openshift3/prometheus:v3.11.82
+      prometheusConfigReloader: registry.access.redhat.com/openshift3/ose-prometheus-config-reloader:v3.11.82
+      prometheusOperator: registry.access.redhat.com/openshift3/ose-prometheus-operator:v3.11.82
+      registry: registry.access.redhat.com/openshift3/ose-docker-registry:v3.11.82
+      registryConsole: registry.access.redhat.com/openshift3/registry-console:v3.11.82
+      router: registry.access.redhat.com/openshift3/ose-haproxy-router:v3.11.82
+      serviceCatalog: registry.access.redhat.com/openshift3/ose-service-catalog:v3.11.82
+      sync: quay.io/openshift-on-azure/sync:v3.2
+      templateServiceBroker: registry.access.redhat.com/openshift3/ose-template-service-broker:v3.11.82
+      webConsole: registry.access.redhat.com/openshift3/ose-web-console:v3.11.82
 ## certificates, used to authenticate to external systems
 ## Geneva integration certificates. Example:
 #certificates:


### PR DESCRIPTION
upgrades need to find released versions in the config file so it would know which api version to initiate. 

```
akerp.(*Server).logger.func1" file="/go/src/github.com/openshift/openshift-azure/pkg/fakerp/middleware.go:15"
time="2019-03-25T10:12:06Z" level=fatal msg="containerservice.OpenShiftManagedClustersClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: autorest/azure: error response cannot be parsed: \"400 Bad Request: Failed to apply request: version \\\"v3.2\\\" not found\\n\" error: json: cannot unmarshal number into Go value of type azure.RequestError"
```

/hold

```release-note
NONE
```