### PR TITLE
Add plugin config template override feature

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,4 @@ cscope.out
 /id_rsa
 /releasenotes
 /vmimage
+/pluginconfig/override.yaml

--- a/env.example
+++ b/env.example
@@ -45,33 +45,6 @@ export DEPLOY_VERSION=v3.11
 #export IMAGE_RESOURCEGROUP=images
 #export IMAGE_RESOURCENAME=$(az image list -g $IMAGE_RESOURCEGROUP -o json --query "[?starts_with(name, '${DEPLOY_OS:-rhel7}-${DEPLOY_VERSION//v}') && tags.valid=='true'].name | sort(@) | [-1]" | tr -d '"')
 
-# If overriding the published marketplace image, uncomment and customise this
-# section
-#export IMAGE_OFFER=osa-preview
-#export IMAGE_VERSION=latest
-
-# If overriding the image used for the sync pod, uncomment and customise this
-# section.
-#export SYNC_IMAGE=quay.io/openshift-on-azure/sync:latest
-
-# If overriding the image used for the metricsbridge pod, uncomment and customise this
-# section.
-#export METRICSBRIDGE_IMAGE=quay.io/openshift-on-azure/metricsbridge:latest
-
-# If overriding the image used for the azure-controllers pod, uncomment and
-# customise this section.
-#export AZURE_CONTROLLERS_IMAGE=quay.io/openshift-on-azure/azure-controllers:latest
-
-# If overriding the image used for the backup container, customise this section.
-#export ETCDBACKUP_IMAGE=quay.io/openshift-on-azure/etcdbackup:latest
-
-# If overriding the image used for the canary container, customise this section.
-#export CANARY_IMAGE=quay.io/openshift-on-azure/canary:latest
-
-# If overriding the image used for the startup pod, uncomment and customise this
-# section.
-#export STARTUP_IMAGE=quay.io/openshift-on-azure/startup:latest
-
 # If set to true, avoid waiting for the resource group to be cleaned up during
 # deletion.
 #export NO_WAIT=true

--- a/pkg/fakerp/server.go
+++ b/pkg/fakerp/server.go
@@ -59,7 +59,10 @@ func NewServer(log *logrus.Entry, resourceGroup, address string) *Server {
 	if err != nil {
 		s.log.Fatal(err)
 	}
-	overridePluginTemplate(s.pluginTemplate)
+	err = overridePluginTemplate(s.pluginTemplate)
+	if err != nil && !os.IsNotExist(err) {
+		s.log.Warnf("error overriding plugin config template: %v", err)
+	}
 	s.plugin, errs = plugin.NewPlugin(s.log, s.pluginTemplate, s.testConfig)
 	if len(errs) > 0 {
 		s.log.Fatal(errs)


### PR DESCRIPTION
This PR allows us to override values set in the plugin config template file with values specified in a `pluginconfig/override.yaml` file.

For example, to change the log level of openshift components within a cluster from 2 (default) to 4, it suffices to create a gitignored `pluginconfig/override.yaml` file with the following content:

```yaml
componentLogLevel:
  apiServer: 4
  controllerManager: 4
  node: 4
```

The following is a list of currently overrideable plugin config template fields:

```
componentLogLevel.apiServer
componentLogLevel.controllerManager
componentLogLevel.node
imageOffer
imageVersion
images.format
images.azureControllers
images.canary
images.etcdBackup
images.metricsBridge
images.startup
images.sync
images.tlsProxy
```

```release-note
NONE
```

fixes #1207

/cc @jim-minter @mjudeikis 