### PR TITLE
re-add runningUnderTest to config blob for v3 compatibility

### DIFF
--- a/cmd/monitoring/monitoring.go
+++ b/cmd/monitoring/monitoring.go
@@ -101,14 +101,14 @@ func (m *monitor) listResourceGroupMonitoringHostnames(ctx context.Context, subs
 }
 
 func (m *monitor) run(ctx context.Context) error {
-	m.log.Info("fetching URLs\n")
+	m.log.Info("fetching URLs")
 	hostnames, err := m.listResourceGroupMonitoringHostnames(ctx, m.subscriptionID, m.resourceGroup)
 	if err != nil {
 		return err
 	}
 
 	for _, hostname := range hostnames {
-		m.log.Debugf("initiate blackbox monitor %s \n", hostname)
+		m.log.Debugf("initiate blackbox monitor %s", hostname)
 		req, err := http.NewRequest(http.MethodGet, fmt.Sprintf("https://%s/healthz", hostname), nil)
 		if err != nil {
 			return err
@@ -141,7 +141,7 @@ func (m *monitor) run(ctx context.Context) error {
 		mon.b.Start(ctx)
 	}
 
-	m.log.Info("collecting metrics... CTRL+C to stop\n")
+	m.log.Info("collecting metrics... CTRL+C to stop")
 	ch := make(chan os.Signal)
 	signal.Notify(ch, os.Interrupt, syscall.SIGTERM)
 	<-ch
@@ -152,7 +152,7 @@ func (m *monitor) run(ctx context.Context) error {
 func (m *monitor) persist(instances []instance) error {
 	for _, mon := range instances {
 		path := path.Join(*outputdir, fmt.Sprintf("%s.log", mon.hostname))
-		m.log.Infof("writing %s\n", path)
+		m.log.Infof("writing %s", path)
 		f, err := os.Create(path)
 		if err != nil {
 			return err

--- a/hack/tests/upgrade-e2e.sh
+++ b/hack/tests/upgrade-e2e.sh
@@ -79,6 +79,6 @@ link_secret
 
 cp -a $T/src/github.com/openshift/openshift-azure/_data .
 
-make upgrade
+ADMIN_MANIFEST=test/manifests/fakerp/admin-update.yaml make upgrade
 
 make e2e

--- a/hack/tests/upgrade-e2e.sh
+++ b/hack/tests/upgrade-e2e.sh
@@ -35,7 +35,7 @@ link_secret(){
     fi
 }
 
-preprare_ci_env(){
+prepare_ci_env(){
     # running in ci
     if [[ -f /usr/local/e2e-secrets/azure/secret ]];then
        . hack/tests/ci-operator-prepare.sh
@@ -74,7 +74,7 @@ make create
 export GOPATH=${ORG_GOPATH}
 cd ${GOPATH}/src/github.com/openshift/openshift-azure
 
-preprare_ci_env
+prepare_ci_env
 link_secret
 
 cp -a $T/src/github.com/openshift/openshift-azure/_data .

--- a/pkg/api/config.go
+++ b/pkg/api/config.go
@@ -49,6 +49,8 @@ type Config struct {
 	SessionSecretAuth []byte          `json:"sessionSecretAuth,omitempty"`
 	SessionSecretEnc  []byte          `json:"sessionSecretEnc,omitempty"`
 
+	DeprecatedRunningUnderTest bool `json:"runningUnderTest,omitempty"` // TODO: remove once v3 is dead
+
 	// misc infra configurables
 	RegistryHTTPSecret             []byte    `json:"registryHttpSecret,omitempty"`
 	PrometheusProxySessionSecret   []byte    `json:"prometheusProxySessionSecret,omitempty"`

--- a/pkg/api/converterfromplugin.go
+++ b/pkg/api/converterfromplugin.go
@@ -17,7 +17,8 @@ func ConvertFromPlugin(in *plugin.Config, old *Config, version string) (*Config,
 		c = old.DeepCopy()
 	}
 
-	c.PluginVersion = in.PluginVersion
+	// do not set c.PluginVersion = in.PluginVersion: this is decided by the
+	// upgrade code!
 
 	if c.ComponentLogLevel.APIServer == nil {
 		c.ComponentLogLevel.APIServer = &in.ComponentLogLevel.APIServer

--- a/pkg/api/converterfromplugin_test.go
+++ b/pkg/api/converterfromplugin_test.go
@@ -101,6 +101,7 @@ func TestConvertFromPlugin(t *testing.T) {
 	// prepare external type
 	var external plugin.Config
 	populate.Walk(&external, func(v reflect.Value) {})
+	external.PluginVersion = "should not be copied"
 	// prepare internal type
 	internal := internalPluginConfig()
 	output, _ := ConvertFromPlugin(&external, &internal, "Versions.key")

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -247,6 +247,7 @@ var marshalled = []byte(`{
 		"serviceAccountKey": "LS0tLS1CRUdJTiBSU0EgUFJJVkFURSBLRVktLS0tLQpNSUlCT1FJQkFBSkJBTko2cWhjWmlBK0tsUURETlZqQTY0TVRJbSt3WGFWUnZ6Q2Zwbm9ya0Y0OVJHMVYvVm5mClZCTmVPNTBvb3E1ZGNpcElOM284bmVwY09QQU5Ybk5vVkVNQ0F3RUFBUUpBSFNIclR2MHlydXdBaWJWN09jaWkKRUdkaW1kRHdkVVJtVVNXWDFrc1hWV09uTXFxeFk4c1ZEZTQrOVNqbW1uMHRpZjc3UDRHWE0zUWxKSjFXa0tvQQo4UUloQVBPWjhjRDd0NTNBazIzOWh1bytMR1FnNUZZaVdVM0JGWTJ1VUQ0RG1EL0xBaUVBM1RFbHdFcC8ybXN5CkVlaXNlc3B6ZlBqQXVSME16clRoS3FEcTEwa3BQbWtDSUdFaThORElUd2FicE81R0cwZEt0WDdUMHRrNTV5eG4KSXdZVkRUQTlWTGVUQWlBd2dhcXB0S3k5Rld6eGlIanFwS01XOE9ZeXNqQXcxSEhjaTFWMHlOS0dvUUlnWlZiVQpNZU1kQVdVdkVJbXowY0RnQ3BLTCtqNDAySm1iZFZ1dkhNNyt3QVU9Ci0tLS0tRU5EIFJTQSBQUklWQVRFIEtFWS0tLS0tCg==",
 		"sessionSecretAuth": "Q29uZmlnLlNlc3Npb25TZWNyZXRBdXRo",
 		"sessionSecretEnc": "Q29uZmlnLlNlc3Npb25TZWNyZXRFbmM=",
+		"runningUnderTest": true,
 		"registryHttpSecret": "Q29uZmlnLlJlZ2lzdHJ5SFRUUFNlY3JldA==",
 		"prometheusProxySessionSecret": "Q29uZmlnLlByb21ldGhldXNQcm94eVNlc3Npb25TZWNyZXQ=",
 		"alertManagerProxySessionSecret": "Q29uZmlnLkFsZXJ0TWFuYWdlclByb3h5U2Vzc2lvblNlY3JldA==",
@@ -401,6 +402,7 @@ func TestAdminAPIParity(t *testing.T) {
 
 	// TODO: why don't we just include all of these in the admin type?
 	notInAdmin := []*regexp.Regexp{
+		regexp.MustCompile(`^\.Config\.DeprecatedRunningUnderTest$`),
 		regexp.MustCompile(`^\.Config\.Images\.ImagePullSecret$`),
 		regexp.MustCompile(`^\.Config\.EtcdMetrics`),
 		regexp.MustCompile(`^\.Config\.(Master|Worker)StartupSASURI$`),

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -20,10 +20,11 @@ type Interface interface {
 	InvalidateSecrets() error
 }
 
-func New(cs *api.OpenShiftManagedCluster) (Interface, error) {
+// TODO: remove runningUnderTest once v3 is dead
+func New(cs *api.OpenShiftManagedCluster, runningUnderTest bool) (Interface, error) {
 	switch cs.Config.PluginVersion {
 	case "v3.2":
-		return v3.New(cs), nil
+		return v3.New(cs, runningUnderTest), nil
 	case "v4.0":
 		return v4.New(cs), nil
 	}

--- a/pkg/config/v3/generate.go
+++ b/pkg/config/v3/generate.go
@@ -371,6 +371,8 @@ func (g *simpleGenerator) Generate(template *pluginapi.Config) (err error) {
 		}
 	}
 
+	c.DeprecatedRunningUnderTest = g.runningUnderTest
+
 	if c.SSHKey == nil {
 		if c.SSHKey, err = tls.NewPrivateKey(); err != nil {
 			return

--- a/pkg/config/v3/generate_test.go
+++ b/pkg/config/v3/generate_test.go
@@ -28,7 +28,7 @@ func TestGenerate(t *testing.T) {
 	var template *pluginapi.Config
 	populate.Walk(&template, prepare)
 
-	cg := simpleGenerator{cs: cs}
+	cg := simpleGenerator{cs: cs, runningUnderTest: true}
 	err := cg.Generate(template)
 	if err != nil {
 		t.Fatal(err)
@@ -122,6 +122,7 @@ func testRequiredFields(cs *api.OpenShiftManagedCluster, t *testing.T) {
 
 	assert(len(c.SessionSecretAuth) != 0, "SessionSecretAuth")
 	assert(len(c.SessionSecretEnc) != 0, "SessionSecretEnc")
+	assert(c.DeprecatedRunningUnderTest, "DeprecatedRunningUnderTest")
 	assert(len(c.RegistryHTTPSecret) != 0, "RegistryHTTPSecret")
 	assert(len(c.AlertManagerProxySessionSecret) != 0, "AlertManagerProxySessionSecret")
 	assert(len(c.AlertsProxySessionSecret) != 0, "AlertsProxySessionSecret")

--- a/pkg/config/v3/types.go
+++ b/pkg/config/v3/types.go
@@ -5,9 +5,13 @@ import (
 )
 
 type simpleGenerator struct {
-	cs *api.OpenShiftManagedCluster
+	cs               *api.OpenShiftManagedCluster
+	runningUnderTest bool
 }
 
-func New(cs *api.OpenShiftManagedCluster) *simpleGenerator {
-	return &simpleGenerator{cs: cs}
+func New(cs *api.OpenShiftManagedCluster, runningUnderTest bool) *simpleGenerator {
+	return &simpleGenerator{
+		cs:               cs,
+		runningUnderTest: runningUnderTest,
+	}
 }

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -191,7 +191,7 @@ func TestRotateClusterSecrets(t *testing.T) {
 		upgraderFactory: func(ctx context.Context, log *logrus.Entry, cs *api.OpenShiftManagedCluster, initializeStorageClients, disableKeepAlives bool, testConfig api.TestConfig) (cluster.Upgrader, error) {
 			return clusterUpgrader, nil
 		},
-		configInterfaceFactory: func(cs *api.OpenShiftManagedCluster) (config.Interface, error) {
+		configInterfaceFactory: func(cs *api.OpenShiftManagedCluster, runningUnderTest bool) (config.Interface, error) {
 			return configInterface, nil
 		},
 		log:          logrus.NewEntry(logrus.StandardLogger()),
@@ -384,7 +384,7 @@ func TestValidateUpdateBlock(t *testing.T) {
 	p := &plugin{
 		log:          logrus.NewEntry(logrus.StandardLogger()),
 		pluginConfig: &pluginapi.Config{PluginVersion: currentVersion},
-		configInterfaceFactory: func(cs *api.OpenShiftManagedCluster) (c config.Interface, err error) {
+		configInterfaceFactory: func(cs *api.OpenShiftManagedCluster, runningUnderTest bool) (c config.Interface, err error) {
 			if cs.Config.PluginVersion != currentVersion {
 				err = fmt.Errorf("bad")
 			}

--- a/pkg/util/structtags/structtags.go
+++ b/pkg/util/structtags/structtags.go
@@ -68,6 +68,8 @@ func toTag(s string) string {
 		return "vnetSubnetID"
 	}
 
+	s = strings.TrimPrefix(s, "Deprecated")
+
 	for _, acronym := range []string{"API", "CIDR", "FQDN", "HTTP", "ID", "SDN", "SKU", "SSH", "TLS", "VM"} {
 		lower := string(acronym[0]) + strings.Map(unicode.ToLower, acronym[1:])
 		s = strings.Replace(s, acronym, lower, -1)


### PR DESCRIPTION
```release-note
NONE
```

fixes #1350 

* Re-adds runningUnderTest which is a requirement for being able to update v3 clusters on v4.
* Fixes logic error whereby ConvertFromPlugin was updating the cluster to the latest version.
* Causes upgrade-e2e.sh to upgrade cluster by writing "latest" to plugin version.