### PR TITLE
latch all configurables that come from the plugin config [v4]

### DIFF
--- a/pkg/api/plugin/convertertointernal_test.go
+++ b/pkg/api/plugin/convertertointernal_test.go
@@ -24,7 +24,7 @@ func internalPluginConfig() api.Config {
 	// this is the expected internal equivalent to
 	// internal API Config
 	return api.Config{
-		PluginVersion: "PluginVersion",
+		PluginVersion: "Versions.key",
 		ComponentLogLevel: api.ComponentLogLevel{
 			APIServer:         to.IntPtr(1),
 			ControllerManager: to.IntPtr(1),
@@ -104,7 +104,7 @@ func TestToInternal(t *testing.T) {
 	external.PluginVersion = "should not be copied"
 	// prepare internal type
 	internal := internalPluginConfig()
-	output, _ := ToInternal(&external, &internal, "Versions.key")
+	output, _ := ToInternal(&external, &api.Config{PluginVersion: "Versions.key"}, true)
 	if !reflect.DeepEqual(*output, internal) {
 		t.Errorf("unexpected diff %s", deep.Equal(*output, internal))
 	}

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -16,7 +16,7 @@ import (
 )
 
 type Interface interface {
-	Generate(template *pluginapi.Config) error
+	Generate(template *pluginapi.Config, setVersionFields bool) error
 	InvalidateSecrets() error
 }
 

--- a/pkg/config/v3/generate.go
+++ b/pkg/config/v3/generate.go
@@ -17,8 +17,8 @@ import (
 	"github.com/openshift/openshift-azure/pkg/util/tls"
 )
 
-func (g *simpleGenerator) Generate(template *pluginapi.Config) (err error) {
-	config, err := pluginapi.ToInternal(template, &g.cs.Config, g.cs.Config.PluginVersion)
+func (g *simpleGenerator) Generate(template *pluginapi.Config, setVersionFields bool) (err error) {
+	config, err := pluginapi.ToInternal(template, &g.cs.Config, setVersionFields)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/v3/generate_test.go
+++ b/pkg/config/v3/generate_test.go
@@ -29,7 +29,7 @@ func TestGenerate(t *testing.T) {
 	populate.Walk(&template, prepare)
 
 	cg := simpleGenerator{cs: cs, runningUnderTest: true}
-	err := cg.Generate(template)
+	err := cg.Generate(template, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -154,7 +154,7 @@ func TestInvalidateSecrets(t *testing.T) {
 	if err := g.InvalidateSecrets(); err != nil {
 		t.Errorf("configGenerator.InvalidateSecrets error = %v", err)
 	}
-	g.Generate(template)
+	g.Generate(template, true)
 
 	// compare fields that are expected to be different
 	if reflect.DeepEqual(saved.Config.Certificates.Admin, cs.Config.Certificates.Admin) {

--- a/pkg/config/v4/generate.go
+++ b/pkg/config/v4/generate.go
@@ -17,8 +17,8 @@ import (
 	"github.com/openshift/openshift-azure/pkg/util/tls"
 )
 
-func (g *simpleGenerator) Generate(template *pluginapi.Config) (err error) {
-	config, err := pluginapi.ToInternal(template, &g.cs.Config, g.cs.Config.PluginVersion)
+func (g *simpleGenerator) Generate(template *pluginapi.Config, setVersionFields bool) (err error) {
+	config, err := pluginapi.ToInternal(template, &g.cs.Config, setVersionFields)
 	if err != nil {
 		return err
 	}

--- a/pkg/config/v4/generate_test.go
+++ b/pkg/config/v4/generate_test.go
@@ -29,7 +29,7 @@ func TestGenerate(t *testing.T) {
 	populate.Walk(&template, prepare)
 
 	cg := simpleGenerator{cs: cs}
-	err := cg.Generate(template)
+	err := cg.Generate(template, true)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -153,7 +153,7 @@ func TestInvalidateSecrets(t *testing.T) {
 	if err := g.InvalidateSecrets(); err != nil {
 		t.Errorf("configGenerator.InvalidateSecrets error = %v", err)
 	}
-	g.Generate(template)
+	g.Generate(template, true)
 
 	// compare fields that are expected to be different
 	if reflect.DeepEqual(saved.Config.Certificates.Admin, cs.Config.Certificates.Admin) {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -87,8 +87,10 @@ func (p *plugin) ValidatePluginTemplate(ctx context.Context) []error {
 }
 
 func (p *plugin) GenerateConfig(ctx context.Context, cs *api.OpenShiftManagedCluster, isUpdate bool) error {
+	var setVersionFields bool
 	if !isUpdate || cs.Config.PluginVersion == "latest" {
 		cs.Config.PluginVersion = p.pluginConfig.PluginVersion
+		setVersionFields = true
 	}
 
 	p.log.Info("generating configs")
@@ -97,7 +99,7 @@ func (p *plugin) GenerateConfig(ctx context.Context, cs *api.OpenShiftManagedClu
 		return &api.PluginError{Err: err, Step: api.PluginStepClientCreation}
 	}
 
-	err = configInterface.Generate(p.pluginConfig)
+	err = configInterface.Generate(p.pluginConfig, setVersionFields)
 	if err != nil {
 		return err
 	}

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -171,7 +171,7 @@ func TestRotateClusterSecrets(t *testing.T) {
 	clusterUpgrader := mock_cluster.NewMockUpgrader(gmc)
 
 	c := configInterface.EXPECT().InvalidateSecrets().Return(nil)
-	c = configInterface.EXPECT().Generate(gomock.Any()).Return(nil).After(c)
+	c = configInterface.EXPECT().Generate(gomock.Any(), false).Return(nil).After(c)
 	c = clusterUpgrader.EXPECT().CreateOrUpdateConfigStorageAccount(nil).Return(nil).After(c)
 	c = clusterUpgrader.EXPECT().GenerateARM(nil, "", true, gomock.Any()).Return(nil, nil).After(c)
 	c = clusterUpgrader.EXPECT().WriteStartupBlobs().Return(nil).After(c)

--- a/pkg/util/mocks/mock_config/config.go
+++ b/pkg/util/mocks/mock_config/config.go
@@ -36,17 +36,17 @@ func (m *MockInterface) EXPECT() *MockInterfaceMockRecorder {
 }
 
 // Generate mocks base method
-func (m *MockInterface) Generate(template *plugin.Config) error {
+func (m *MockInterface) Generate(template *plugin.Config, setVersionFields bool) error {
 	m.ctrl.T.Helper()
-	ret := m.ctrl.Call(m, "Generate", template)
+	ret := m.ctrl.Call(m, "Generate", template, setVersionFields)
 	ret0, _ := ret[0].(error)
 	return ret0
 }
 
 // Generate indicates an expected call of Generate
-func (mr *MockInterfaceMockRecorder) Generate(template interface{}) *gomock.Call {
+func (mr *MockInterfaceMockRecorder) Generate(template, setVersionFields interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Generate", reflect.TypeOf((*MockInterface)(nil).Generate), template)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Generate", reflect.TypeOf((*MockInterface)(nil).Generate), template, setVersionFields)
 }
 
 // InvalidateSecrets mocks base method


### PR DESCRIPTION
```release-note
latch all configurables that come from the plugin config, such that a plugin config change won't cause unexpected cluster rotations
```

backport to release-v4 - original at #1407
