### PR TITLE
latch all configurables that come from the plugin config

### DIFF
--- a/pkg/api/plugin/convertertointernal_test.go
+++ b/pkg/api/plugin/convertertointernal_test.go
@@ -24,7 +24,7 @@ func internalPluginConfig() api.Config {
 	// this is the expected internal equivalent to
 	// internal API Config
 	return api.Config{
-		PluginVersion: "PluginVersion",
+		PluginVersion: "Versions.key",
 		ComponentLogLevel: api.ComponentLogLevel{
 			APIServer:         to.IntPtr(1),
 			ControllerManager: to.IntPtr(1),
@@ -104,7 +104,7 @@ func TestToInternal(t *testing.T) {
 	external.PluginVersion = "should not be copied"
 	// prepare internal type
 	internal := internalPluginConfig()
-	output, _ := ToInternal(&external, &internal, "Versions.key")
+	output, _ := ToInternal(&external, &api.Config{PluginVersion: "Versions.key"}, true)
 	if !reflect.DeepEqual(*output, internal) {
 		t.Errorf("unexpected diff %s", deep.Equal(*output, internal))
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -17,7 +17,7 @@ import (
 )
 
 type Interface interface {
-	Generate(template *pluginapi.Config) error
+	Generate(template *pluginapi.Config, setVersionFields bool) error
 	InvalidateSecrets() error
 }
 

--- a/pkg/config/v3/generate.go
+++ b/pkg/config/v3/generate.go
@@ -17,8 +17,8 @@ import (
 	"github.com/openshift/openshift-azure/pkg/util/tls"
 )
 
-func (g *simpleGenerator) Generate(template *pluginapi.Config) (err error) {
-	config, err := pluginapi.ToInternal(template, &g.cs.Config, g.cs.Config.PluginVersion)
+func (g *simpleGenerator) Generate(template *pluginapi.Config, setVersionFields bool) (err error) {
+	config, err := pluginapi.ToInternal(template, &g.cs.Config, setVersionFields)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/v3/generate.go
+++ b/pkg/config/v3/generate.go
@@ -435,37 +435,28 @@ func (g *simpleGenerator) Generate(template *pluginapi.Config, setVersionFields 
 	return
 }
 
-// InvalidateSecrets removes all non-ca certificates, private keys and secrets from an
-// OpenShiftManagedCluster's Config
+// InvalidateSecrets removes some secrets from an OpenShiftManagedCluster.Config
 func (g *simpleGenerator) InvalidateSecrets() (err error) {
-	g.cs.Config.Certificates.Admin = api.CertKeyPair{}
-	g.cs.Config.Certificates.AggregatorFrontProxy = api.CertKeyPair{}
-	g.cs.Config.Certificates.BlackBoxMonitor = api.CertKeyPair{}
-	g.cs.Config.Certificates.EtcdClient = api.CertKeyPair{}
-	g.cs.Config.Certificates.EtcdPeer = api.CertKeyPair{}
-	g.cs.Config.Certificates.EtcdServer = api.CertKeyPair{}
+	g.cs.Config.SSHKey = nil
+
 	g.cs.Config.Certificates.GenevaLogging = api.CertKeyPair{}
 	g.cs.Config.Certificates.GenevaMetrics = api.CertKeyPair{}
-	g.cs.Config.Certificates.MasterKubeletClient = api.CertKeyPair{}
-	g.cs.Config.Certificates.MasterProxyClient = api.CertKeyPair{}
-	g.cs.Config.Certificates.MasterServer = api.CertKeyPair{}
-	g.cs.Config.Certificates.NodeBootstrap = api.CertKeyPair{}
-	g.cs.Config.Certificates.SDN = api.CertKeyPair{}
-	g.cs.Config.Certificates.OpenShiftMaster = api.CertKeyPair{}
-	g.cs.Config.Certificates.Registry = api.CertKeyPair{}
-	g.cs.Config.Certificates.RegistryConsole = api.CertKeyPair{}
-	g.cs.Config.Certificates.ServiceCatalogServer = api.CertKeyPair{}
 
-	g.cs.Config.SSHKey = nil
-	g.cs.Config.RegistryHTTPSecret = nil
-	g.cs.Config.RegistryConsoleOAuthSecret = ""
-	g.cs.Config.ConsoleOAuthSecret = ""
-	g.cs.Config.AlertManagerProxySessionSecret = nil
-	g.cs.Config.AlertsProxySessionSecret = nil
-	g.cs.Config.PrometheusProxySessionSecret = nil
+	g.cs.Config.Images.GenevaImagePullSecret = nil
+	g.cs.Config.Images.ImagePullSecret = nil
+
 	g.cs.Config.SessionSecretAuth = nil
 	g.cs.Config.SessionSecretEnc = nil
-	g.cs.Config.Images.GenevaImagePullSecret = nil
+
+	g.cs.Config.RegistryHTTPSecret = nil
+	g.cs.Config.PrometheusProxySessionSecret = nil
+	g.cs.Config.AlertManagerProxySessionSecret = nil
+	g.cs.Config.AlertsProxySessionSecret = nil
+	g.cs.Config.RegistryConsoleOAuthSecret = ""
+	g.cs.Config.ConsoleOAuthSecret = ""
+	g.cs.Config.RouterStatsPassword = ""
+	g.cs.Config.EtcdMetricsPassword = ""
+	g.cs.Config.EtcdMetricsUsername = ""
 
 	return
 }

--- a/pkg/config/v3/generate_test.go
+++ b/pkg/config/v3/generate_test.go
@@ -1,14 +1,17 @@
 package config
 
 import (
+	"bytes"
 	"reflect"
 	"testing"
 
+	"github.com/go-test/deep"
 	uuid "github.com/satori/go.uuid"
 
 	"github.com/openshift/openshift-azure/pkg/api"
 	pluginapi "github.com/openshift/openshift-azure/pkg/api/plugin"
 	"github.com/openshift/openshift-azure/test/util/populate"
+	"github.com/openshift/openshift-azure/test/util/tls"
 )
 
 func TestGenerate(t *testing.T) {
@@ -136,132 +139,76 @@ func testRequiredFields(cs *api.OpenShiftManagedCluster, t *testing.T) {
 }
 
 func TestInvalidateSecrets(t *testing.T) {
-	prepare := func(v reflect.Value) {
-		switch v.Interface().(type) {
-		case []api.IdentityProvider:
-			// set the Provider to AADIdentityProvider
-			v.Set(reflect.ValueOf([]api.IdentityProvider{{Provider: &api.AADIdentityProvider{Kind: "AADIdentityProvider"}}}))
+	assert := func(c bool, name string) {
+		if !c {
+			t.Errorf("%s same", name)
 		}
 	}
+
 	cs := &api.OpenShiftManagedCluster{}
-	template := &pluginapi.Config{}
-	populate.Walk(cs, prepare)
-	populate.Walk(template, prepare)
-	cs.Config.PluginVersion = "Versions.key"
+	pluginConfig := &pluginapi.Config{}
 
 	g := simpleGenerator{cs: cs}
-	saved := cs.DeepCopy()
-	if err := g.InvalidateSecrets(); err != nil {
-		t.Errorf("configGenerator.InvalidateSecrets error = %v", err)
+	err := g.Generate(pluginConfig, false)
+	if err != nil {
+		t.Error(err)
 	}
-	g.Generate(template, true)
+
+	saved := cs.DeepCopy()
+
+	err = g.InvalidateSecrets()
+	if err != nil {
+		t.Error(err)
+	}
+
+	pluginConfig.GenevaImagePullSecret = []byte("genevaImagePullSecret")
+	pluginConfig.ImagePullSecret = []byte("imagePullSecret")
+	pluginConfig.Certificates.GenevaLogging.Cert = tls.GetDummyCertificate()
+	pluginConfig.Certificates.GenevaMetrics.Cert = tls.GetDummyCertificate()
+
+	err = g.Generate(pluginConfig, false)
+	if err != nil {
+		t.Error(err)
+	}
 
 	// compare fields that are expected to be different
-	if reflect.DeepEqual(saved.Config.Certificates.Admin, cs.Config.Certificates.Admin) {
-		t.Errorf("expected change to Admin certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Certificates.AggregatorFrontProxy, cs.Config.Certificates.AggregatorFrontProxy) {
-		t.Errorf("expected change to AggregatorFrontProxy certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Certificates.BlackBoxMonitor, cs.Config.Certificates.BlackBoxMonitor) {
-		t.Errorf("expected change to BlackBoxMonitor certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Certificates.EtcdClient, cs.Config.Certificates.EtcdClient) {
-		t.Errorf("expected change to EtcdClient certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Certificates.EtcdPeer, cs.Config.Certificates.EtcdPeer) {
-		t.Errorf("expected change to EtcdPeer certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Certificates.EtcdServer, cs.Config.Certificates.EtcdServer) {
-		t.Errorf("expected change to EtcdServer certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Certificates.MasterKubeletClient, cs.Config.Certificates.MasterKubeletClient) {
-		t.Errorf("expected change to MasterKubeletClient certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Certificates.MasterProxyClient, cs.Config.Certificates.MasterProxyClient) {
-		t.Errorf("expected change to MasterProxyClient certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Certificates.MasterServer, cs.Config.Certificates.MasterServer) {
-		t.Errorf("expected change to MasterProxyClient certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Certificates.NodeBootstrap, cs.Config.Certificates.NodeBootstrap) {
-		t.Errorf("expected change to NodeBootstrap certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Certificates.SDN, cs.Config.Certificates.SDN) {
-		t.Errorf("expected change to SDN certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Certificates.OpenShiftMaster, cs.Config.Certificates.OpenShiftMaster) {
-		t.Errorf("expected change to OpenShiftMaster certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Certificates.Registry, cs.Config.Certificates.Registry) {
-		t.Errorf("expected change to Registry certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Certificates.RegistryConsole, cs.Config.Certificates.RegistryConsole) {
-		t.Errorf("expected change to RegistryConsole certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Certificates.ServiceCatalogServer, cs.Config.Certificates.ServiceCatalogServer) {
-		t.Errorf("expected change to ServiceCatalogServer certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.SSHKey, cs.Config.SSHKey) {
-		t.Errorf("expected change to SSHKey after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.RegistryHTTPSecret, cs.Config.RegistryHTTPSecret) {
-		t.Errorf("expected change to RegistryHTTPSecret after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.RegistryConsoleOAuthSecret, cs.Config.RegistryConsoleOAuthSecret) {
-		t.Errorf("expected change to RegistryConsoleOAuthSecret after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.ConsoleOAuthSecret, cs.Config.ConsoleOAuthSecret) {
-		t.Errorf("expected change to ConsoleOAuthSecret after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.AlertManagerProxySessionSecret, cs.Config.AlertManagerProxySessionSecret) {
-		t.Errorf("expected change to AlertManagerProxySessionSecret after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.AlertsProxySessionSecret, cs.Config.AlertsProxySessionSecret) {
-		t.Errorf("expected change to AlertsProxySessionSecret after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.PrometheusProxySessionSecret, cs.Config.PrometheusProxySessionSecret) {
-		t.Errorf("expected change to PrometheusProxySessionSecret after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.SessionSecretAuth, cs.Config.SessionSecretAuth) {
-		t.Errorf("expected change to SessionSecretAuth after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.SessionSecretEnc, cs.Config.SessionSecretEnc) {
-		t.Errorf("expected change to SessionSecretEnc after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Images.GenevaImagePullSecret, cs.Config.Images.GenevaImagePullSecret) {
-		t.Errorf("expected change to GenevaImagePullSecret after secret invalidation")
-	}
-
-	// compare fields that are expected to be the same
-	if !reflect.DeepEqual(saved.Config.Certificates.GenevaMetrics, cs.Config.Certificates.GenevaMetrics) {
-		t.Errorf("unexpected change to GenevaMetrics certificates after secret invalidation")
-	}
-	if !reflect.DeepEqual(saved.Config.Certificates.GenevaLogging, cs.Config.Certificates.GenevaLogging) {
-		t.Errorf("unexpected change to GenevaLogging after secret invalidation")
-	}
+	assert(!reflect.DeepEqual(cs.Config.SSHKey, saved.Config.SSHKey), "sshKey")
+	assert(!reflect.DeepEqual(cs.Config.Certificates.GenevaLogging, saved.Config.Certificates.GenevaLogging), "certificates.genevaLogging")
+	assert(!reflect.DeepEqual(cs.Config.Certificates.GenevaMetrics, saved.Config.Certificates.GenevaMetrics), "certificates.genevaMetrics")
+	assert(!bytes.Equal(cs.Config.Images.GenevaImagePullSecret, saved.Config.Images.GenevaImagePullSecret), "images.genevaImagePullSecret")
+	assert(!bytes.Equal(cs.Config.Images.ImagePullSecret, saved.Config.Images.ImagePullSecret), "images.imagePullSecret")
+	assert(!bytes.Equal(cs.Config.SessionSecretAuth, saved.Config.SessionSecretAuth), "sessionSecretAuth")
+	assert(!bytes.Equal(cs.Config.SessionSecretEnc, saved.Config.SessionSecretEnc), "sessionSecreteEnc")
+	assert(!bytes.Equal(cs.Config.RegistryHTTPSecret, saved.Config.RegistryHTTPSecret), "registryHTTPSecret")
+	assert(!bytes.Equal(cs.Config.PrometheusProxySessionSecret, saved.Config.PrometheusProxySessionSecret), "prometheusProxySessionSecret")
+	assert(!bytes.Equal(cs.Config.AlertManagerProxySessionSecret, saved.Config.AlertManagerProxySessionSecret), "alertManagerProxySessionSecret")
+	assert(!bytes.Equal(cs.Config.AlertsProxySessionSecret, saved.Config.AlertsProxySessionSecret), "alertsProxySessionSecret")
+	assert(cs.Config.RegistryConsoleOAuthSecret != saved.Config.RegistryConsoleOAuthSecret, "registryConsoleOAuthSecret")
+	assert(cs.Config.ConsoleOAuthSecret != saved.Config.ConsoleOAuthSecret, "consoleOAuthSecret")
+	assert(cs.Config.RouterStatsPassword != saved.Config.RouterStatsPassword, "routerStatsPassword")
+	assert(cs.Config.EtcdMetricsPassword != saved.Config.EtcdMetricsPassword, "etcdMetricsPassword")
+	assert(cs.Config.EtcdMetricsUsername != saved.Config.EtcdMetricsUsername, "etcdMetricsUsername")
 
 	// assign saved values back to those changed in cs
-	cs.Config.Certificates.Admin = saved.Config.Certificates.Admin
-	cs.Config.Certificates.AggregatorFrontProxy = saved.Config.Certificates.AggregatorFrontProxy
-	cs.Config.Certificates.BlackBoxMonitor = saved.Config.Certificates.BlackBoxMonitor
-	cs.Config.Certificates.EtcdClient = saved.Config.Certificates.EtcdClient
-	cs.Config.Certificates.EtcdPeer = saved.Config.Certificates.EtcdPeer
-	cs.Config.Certificates.EtcdServer = saved.Config.Certificates.EtcdServer
-	cs.Config.Certificates.MasterKubeletClient = saved.Config.Certificates.MasterKubeletClient
-	cs.Config.Certificates.MasterProxyClient = saved.Config.Certificates.MasterProxyClient
-	cs.Config.Certificates.MasterServer = saved.Config.Certificates.MasterServer
-	cs.Config.Certificates.NodeBootstrap = saved.Config.Certificates.NodeBootstrap
-	cs.Config.Certificates.SDN = saved.Config.Certificates.SDN
-	cs.Config.Certificates.OpenShiftMaster = saved.Config.Certificates.OpenShiftMaster
-	cs.Config.Certificates.Registry = saved.Config.Certificates.Registry
-	cs.Config.Certificates.RegistryConsole = saved.Config.Certificates.RegistryConsole
-	cs.Config.Certificates.ServiceCatalogServer = saved.Config.Certificates.ServiceCatalogServer
+	cs.Config.SSHKey = saved.Config.SSHKey
 	cs.Config.Certificates.GenevaLogging = saved.Config.Certificates.GenevaLogging
 	cs.Config.Certificates.GenevaMetrics = saved.Config.Certificates.GenevaMetrics
+	cs.Config.Images.GenevaImagePullSecret = saved.Config.Images.GenevaImagePullSecret
+	cs.Config.Images.ImagePullSecret = saved.Config.Images.ImagePullSecret
+	cs.Config.SessionSecretAuth = saved.Config.SessionSecretAuth
+	cs.Config.SessionSecretEnc = saved.Config.SessionSecretEnc
+	cs.Config.RegistryHTTPSecret = saved.Config.RegistryHTTPSecret
+	cs.Config.PrometheusProxySessionSecret = saved.Config.PrometheusProxySessionSecret
+	cs.Config.AlertManagerProxySessionSecret = saved.Config.AlertManagerProxySessionSecret
+	cs.Config.AlertsProxySessionSecret = saved.Config.AlertsProxySessionSecret
+	cs.Config.RegistryConsoleOAuthSecret = saved.Config.RegistryConsoleOAuthSecret
+	cs.Config.ConsoleOAuthSecret = saved.Config.ConsoleOAuthSecret
+	cs.Config.RouterStatsPassword = saved.Config.RouterStatsPassword
+	cs.Config.EtcdMetricsPassword = saved.Config.EtcdMetricsPassword
+	cs.Config.EtcdMetricsUsername = saved.Config.EtcdMetricsUsername
 
 	// compare certs from saved and cs
-	if !reflect.DeepEqual(saved.Config.Certificates, cs.Config.Certificates) {
-		t.Errorf("expected saved and cs config blobs to be equal")
+	if !reflect.DeepEqual(cs, saved) {
+		t.Errorf("expected saved and cs config blobs to be equal: %s", deep.Equal(cs, saved))
 	}
 }

--- a/pkg/config/v3/generate_test.go
+++ b/pkg/config/v3/generate_test.go
@@ -29,7 +29,7 @@ func TestGenerate(t *testing.T) {
 	populate.Walk(&template, prepare)
 
 	cg := simpleGenerator{cs: cs, runningUnderTest: true}
-	err := cg.Generate(template)
+	err := cg.Generate(template, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -154,7 +154,7 @@ func TestInvalidateSecrets(t *testing.T) {
 	if err := g.InvalidateSecrets(); err != nil {
 		t.Errorf("configGenerator.InvalidateSecrets error = %v", err)
 	}
-	g.Generate(template)
+	g.Generate(template, true)
 
 	// compare fields that are expected to be different
 	if reflect.DeepEqual(saved.Config.Certificates.Admin, cs.Config.Certificates.Admin) {

--- a/pkg/config/v4/generate.go
+++ b/pkg/config/v4/generate.go
@@ -17,8 +17,8 @@ import (
 	"github.com/openshift/openshift-azure/pkg/util/tls"
 )
 
-func (g *simpleGenerator) Generate(template *pluginapi.Config) (err error) {
-	config, err := pluginapi.ToInternal(template, &g.cs.Config, g.cs.Config.PluginVersion)
+func (g *simpleGenerator) Generate(template *pluginapi.Config, setVersionFields bool) (err error) {
+	config, err := pluginapi.ToInternal(template, &g.cs.Config, setVersionFields)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/v4/generate.go
+++ b/pkg/config/v4/generate.go
@@ -433,37 +433,28 @@ func (g *simpleGenerator) Generate(template *pluginapi.Config, setVersionFields 
 	return
 }
 
-// InvalidateSecrets removes all non-ca certificates, private keys and secrets from an
-// OpenShiftManagedCluster's Config
+// InvalidateSecrets removes some secrets from an OpenShiftManagedCluster.Config
 func (g *simpleGenerator) InvalidateSecrets() (err error) {
-	g.cs.Config.Certificates.Admin = api.CertKeyPair{}
-	g.cs.Config.Certificates.AggregatorFrontProxy = api.CertKeyPair{}
-	g.cs.Config.Certificates.BlackBoxMonitor = api.CertKeyPair{}
-	g.cs.Config.Certificates.EtcdClient = api.CertKeyPair{}
-	g.cs.Config.Certificates.EtcdPeer = api.CertKeyPair{}
-	g.cs.Config.Certificates.EtcdServer = api.CertKeyPair{}
+	g.cs.Config.SSHKey = nil
+
 	g.cs.Config.Certificates.GenevaLogging = api.CertKeyPair{}
 	g.cs.Config.Certificates.GenevaMetrics = api.CertKeyPair{}
-	g.cs.Config.Certificates.MasterKubeletClient = api.CertKeyPair{}
-	g.cs.Config.Certificates.MasterProxyClient = api.CertKeyPair{}
-	g.cs.Config.Certificates.MasterServer = api.CertKeyPair{}
-	g.cs.Config.Certificates.NodeBootstrap = api.CertKeyPair{}
-	g.cs.Config.Certificates.SDN = api.CertKeyPair{}
-	g.cs.Config.Certificates.OpenShiftMaster = api.CertKeyPair{}
-	g.cs.Config.Certificates.Registry = api.CertKeyPair{}
-	g.cs.Config.Certificates.RegistryConsole = api.CertKeyPair{}
-	g.cs.Config.Certificates.ServiceCatalogServer = api.CertKeyPair{}
 
-	g.cs.Config.SSHKey = nil
-	g.cs.Config.RegistryHTTPSecret = nil
-	g.cs.Config.RegistryConsoleOAuthSecret = ""
-	g.cs.Config.ConsoleOAuthSecret = ""
-	g.cs.Config.AlertManagerProxySessionSecret = nil
-	g.cs.Config.AlertsProxySessionSecret = nil
-	g.cs.Config.PrometheusProxySessionSecret = nil
+	g.cs.Config.Images.GenevaImagePullSecret = nil
+	g.cs.Config.Images.ImagePullSecret = nil
+
 	g.cs.Config.SessionSecretAuth = nil
 	g.cs.Config.SessionSecretEnc = nil
-	g.cs.Config.Images.GenevaImagePullSecret = nil
+
+	g.cs.Config.RegistryHTTPSecret = nil
+	g.cs.Config.PrometheusProxySessionSecret = nil
+	g.cs.Config.AlertManagerProxySessionSecret = nil
+	g.cs.Config.AlertsProxySessionSecret = nil
+	g.cs.Config.RegistryConsoleOAuthSecret = ""
+	g.cs.Config.ConsoleOAuthSecret = ""
+	g.cs.Config.RouterStatsPassword = ""
+	g.cs.Config.EtcdMetricsPassword = ""
+	g.cs.Config.EtcdMetricsUsername = ""
 
 	return
 }

--- a/pkg/config/v4/generate_test.go
+++ b/pkg/config/v4/generate_test.go
@@ -29,7 +29,7 @@ func TestGenerate(t *testing.T) {
 	populate.Walk(&template, prepare)
 
 	cg := simpleGenerator{cs: cs}
-	err := cg.Generate(template)
+	err := cg.Generate(template, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -153,7 +153,7 @@ func TestInvalidateSecrets(t *testing.T) {
 	if err := g.InvalidateSecrets(); err != nil {
 		t.Errorf("configGenerator.InvalidateSecrets error = %v", err)
 	}
-	g.Generate(template)
+	g.Generate(template, true)
 
 	// compare fields that are expected to be different
 	if reflect.DeepEqual(saved.Config.Certificates.Admin, cs.Config.Certificates.Admin) {

--- a/pkg/config/v4/generate_test.go
+++ b/pkg/config/v4/generate_test.go
@@ -1,14 +1,17 @@
 package config
 
 import (
+	"bytes"
 	"reflect"
 	"testing"
 
+	"github.com/go-test/deep"
 	uuid "github.com/satori/go.uuid"
 
 	"github.com/openshift/openshift-azure/pkg/api"
 	pluginapi "github.com/openshift/openshift-azure/pkg/api/plugin"
 	"github.com/openshift/openshift-azure/test/util/populate"
+	"github.com/openshift/openshift-azure/test/util/tls"
 )
 
 func TestGenerate(t *testing.T) {
@@ -135,132 +138,76 @@ func testRequiredFields(cs *api.OpenShiftManagedCluster, t *testing.T) {
 }
 
 func TestInvalidateSecrets(t *testing.T) {
-	prepare := func(v reflect.Value) {
-		switch v.Interface().(type) {
-		case []api.IdentityProvider:
-			// set the Provider to AADIdentityProvider
-			v.Set(reflect.ValueOf([]api.IdentityProvider{{Provider: &api.AADIdentityProvider{Kind: "AADIdentityProvider"}}}))
+	assert := func(c bool, name string) {
+		if !c {
+			t.Errorf("%s same", name)
 		}
 	}
+
 	cs := &api.OpenShiftManagedCluster{}
-	template := &pluginapi.Config{}
-	populate.Walk(cs, prepare)
-	populate.Walk(template, prepare)
-	cs.Config.PluginVersion = "Versions.key"
+	pluginConfig := &pluginapi.Config{}
 
 	g := simpleGenerator{cs: cs}
-	saved := cs.DeepCopy()
-	if err := g.InvalidateSecrets(); err != nil {
-		t.Errorf("configGenerator.InvalidateSecrets error = %v", err)
+	err := g.Generate(pluginConfig, false)
+	if err != nil {
+		t.Error(err)
 	}
-	g.Generate(template, true)
+
+	saved := cs.DeepCopy()
+
+	err = g.InvalidateSecrets()
+	if err != nil {
+		t.Error(err)
+	}
+
+	pluginConfig.GenevaImagePullSecret = []byte("genevaImagePullSecret")
+	pluginConfig.ImagePullSecret = []byte("imagePullSecret")
+	pluginConfig.Certificates.GenevaLogging.Cert = tls.GetDummyCertificate()
+	pluginConfig.Certificates.GenevaMetrics.Cert = tls.GetDummyCertificate()
+
+	err = g.Generate(pluginConfig, false)
+	if err != nil {
+		t.Error(err)
+	}
 
 	// compare fields that are expected to be different
-	if reflect.DeepEqual(saved.Config.Certificates.Admin, cs.Config.Certificates.Admin) {
-		t.Errorf("expected change to Admin certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Certificates.AggregatorFrontProxy, cs.Config.Certificates.AggregatorFrontProxy) {
-		t.Errorf("expected change to AggregatorFrontProxy certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Certificates.BlackBoxMonitor, cs.Config.Certificates.BlackBoxMonitor) {
-		t.Errorf("expected change to BlackBoxMonitor certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Certificates.EtcdClient, cs.Config.Certificates.EtcdClient) {
-		t.Errorf("expected change to EtcdClient certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Certificates.EtcdPeer, cs.Config.Certificates.EtcdPeer) {
-		t.Errorf("expected change to EtcdPeer certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Certificates.EtcdServer, cs.Config.Certificates.EtcdServer) {
-		t.Errorf("expected change to EtcdServer certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Certificates.MasterKubeletClient, cs.Config.Certificates.MasterKubeletClient) {
-		t.Errorf("expected change to MasterKubeletClient certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Certificates.MasterProxyClient, cs.Config.Certificates.MasterProxyClient) {
-		t.Errorf("expected change to MasterProxyClient certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Certificates.MasterServer, cs.Config.Certificates.MasterServer) {
-		t.Errorf("expected change to MasterProxyClient certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Certificates.NodeBootstrap, cs.Config.Certificates.NodeBootstrap) {
-		t.Errorf("expected change to NodeBootstrap certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Certificates.SDN, cs.Config.Certificates.SDN) {
-		t.Errorf("expected change to SDN certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Certificates.OpenShiftMaster, cs.Config.Certificates.OpenShiftMaster) {
-		t.Errorf("expected change to OpenShiftMaster certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Certificates.Registry, cs.Config.Certificates.Registry) {
-		t.Errorf("expected change to Registry certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Certificates.RegistryConsole, cs.Config.Certificates.RegistryConsole) {
-		t.Errorf("expected change to RegistryConsole certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Certificates.ServiceCatalogServer, cs.Config.Certificates.ServiceCatalogServer) {
-		t.Errorf("expected change to ServiceCatalogServer certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.SSHKey, cs.Config.SSHKey) {
-		t.Errorf("expected change to SSHKey after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.RegistryHTTPSecret, cs.Config.RegistryHTTPSecret) {
-		t.Errorf("expected change to RegistryHTTPSecret after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.RegistryConsoleOAuthSecret, cs.Config.RegistryConsoleOAuthSecret) {
-		t.Errorf("expected change to RegistryConsoleOAuthSecret after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.ConsoleOAuthSecret, cs.Config.ConsoleOAuthSecret) {
-		t.Errorf("expected change to ConsoleOAuthSecret after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.AlertManagerProxySessionSecret, cs.Config.AlertManagerProxySessionSecret) {
-		t.Errorf("expected change to AlertManagerProxySessionSecret after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.AlertsProxySessionSecret, cs.Config.AlertsProxySessionSecret) {
-		t.Errorf("expected change to AlertsProxySessionSecret after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.PrometheusProxySessionSecret, cs.Config.PrometheusProxySessionSecret) {
-		t.Errorf("expected change to PrometheusProxySessionSecret after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.SessionSecretAuth, cs.Config.SessionSecretAuth) {
-		t.Errorf("expected change to SessionSecretAuth after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.SessionSecretEnc, cs.Config.SessionSecretEnc) {
-		t.Errorf("expected change to SessionSecretEnc after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Images.GenevaImagePullSecret, cs.Config.Images.GenevaImagePullSecret) {
-		t.Errorf("expected change to GenevaImagePullSecret after secret invalidation")
-	}
-
-	// compare fields that are expected to be the same
-	if !reflect.DeepEqual(saved.Config.Certificates.GenevaMetrics, cs.Config.Certificates.GenevaMetrics) {
-		t.Errorf("unexpected change to GenevaMetrics certificates after secret invalidation")
-	}
-	if !reflect.DeepEqual(saved.Config.Certificates.GenevaLogging, cs.Config.Certificates.GenevaLogging) {
-		t.Errorf("unexpected change to GenevaLogging after secret invalidation")
-	}
+	assert(!reflect.DeepEqual(cs.Config.SSHKey, saved.Config.SSHKey), "sshKey")
+	assert(!reflect.DeepEqual(cs.Config.Certificates.GenevaLogging, saved.Config.Certificates.GenevaLogging), "certificates.genevaLogging")
+	assert(!reflect.DeepEqual(cs.Config.Certificates.GenevaMetrics, saved.Config.Certificates.GenevaMetrics), "certificates.genevaMetrics")
+	assert(!bytes.Equal(cs.Config.Images.GenevaImagePullSecret, saved.Config.Images.GenevaImagePullSecret), "images.genevaImagePullSecret")
+	assert(!bytes.Equal(cs.Config.Images.ImagePullSecret, saved.Config.Images.ImagePullSecret), "images.imagePullSecret")
+	assert(!bytes.Equal(cs.Config.SessionSecretAuth, saved.Config.SessionSecretAuth), "sessionSecretAuth")
+	assert(!bytes.Equal(cs.Config.SessionSecretEnc, saved.Config.SessionSecretEnc), "sessionSecreteEnc")
+	assert(!bytes.Equal(cs.Config.RegistryHTTPSecret, saved.Config.RegistryHTTPSecret), "registryHTTPSecret")
+	assert(!bytes.Equal(cs.Config.PrometheusProxySessionSecret, saved.Config.PrometheusProxySessionSecret), "prometheusProxySessionSecret")
+	assert(!bytes.Equal(cs.Config.AlertManagerProxySessionSecret, saved.Config.AlertManagerProxySessionSecret), "alertManagerProxySessionSecret")
+	assert(!bytes.Equal(cs.Config.AlertsProxySessionSecret, saved.Config.AlertsProxySessionSecret), "alertsProxySessionSecret")
+	assert(cs.Config.RegistryConsoleOAuthSecret != saved.Config.RegistryConsoleOAuthSecret, "registryConsoleOAuthSecret")
+	assert(cs.Config.ConsoleOAuthSecret != saved.Config.ConsoleOAuthSecret, "consoleOAuthSecret")
+	assert(cs.Config.RouterStatsPassword != saved.Config.RouterStatsPassword, "routerStatsPassword")
+	assert(cs.Config.EtcdMetricsPassword != saved.Config.EtcdMetricsPassword, "etcdMetricsPassword")
+	assert(cs.Config.EtcdMetricsUsername != saved.Config.EtcdMetricsUsername, "etcdMetricsUsername")
 
 	// assign saved values back to those changed in cs
-	cs.Config.Certificates.Admin = saved.Config.Certificates.Admin
-	cs.Config.Certificates.AggregatorFrontProxy = saved.Config.Certificates.AggregatorFrontProxy
-	cs.Config.Certificates.BlackBoxMonitor = saved.Config.Certificates.BlackBoxMonitor
-	cs.Config.Certificates.EtcdClient = saved.Config.Certificates.EtcdClient
-	cs.Config.Certificates.EtcdPeer = saved.Config.Certificates.EtcdPeer
-	cs.Config.Certificates.EtcdServer = saved.Config.Certificates.EtcdServer
-	cs.Config.Certificates.MasterKubeletClient = saved.Config.Certificates.MasterKubeletClient
-	cs.Config.Certificates.MasterProxyClient = saved.Config.Certificates.MasterProxyClient
-	cs.Config.Certificates.MasterServer = saved.Config.Certificates.MasterServer
-	cs.Config.Certificates.NodeBootstrap = saved.Config.Certificates.NodeBootstrap
-	cs.Config.Certificates.SDN = saved.Config.Certificates.SDN
-	cs.Config.Certificates.OpenShiftMaster = saved.Config.Certificates.OpenShiftMaster
-	cs.Config.Certificates.Registry = saved.Config.Certificates.Registry
-	cs.Config.Certificates.RegistryConsole = saved.Config.Certificates.RegistryConsole
-	cs.Config.Certificates.ServiceCatalogServer = saved.Config.Certificates.ServiceCatalogServer
+	cs.Config.SSHKey = saved.Config.SSHKey
 	cs.Config.Certificates.GenevaLogging = saved.Config.Certificates.GenevaLogging
 	cs.Config.Certificates.GenevaMetrics = saved.Config.Certificates.GenevaMetrics
+	cs.Config.Images.GenevaImagePullSecret = saved.Config.Images.GenevaImagePullSecret
+	cs.Config.Images.ImagePullSecret = saved.Config.Images.ImagePullSecret
+	cs.Config.SessionSecretAuth = saved.Config.SessionSecretAuth
+	cs.Config.SessionSecretEnc = saved.Config.SessionSecretEnc
+	cs.Config.RegistryHTTPSecret = saved.Config.RegistryHTTPSecret
+	cs.Config.PrometheusProxySessionSecret = saved.Config.PrometheusProxySessionSecret
+	cs.Config.AlertManagerProxySessionSecret = saved.Config.AlertManagerProxySessionSecret
+	cs.Config.AlertsProxySessionSecret = saved.Config.AlertsProxySessionSecret
+	cs.Config.RegistryConsoleOAuthSecret = saved.Config.RegistryConsoleOAuthSecret
+	cs.Config.ConsoleOAuthSecret = saved.Config.ConsoleOAuthSecret
+	cs.Config.RouterStatsPassword = saved.Config.RouterStatsPassword
+	cs.Config.EtcdMetricsPassword = saved.Config.EtcdMetricsPassword
+	cs.Config.EtcdMetricsUsername = saved.Config.EtcdMetricsUsername
 
 	// compare certs from saved and cs
-	if !reflect.DeepEqual(saved.Config.Certificates, cs.Config.Certificates) {
-		t.Errorf("expected saved and cs config blobs to be equal")
+	if !reflect.DeepEqual(cs, saved) {
+		t.Errorf("expected saved and cs config blobs to be equal: %s", deep.Equal(cs, saved))
 	}
 }

--- a/pkg/config/v5/generate.go
+++ b/pkg/config/v5/generate.go
@@ -17,8 +17,8 @@ import (
 	"github.com/openshift/openshift-azure/pkg/util/tls"
 )
 
-func (g *simpleGenerator) Generate(template *pluginapi.Config) (err error) {
-	config, err := pluginapi.ToInternal(template, &g.cs.Config, g.cs.Config.PluginVersion)
+func (g *simpleGenerator) Generate(template *pluginapi.Config, setVersionFields bool) (err error) {
+	config, err := pluginapi.ToInternal(template, &g.cs.Config, setVersionFields)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/v5/generate.go
+++ b/pkg/config/v5/generate.go
@@ -433,37 +433,28 @@ func (g *simpleGenerator) Generate(template *pluginapi.Config, setVersionFields 
 	return
 }
 
-// InvalidateSecrets removes all non-ca certificates, private keys and secrets from an
-// OpenShiftManagedCluster's Config
+// InvalidateSecrets removes some secrets from an OpenShiftManagedCluster.Config
 func (g *simpleGenerator) InvalidateSecrets() (err error) {
-	g.cs.Config.Certificates.Admin = api.CertKeyPair{}
-	g.cs.Config.Certificates.AggregatorFrontProxy = api.CertKeyPair{}
-	g.cs.Config.Certificates.BlackBoxMonitor = api.CertKeyPair{}
-	g.cs.Config.Certificates.EtcdClient = api.CertKeyPair{}
-	g.cs.Config.Certificates.EtcdPeer = api.CertKeyPair{}
-	g.cs.Config.Certificates.EtcdServer = api.CertKeyPair{}
+	g.cs.Config.SSHKey = nil
+
 	g.cs.Config.Certificates.GenevaLogging = api.CertKeyPair{}
 	g.cs.Config.Certificates.GenevaMetrics = api.CertKeyPair{}
-	g.cs.Config.Certificates.MasterKubeletClient = api.CertKeyPair{}
-	g.cs.Config.Certificates.MasterProxyClient = api.CertKeyPair{}
-	g.cs.Config.Certificates.MasterServer = api.CertKeyPair{}
-	g.cs.Config.Certificates.NodeBootstrap = api.CertKeyPair{}
-	g.cs.Config.Certificates.SDN = api.CertKeyPair{}
-	g.cs.Config.Certificates.OpenShiftMaster = api.CertKeyPair{}
-	g.cs.Config.Certificates.Registry = api.CertKeyPair{}
-	g.cs.Config.Certificates.RegistryConsole = api.CertKeyPair{}
-	g.cs.Config.Certificates.ServiceCatalogServer = api.CertKeyPair{}
 
-	g.cs.Config.SSHKey = nil
-	g.cs.Config.RegistryHTTPSecret = nil
-	g.cs.Config.RegistryConsoleOAuthSecret = ""
-	g.cs.Config.ConsoleOAuthSecret = ""
-	g.cs.Config.AlertManagerProxySessionSecret = nil
-	g.cs.Config.AlertsProxySessionSecret = nil
-	g.cs.Config.PrometheusProxySessionSecret = nil
+	g.cs.Config.Images.GenevaImagePullSecret = nil
+	g.cs.Config.Images.ImagePullSecret = nil
+
 	g.cs.Config.SessionSecretAuth = nil
 	g.cs.Config.SessionSecretEnc = nil
-	g.cs.Config.Images.GenevaImagePullSecret = nil
+
+	g.cs.Config.RegistryHTTPSecret = nil
+	g.cs.Config.PrometheusProxySessionSecret = nil
+	g.cs.Config.AlertManagerProxySessionSecret = nil
+	g.cs.Config.AlertsProxySessionSecret = nil
+	g.cs.Config.RegistryConsoleOAuthSecret = ""
+	g.cs.Config.ConsoleOAuthSecret = ""
+	g.cs.Config.RouterStatsPassword = ""
+	g.cs.Config.EtcdMetricsPassword = ""
+	g.cs.Config.EtcdMetricsUsername = ""
 
 	return
 }

--- a/pkg/config/v5/generate_test.go
+++ b/pkg/config/v5/generate_test.go
@@ -29,7 +29,7 @@ func TestGenerate(t *testing.T) {
 	populate.Walk(&template, prepare)
 
 	cg := simpleGenerator{cs: cs}
-	err := cg.Generate(template)
+	err := cg.Generate(template, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -153,7 +153,7 @@ func TestInvalidateSecrets(t *testing.T) {
 	if err := g.InvalidateSecrets(); err != nil {
 		t.Errorf("configGenerator.InvalidateSecrets error = %v", err)
 	}
-	g.Generate(template)
+	g.Generate(template, true)
 
 	// compare fields that are expected to be different
 	if reflect.DeepEqual(saved.Config.Certificates.Admin, cs.Config.Certificates.Admin) {

--- a/pkg/config/v5/generate_test.go
+++ b/pkg/config/v5/generate_test.go
@@ -1,14 +1,17 @@
 package config
 
 import (
+	"bytes"
 	"reflect"
 	"testing"
 
+	"github.com/go-test/deep"
 	uuid "github.com/satori/go.uuid"
 
 	"github.com/openshift/openshift-azure/pkg/api"
 	pluginapi "github.com/openshift/openshift-azure/pkg/api/plugin"
 	"github.com/openshift/openshift-azure/test/util/populate"
+	"github.com/openshift/openshift-azure/test/util/tls"
 )
 
 func TestGenerate(t *testing.T) {
@@ -135,132 +138,76 @@ func testRequiredFields(cs *api.OpenShiftManagedCluster, t *testing.T) {
 }
 
 func TestInvalidateSecrets(t *testing.T) {
-	prepare := func(v reflect.Value) {
-		switch v.Interface().(type) {
-		case []api.IdentityProvider:
-			// set the Provider to AADIdentityProvider
-			v.Set(reflect.ValueOf([]api.IdentityProvider{{Provider: &api.AADIdentityProvider{Kind: "AADIdentityProvider"}}}))
+	assert := func(c bool, name string) {
+		if !c {
+			t.Errorf("%s same", name)
 		}
 	}
+
 	cs := &api.OpenShiftManagedCluster{}
-	template := &pluginapi.Config{}
-	populate.Walk(cs, prepare)
-	populate.Walk(template, prepare)
-	cs.Config.PluginVersion = "Versions.key"
+	pluginConfig := &pluginapi.Config{}
 
 	g := simpleGenerator{cs: cs}
-	saved := cs.DeepCopy()
-	if err := g.InvalidateSecrets(); err != nil {
-		t.Errorf("configGenerator.InvalidateSecrets error = %v", err)
+	err := g.Generate(pluginConfig, false)
+	if err != nil {
+		t.Error(err)
 	}
-	g.Generate(template, true)
+
+	saved := cs.DeepCopy()
+
+	err = g.InvalidateSecrets()
+	if err != nil {
+		t.Error(err)
+	}
+
+	pluginConfig.GenevaImagePullSecret = []byte("genevaImagePullSecret")
+	pluginConfig.ImagePullSecret = []byte("imagePullSecret")
+	pluginConfig.Certificates.GenevaLogging.Cert = tls.GetDummyCertificate()
+	pluginConfig.Certificates.GenevaMetrics.Cert = tls.GetDummyCertificate()
+
+	err = g.Generate(pluginConfig, false)
+	if err != nil {
+		t.Error(err)
+	}
 
 	// compare fields that are expected to be different
-	if reflect.DeepEqual(saved.Config.Certificates.Admin, cs.Config.Certificates.Admin) {
-		t.Errorf("expected change to Admin certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Certificates.AggregatorFrontProxy, cs.Config.Certificates.AggregatorFrontProxy) {
-		t.Errorf("expected change to AggregatorFrontProxy certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Certificates.BlackBoxMonitor, cs.Config.Certificates.BlackBoxMonitor) {
-		t.Errorf("expected change to BlackBoxMonitor certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Certificates.EtcdClient, cs.Config.Certificates.EtcdClient) {
-		t.Errorf("expected change to EtcdClient certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Certificates.EtcdPeer, cs.Config.Certificates.EtcdPeer) {
-		t.Errorf("expected change to EtcdPeer certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Certificates.EtcdServer, cs.Config.Certificates.EtcdServer) {
-		t.Errorf("expected change to EtcdServer certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Certificates.MasterKubeletClient, cs.Config.Certificates.MasterKubeletClient) {
-		t.Errorf("expected change to MasterKubeletClient certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Certificates.MasterProxyClient, cs.Config.Certificates.MasterProxyClient) {
-		t.Errorf("expected change to MasterProxyClient certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Certificates.MasterServer, cs.Config.Certificates.MasterServer) {
-		t.Errorf("expected change to MasterProxyClient certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Certificates.NodeBootstrap, cs.Config.Certificates.NodeBootstrap) {
-		t.Errorf("expected change to NodeBootstrap certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Certificates.SDN, cs.Config.Certificates.SDN) {
-		t.Errorf("expected change to SDN certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Certificates.OpenShiftMaster, cs.Config.Certificates.OpenShiftMaster) {
-		t.Errorf("expected change to OpenShiftMaster certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Certificates.Registry, cs.Config.Certificates.Registry) {
-		t.Errorf("expected change to Registry certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Certificates.RegistryConsole, cs.Config.Certificates.RegistryConsole) {
-		t.Errorf("expected change to RegistryConsole certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Certificates.ServiceCatalogServer, cs.Config.Certificates.ServiceCatalogServer) {
-		t.Errorf("expected change to ServiceCatalogServer certificates after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.SSHKey, cs.Config.SSHKey) {
-		t.Errorf("expected change to SSHKey after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.RegistryHTTPSecret, cs.Config.RegistryHTTPSecret) {
-		t.Errorf("expected change to RegistryHTTPSecret after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.RegistryConsoleOAuthSecret, cs.Config.RegistryConsoleOAuthSecret) {
-		t.Errorf("expected change to RegistryConsoleOAuthSecret after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.ConsoleOAuthSecret, cs.Config.ConsoleOAuthSecret) {
-		t.Errorf("expected change to ConsoleOAuthSecret after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.AlertManagerProxySessionSecret, cs.Config.AlertManagerProxySessionSecret) {
-		t.Errorf("expected change to AlertManagerProxySessionSecret after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.AlertsProxySessionSecret, cs.Config.AlertsProxySessionSecret) {
-		t.Errorf("expected change to AlertsProxySessionSecret after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.PrometheusProxySessionSecret, cs.Config.PrometheusProxySessionSecret) {
-		t.Errorf("expected change to PrometheusProxySessionSecret after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.SessionSecretAuth, cs.Config.SessionSecretAuth) {
-		t.Errorf("expected change to SessionSecretAuth after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.SessionSecretEnc, cs.Config.SessionSecretEnc) {
-		t.Errorf("expected change to SessionSecretEnc after secret invalidation")
-	}
-	if reflect.DeepEqual(saved.Config.Images.GenevaImagePullSecret, cs.Config.Images.GenevaImagePullSecret) {
-		t.Errorf("expected change to GenevaImagePullSecret after secret invalidation")
-	}
-
-	// compare fields that are expected to be the same
-	if !reflect.DeepEqual(saved.Config.Certificates.GenevaMetrics, cs.Config.Certificates.GenevaMetrics) {
-		t.Errorf("unexpected change to GenevaMetrics certificates after secret invalidation")
-	}
-	if !reflect.DeepEqual(saved.Config.Certificates.GenevaLogging, cs.Config.Certificates.GenevaLogging) {
-		t.Errorf("unexpected change to GenevaLogging after secret invalidation")
-	}
+	assert(!reflect.DeepEqual(cs.Config.SSHKey, saved.Config.SSHKey), "sshKey")
+	assert(!reflect.DeepEqual(cs.Config.Certificates.GenevaLogging, saved.Config.Certificates.GenevaLogging), "certificates.genevaLogging")
+	assert(!reflect.DeepEqual(cs.Config.Certificates.GenevaMetrics, saved.Config.Certificates.GenevaMetrics), "certificates.genevaMetrics")
+	assert(!bytes.Equal(cs.Config.Images.GenevaImagePullSecret, saved.Config.Images.GenevaImagePullSecret), "images.genevaImagePullSecret")
+	assert(!bytes.Equal(cs.Config.Images.ImagePullSecret, saved.Config.Images.ImagePullSecret), "images.imagePullSecret")
+	assert(!bytes.Equal(cs.Config.SessionSecretAuth, saved.Config.SessionSecretAuth), "sessionSecretAuth")
+	assert(!bytes.Equal(cs.Config.SessionSecretEnc, saved.Config.SessionSecretEnc), "sessionSecreteEnc")
+	assert(!bytes.Equal(cs.Config.RegistryHTTPSecret, saved.Config.RegistryHTTPSecret), "registryHTTPSecret")
+	assert(!bytes.Equal(cs.Config.PrometheusProxySessionSecret, saved.Config.PrometheusProxySessionSecret), "prometheusProxySessionSecret")
+	assert(!bytes.Equal(cs.Config.AlertManagerProxySessionSecret, saved.Config.AlertManagerProxySessionSecret), "alertManagerProxySessionSecret")
+	assert(!bytes.Equal(cs.Config.AlertsProxySessionSecret, saved.Config.AlertsProxySessionSecret), "alertsProxySessionSecret")
+	assert(cs.Config.RegistryConsoleOAuthSecret != saved.Config.RegistryConsoleOAuthSecret, "registryConsoleOAuthSecret")
+	assert(cs.Config.ConsoleOAuthSecret != saved.Config.ConsoleOAuthSecret, "consoleOAuthSecret")
+	assert(cs.Config.RouterStatsPassword != saved.Config.RouterStatsPassword, "routerStatsPassword")
+	assert(cs.Config.EtcdMetricsPassword != saved.Config.EtcdMetricsPassword, "etcdMetricsPassword")
+	assert(cs.Config.EtcdMetricsUsername != saved.Config.EtcdMetricsUsername, "etcdMetricsUsername")
 
 	// assign saved values back to those changed in cs
-	cs.Config.Certificates.Admin = saved.Config.Certificates.Admin
-	cs.Config.Certificates.AggregatorFrontProxy = saved.Config.Certificates.AggregatorFrontProxy
-	cs.Config.Certificates.BlackBoxMonitor = saved.Config.Certificates.BlackBoxMonitor
-	cs.Config.Certificates.EtcdClient = saved.Config.Certificates.EtcdClient
-	cs.Config.Certificates.EtcdPeer = saved.Config.Certificates.EtcdPeer
-	cs.Config.Certificates.EtcdServer = saved.Config.Certificates.EtcdServer
-	cs.Config.Certificates.MasterKubeletClient = saved.Config.Certificates.MasterKubeletClient
-	cs.Config.Certificates.MasterProxyClient = saved.Config.Certificates.MasterProxyClient
-	cs.Config.Certificates.MasterServer = saved.Config.Certificates.MasterServer
-	cs.Config.Certificates.NodeBootstrap = saved.Config.Certificates.NodeBootstrap
-	cs.Config.Certificates.SDN = saved.Config.Certificates.SDN
-	cs.Config.Certificates.OpenShiftMaster = saved.Config.Certificates.OpenShiftMaster
-	cs.Config.Certificates.Registry = saved.Config.Certificates.Registry
-	cs.Config.Certificates.RegistryConsole = saved.Config.Certificates.RegistryConsole
-	cs.Config.Certificates.ServiceCatalogServer = saved.Config.Certificates.ServiceCatalogServer
+	cs.Config.SSHKey = saved.Config.SSHKey
 	cs.Config.Certificates.GenevaLogging = saved.Config.Certificates.GenevaLogging
 	cs.Config.Certificates.GenevaMetrics = saved.Config.Certificates.GenevaMetrics
+	cs.Config.Images.GenevaImagePullSecret = saved.Config.Images.GenevaImagePullSecret
+	cs.Config.Images.ImagePullSecret = saved.Config.Images.ImagePullSecret
+	cs.Config.SessionSecretAuth = saved.Config.SessionSecretAuth
+	cs.Config.SessionSecretEnc = saved.Config.SessionSecretEnc
+	cs.Config.RegistryHTTPSecret = saved.Config.RegistryHTTPSecret
+	cs.Config.PrometheusProxySessionSecret = saved.Config.PrometheusProxySessionSecret
+	cs.Config.AlertManagerProxySessionSecret = saved.Config.AlertManagerProxySessionSecret
+	cs.Config.AlertsProxySessionSecret = saved.Config.AlertsProxySessionSecret
+	cs.Config.RegistryConsoleOAuthSecret = saved.Config.RegistryConsoleOAuthSecret
+	cs.Config.ConsoleOAuthSecret = saved.Config.ConsoleOAuthSecret
+	cs.Config.RouterStatsPassword = saved.Config.RouterStatsPassword
+	cs.Config.EtcdMetricsPassword = saved.Config.EtcdMetricsPassword
+	cs.Config.EtcdMetricsUsername = saved.Config.EtcdMetricsUsername
 
 	// compare certs from saved and cs
-	if !reflect.DeepEqual(saved.Config.Certificates, cs.Config.Certificates) {
-		t.Errorf("expected saved and cs config blobs to be equal")
+	if !reflect.DeepEqual(cs, saved) {
+		t.Errorf("expected saved and cs config blobs to be equal: %s", deep.Equal(cs, saved))
 	}
 }

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -87,8 +87,10 @@ func (p *plugin) ValidatePluginTemplate(ctx context.Context) []error {
 }
 
 func (p *plugin) GenerateConfig(ctx context.Context, cs *api.OpenShiftManagedCluster, isUpdate bool) error {
+	var setVersionFields bool
 	if !isUpdate || cs.Config.PluginVersion == "latest" {
 		cs.Config.PluginVersion = p.pluginConfig.PluginVersion
+		setVersionFields = true
 	}
 
 	p.log.Info("generating configs")
@@ -97,7 +99,7 @@ func (p *plugin) GenerateConfig(ctx context.Context, cs *api.OpenShiftManagedClu
 		return &api.PluginError{Err: err, Step: api.PluginStepClientCreation}
 	}
 
-	err = configInterface.Generate(p.pluginConfig)
+	err = configInterface.Generate(p.pluginConfig, setVersionFields)
 	if err != nil {
 		return err
 	}

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -171,7 +171,7 @@ func TestRotateClusterSecrets(t *testing.T) {
 	clusterUpgrader := mock_cluster.NewMockUpgrader(gmc)
 
 	c := configInterface.EXPECT().InvalidateSecrets().Return(nil)
-	c = configInterface.EXPECT().Generate(gomock.Any()).Return(nil).After(c)
+	c = configInterface.EXPECT().Generate(gomock.Any(), false).Return(nil).After(c)
 	c = clusterUpgrader.EXPECT().CreateOrUpdateConfigStorageAccount(nil).Return(nil).After(c)
 	c = clusterUpgrader.EXPECT().GenerateARM(nil, "", true, gomock.Any()).Return(nil, nil).After(c)
 	c = clusterUpgrader.EXPECT().WriteStartupBlobs().Return(nil).After(c)

--- a/pkg/util/mocks/mock_config/config.go
+++ b/pkg/util/mocks/mock_config/config.go
@@ -36,17 +36,17 @@ func (m *MockInterface) EXPECT() *MockInterfaceMockRecorder {
 }
 
 // Generate mocks base method
-func (m *MockInterface) Generate(template *plugin.Config) error {
+func (m *MockInterface) Generate(template *plugin.Config, setVersionFields bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Generate", template)
+	ret := m.ctrl.Call(m, "Generate", template, setVersionFields)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Generate indicates an expected call of Generate
-func (mr *MockInterfaceMockRecorder) Generate(template interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) Generate(template, setVersionFields interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Generate", reflect.TypeOf((*MockInterface)(nil).Generate), template)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Generate", reflect.TypeOf((*MockInterface)(nil).Generate), template, setVersionFields)
 }
 
 // InvalidateSecrets mocks base method

--- a/test/e2e/specs/fakerp/keyrotation.go
+++ b/test/e2e/specs/fakerp/keyrotation.go
@@ -3,7 +3,6 @@ package fakerp
 import (
 	"context"
 	"os"
-	"reflect"
 
 	. "github.com/onsi/ginkgo"
 	. "github.com/onsi/gomega"
@@ -40,33 +39,11 @@ var _ = Describe("Key Rotation E2E tests [KeyRotation][Fake][LongRunning]", func
 		Expect(after).NotTo(BeNil())
 
 		By("Verifying that ca certificates have not been updated")
-		Expect(reflect.DeepEqual(before.Config.Certificates.ServiceSigningCa.Cert, after.Config.Certificates.ServiceSigningCa.Cert)).To(BeTrue())
-		Expect(reflect.DeepEqual(before.Config.Certificates.ServiceCatalogCa.Cert, after.Config.Certificates.ServiceCatalogCa.Cert)).To(BeTrue())
-		Expect(reflect.DeepEqual(before.Config.Certificates.FrontProxyCa.Cert, after.Config.Certificates.FrontProxyCa.Cert)).To(BeTrue())
-		Expect(reflect.DeepEqual(before.Config.Certificates.EtcdCa.Cert, after.Config.Certificates.EtcdCa.Cert)).To(BeTrue())
-		Expect(reflect.DeepEqual(before.Config.Certificates.Ca.Cert, after.Config.Certificates.Ca.Cert)).To(BeTrue())
-
-		By("Verifying that certain non-ca public certificates have been updated")
-		Expect(reflect.DeepEqual(before.Config.Certificates.Admin.Cert, after.Config.Certificates.Admin.Cert)).To(BeFalse())
-		Expect(reflect.DeepEqual(before.Config.Certificates.AggregatorFrontProxy.Cert, after.Config.Certificates.AggregatorFrontProxy.Cert)).To(BeFalse())
-		Expect(reflect.DeepEqual(before.Config.Certificates.BlackBoxMonitor.Cert, after.Config.Certificates.BlackBoxMonitor.Cert)).To(BeFalse())
-		Expect(reflect.DeepEqual(before.Config.Certificates.EtcdClient.Cert, after.Config.Certificates.EtcdClient.Cert)).To(BeFalse())
-		Expect(reflect.DeepEqual(before.Config.Certificates.EtcdPeer.Cert, after.Config.Certificates.EtcdPeer.Cert)).To(BeFalse())
-		Expect(reflect.DeepEqual(before.Config.Certificates.EtcdServer.Cert, after.Config.Certificates.EtcdServer.Cert)).To(BeFalse())
-		Expect(reflect.DeepEqual(before.Config.Certificates.MasterKubeletClient.Cert, after.Config.Certificates.MasterKubeletClient.Cert)).To(BeFalse())
-		Expect(reflect.DeepEqual(before.Config.Certificates.MasterProxyClient.Cert, after.Config.Certificates.MasterProxyClient.Cert)).To(BeFalse())
-		Expect(reflect.DeepEqual(before.Config.Certificates.MasterServer.Cert, after.Config.Certificates.MasterServer.Cert)).To(BeFalse())
-		Expect(reflect.DeepEqual(before.Config.Certificates.NodeBootstrap.Cert, after.Config.Certificates.NodeBootstrap.Cert)).To(BeFalse())
-		Expect(reflect.DeepEqual(before.Config.Certificates.SDN.Cert, after.Config.Certificates.SDN.Cert)).To(BeFalse())
-		Expect(reflect.DeepEqual(before.Config.Certificates.OpenShiftMaster.Cert, after.Config.Certificates.OpenShiftMaster.Cert)).To(BeFalse())
-		Expect(reflect.DeepEqual(before.Config.Certificates.Registry.Cert, after.Config.Certificates.Registry.Cert)).To(BeFalse())
-		Expect(reflect.DeepEqual(before.Config.Certificates.RegistryConsole.Cert, after.Config.Certificates.RegistryConsole.Cert)).To(BeFalse())
-		Expect(reflect.DeepEqual(before.Config.Certificates.ServiceCatalogServer.Cert, after.Config.Certificates.ServiceCatalogServer.Cert)).To(BeFalse())
-
-		// TODO: work towards moving the certs below to the updated section above
-		By("Verifying that certain non-ca public certificates have not been updated")
-		Expect(reflect.DeepEqual(before.Config.Certificates.GenevaLogging.Cert, after.Config.Certificates.GenevaLogging.Cert)).To(BeTrue())
-		Expect(reflect.DeepEqual(before.Config.Certificates.GenevaMetrics.Cert, after.Config.Certificates.GenevaMetrics.Cert)).To(BeTrue())
+		Expect(before.Config.Certificates.ServiceSigningCa.Cert).To(Equal(after.Config.Certificates.ServiceSigningCa.Cert))
+		Expect(before.Config.Certificates.ServiceCatalogCa.Cert).To(Equal(after.Config.Certificates.ServiceCatalogCa.Cert))
+		Expect(before.Config.Certificates.FrontProxyCa.Cert).To(Equal(after.Config.Certificates.FrontProxyCa.Cert))
+		Expect(before.Config.Certificates.EtcdCa.Cert).To(Equal(after.Config.Certificates.EtcdCa.Cert))
+		Expect(before.Config.Certificates.Ca.Cert).To(Equal(after.Config.Certificates.Ca.Cert))
 
 		By("Validating the cluster")
 		errs := sanity.Checker.ValidateCluster(context.Background())


### PR DESCRIPTION
```release-note
* latch all configurables that come from the plugin config, such that a plugin config change won't cause unexpected cluster rotations
* secret rotation geneva action stub re-reads geneva certs from plugin config, among resetting a few other secrets
```

