### PR TITLE
Log arm template deployment properties after context timeout

### DIFF
--- a/pkg/util/azureclient/resources.go
+++ b/pkg/util/azureclient/resources.go
@@ -12,6 +12,7 @@ type DeploymentsClient interface {
 	CreateOrUpdate(ctx context.Context, resourceGroupName string, deploymentName string, parameters resources.Deployment) (result resources.DeploymentsCreateOrUpdateFuture, err error)
 	Client
 	DeploymentClient() resources.DeploymentsClient
+	Get(ctx context.Context, resourceGroupName string, deploymentName string) (result resources.DeploymentExtended, err error)
 }
 
 type deploymentsClient struct {

--- a/pkg/util/mocks/mock_azureclient/azureclient.go
+++ b/pkg/util/mocks/mock_azureclient/azureclient.go
@@ -327,6 +327,21 @@ func (mr *MockDeploymentsClientMockRecorder) DeploymentClient() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "DeploymentClient", reflect.TypeOf((*MockDeploymentsClient)(nil).DeploymentClient))
 }
 
+// Get mocks base method
+func (m *MockDeploymentsClient) Get(arg0 context.Context, arg1, arg2 string) (resources.DeploymentExtended, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Get", arg0, arg1, arg2)
+	ret0, _ := ret[0].(resources.DeploymentExtended)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Get indicates an expected call of Get
+func (mr *MockDeploymentsClientMockRecorder) Get(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockDeploymentsClient)(nil).Get), arg0, arg1, arg2)
+}
+
 // MockGroupsClient is a mock of GroupsClient interface
 type MockGroupsClient struct {
 	ctrl     *gomock.Controller


### PR DESCRIPTION
Detects a timeout during the arm template deployment, fetches the deployment and logs its properties to assist in debugging what caused the deployment to hang

fixes #1340 

/cc @jim-minter @mjudeikis @thekad 

```release-note
NONE
```