### PR TITLE
drop provisioning state when converting to internal model

### DIFF
--- a/cmd/createorupdate/createorupdate.go
+++ b/cmd/createorupdate/createorupdate.go
@@ -90,9 +90,6 @@ func createOrUpdatev20190430(ctx context.Context, log *logrus.Entry, rpc v201904
 
 func createOrUpdateAdmin(ctx context.Context, log *logrus.Entry, ac *adminclient.Client, rpc v20190430client.OpenShiftManagedClustersClient, resourceGroup string, oc *admin.OpenShiftManagedCluster, manifestFile string) (*v20190430.OpenShiftManagedCluster, error) {
 	log.Info("creating/updating cluster")
-	if oc.Properties != nil {
-		oc.Properties.ProvisioningState = nil // TODO: should not need to do this
-	}
 	resp, err := ac.CreateOrUpdate(ctx, resourceGroup, resourceGroup, oc)
 	if err != nil {
 		return nil, err

--- a/pkg/api/2018-09-30-preview/converterfrominternal_test.go
+++ b/pkg/api/2018-09-30-preview/converterfrominternal_test.go
@@ -15,7 +15,7 @@ func TestFromInternal(t *testing.T) {
 		oc *OpenShiftManagedCluster
 	}{
 		{
-			cs: api.GetInternalMockCluster(),
+			cs: api.GetInternalMockCluster(true),
 			oc: managedCluster(),
 		},
 	}

--- a/pkg/api/2018-09-30-preview/convertertointernal.go
+++ b/pkg/api/2018-09-30-preview/convertertointernal.go
@@ -71,9 +71,8 @@ func mergeProperties(oc *OpenShiftManagedCluster, cs *api.OpenShiftManagedCluste
 	if oc.Properties == nil {
 		return nil
 	}
-	if oc.Properties.ProvisioningState != nil {
-		cs.Properties.ProvisioningState = api.ProvisioningState(*oc.Properties.ProvisioningState)
-	}
+	// ProvisioningState field is dropped from customer API payloads
+	// oc.Properties.ProvisioningState
 	if oc.Properties.OpenShiftVersion != nil {
 		cs.Properties.OpenShiftVersion = *oc.Properties.OpenShiftVersion
 	}

--- a/pkg/api/2019-04-30/converterfrominternal_test.go
+++ b/pkg/api/2019-04-30/converterfrominternal_test.go
@@ -15,7 +15,7 @@ func TestFromInternal(t *testing.T) {
 		oc *OpenShiftManagedCluster
 	}{
 		{
-			cs: api.GetInternalMockCluster(),
+			cs: api.GetInternalMockCluster(true),
 			oc: managedCluster(),
 		},
 	}

--- a/pkg/api/2019-04-30/convertertointernal.go
+++ b/pkg/api/2019-04-30/convertertointernal.go
@@ -71,9 +71,8 @@ func mergeProperties(oc *OpenShiftManagedCluster, cs *api.OpenShiftManagedCluste
 	if oc.Properties == nil {
 		return nil
 	}
-	if oc.Properties.ProvisioningState != nil {
-		cs.Properties.ProvisioningState = api.ProvisioningState(*oc.Properties.ProvisioningState)
-	}
+	// ProvisioningState field is dropped from customer API payloads
+	// oc.Properties.ProvisioningState
 	if oc.Properties.OpenShiftVersion != nil {
 		cs.Properties.OpenShiftVersion = *oc.Properties.OpenShiftVersion
 	}

--- a/pkg/api/admin/convertertointernal.go
+++ b/pkg/api/admin/convertertointernal.go
@@ -74,9 +74,6 @@ func mergeFromResourcePurchasePlanAdmin(oc *OpenShiftManagedCluster, cs *api.Ope
 }
 
 func mergePropertiesAdmin(oc *OpenShiftManagedCluster, cs *api.OpenShiftManagedCluster) error {
-	if oc.Properties.ProvisioningState != nil {
-		cs.Properties.ProvisioningState = api.ProvisioningState(*oc.Properties.ProvisioningState)
-	}
 	if oc.Properties.OpenShiftVersion != nil {
 		cs.Properties.OpenShiftVersion = *oc.Properties.OpenShiftVersion
 	}

--- a/pkg/api/admin/convertertointernal_test.go
+++ b/pkg/api/admin/convertertointernal_test.go
@@ -33,7 +33,7 @@ func managedCluster() *OpenShiftManagedCluster {
 }
 
 func internalManagedCluster() *api.OpenShiftManagedCluster {
-	cs := api.GetInternalMockCluster()
+	cs := api.GetInternalMockCluster(false)
 
 	prepare := func(v reflect.Value) {
 		switch v.Interface().(type) {
@@ -309,6 +309,11 @@ func TestRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Error(err)
 	}
+
+	// dropped fields might be in the start,
+	// but they will be dropped in the final result
+	*start.Properties.ProvisioningState = ""
+
 	end := FromInternal(internal)
 	if !reflect.DeepEqual(start, end) {
 		t.Errorf("unexpected diff %s", deep.Equal(start, end))

--- a/pkg/api/mock.go
+++ b/pkg/api/mock.go
@@ -5,12 +5,12 @@ import (
 )
 
 // GetInternalMockCluster returns mock object of the
-// internal API model
-func GetInternalMockCluster() *OpenShiftManagedCluster {
+// internal API model. droppableFields defines if we want to return fields
+// which are dropped when converting from external to internal representation
+func GetInternalMockCluster(droppableFields bool) *OpenShiftManagedCluster {
 	// this is the expected internal equivalent to
 	// v20190430ManagedCluster()
-
-	return &OpenShiftManagedCluster{
+	oc := &OpenShiftManagedCluster{
 		ID:       "ID",
 		Location: "Location",
 		Name:     "Name",
@@ -25,10 +25,9 @@ func GetInternalMockCluster() *OpenShiftManagedCluster {
 		},
 		Type: "Type",
 		Properties: Properties{
-			ProvisioningState: "Properties.ProvisioningState",
-			OpenShiftVersion:  "Properties.OpenShiftVersion",
-			ClusterVersion:    "Properties.ClusterVersion",
-			PublicHostname:    "Properties.PublicHostname",
+			OpenShiftVersion: "Properties.OpenShiftVersion",
+			ClusterVersion:   "Properties.ClusterVersion",
+			PublicHostname:   "Properties.PublicHostname",
 			RouterProfiles: []RouterProfile{
 				{
 					Name:            "Properties.RouterProfiles[0].Name",
@@ -76,4 +75,10 @@ func GetInternalMockCluster() *OpenShiftManagedCluster {
 			},
 		},
 	}
+
+	if droppableFields {
+		oc.Properties.ProvisioningState = "Properties.ProvisioningState"
+	}
+
+	return oc
 }

--- a/pkg/fakerp/client/manifest.go
+++ b/pkg/fakerp/client/manifest.go
@@ -43,9 +43,6 @@ func GenerateManifest(manifestFile string) (*v20190430.OpenShiftManagedCluster, 
 		return nil, err
 	}
 
-	if oc.Properties != nil {
-		oc.Properties.ProvisioningState = nil // TODO: should not need to do this
-	}
 	return oc, nil
 }
 
@@ -71,8 +68,5 @@ func GenerateManifestAdmin(manifestFile string) (*admin.OpenShiftManagedCluster,
 		return nil, err
 	}
 
-	if oc.Properties != nil {
-		oc.Properties.ProvisioningState = nil // TODO: should not need to do this
-	}
 	return oc, nil
 }

--- a/test/e2e/specs/fakerp/admin.go
+++ b/test/e2e/specs/fakerp/admin.go
@@ -74,7 +74,6 @@ var _ = Describe("Openshift on Azure admin e2e tests [Fake]", func() {
 		external, err := azurecli.OpenShiftManagedClusters.Get(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(external).NotTo(BeNil())
-		external.Properties.ProvisioningState = nil // TODO: should not need to do this
 
 		updated, err := azurecli.OpenShiftManagedClusters.CreateOrUpdateAndWait(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"), external)
 		Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/specs/scaleupdown.go
+++ b/test/e2e/specs/scaleupdown.go
@@ -55,7 +55,7 @@ var _ = Describe("Scale Up/Down E2E tests [ScaleUpDown][Fake][LongRunning]", fun
 		By("Fetching the manifest")
 		external, err := azurecli.OpenShiftManagedClusters.Get(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
 		Expect(err).NotTo(HaveOccurred())
-		external.Properties.ProvisioningState = nil // TODO: should not need to do this
+
 		err = setCount(&external, count)
 		Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
```release-note
Drop ProvisioningState field from customer API in the converters. 
```
For discussion. 
currently, the provisioning state is overwritten from external API.

Example:
1. Customer checks his cluster state and time x. Gets result with provisioning state in.
2. We initiate cluster upgrade via api, so state now is `Upgrading`.
3. Cluster initiates any permitted api change (scale-up) using data payload he got from case 1. 
    If not handled this might cause state to be updated. 

This might not be a case as it depends a lot on how it is handled in RealRP. But at this point, I think it is safer to drop fields like this from externalAPI in the converters, when reading the payload.

This still missing tests to cover it. But wanted to put this as I might miss some context. 