### PR TITLE
Fix vmimage build commits being tagged as dirty in CI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,7 +18,7 @@
 coverage.out
 cscope.files
 cscope.out
-/secrets/*
+/secrets
 /fakerp
 /artifacts
 /id_rsa


### PR DESCRIPTION
A symlink was being created to store azure secrets in `secrets`. This caused the working copy of the code to be detected as dirty. 

To fix this, we add `secrets` to .gitignore because git considers folder symlinks to be files.

fixes #1339 

```release-note
NONE
```

/cc @mjudeikis @jim-minter @Makdaam 