### PR TITLE
Slow the polling of WaitForReadySyncPod to 10 seconds

### DIFF
--- a/pkg/cluster/kubeclient/ready.go
+++ b/pkg/cluster/kubeclient/ready.go
@@ -38,7 +38,7 @@ func (u *kubeclient) WaitForReadyWorker(ctx context.Context, hostname string) er
 }
 
 func (u *kubeclient) WaitForReadySyncPod(ctx context.Context) error {
-	return wait.PollImmediateUntil(time.Second,
+	return wait.PollImmediateUntil(10*time.Second,
 		func() (bool, error) {
 			_, err := u.client.CoreV1().
 				Services("kube-system").


### PR DESCRIPTION
This should make the output of cluster create less wordy
```release-note
NONE
```