### PR TITLE
make TestConfig optional in NewPlugin

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -31,7 +31,12 @@ type plugin struct {
 var _ api.Plugin = &plugin{}
 
 // NewPlugin creates a new plugin instance
-func NewPlugin(log *logrus.Entry, pluginConfig *pluginapi.Config, testConfig api.TestConfig) (api.Plugin, []error) {
+func NewPlugin(log *logrus.Entry, pluginConfig *pluginapi.Config, optionalTestConfig ...api.TestConfig) (api.Plugin, []error) {
+	var testConfig api.TestConfig
+	if len(optionalTestConfig) > 0 {
+		testConfig = optionalTestConfig[0]
+	}
+
 	return &plugin{
 		log:                    log,
 		pluginConfig:           pluginConfig,


### PR DESCRIPTION
```release-note
make TestConfig optional in NewPlugin
```

requested by MSFT, backported to v3.2.1
(not going to update all of release to use v3.2.1 instead of v3.2...)