### PR TITLE
Export 'Log' from the SanityChecker struct.

### DIFF
--- a/test/e2e/standard/sanitychecker.go
+++ b/test/e2e/standard/sanitychecker.go
@@ -33,7 +33,7 @@ type DeepTestInterface interface {
 }
 
 type SanityChecker struct {
-	log    *logrus.Entry
+	Log    *logrus.Entry
 	cs     *internalapi.OpenShiftManagedCluster
 	Client *openshift.ClientSet
 }
@@ -43,7 +43,7 @@ var _ DeepTestInterface = &SanityChecker{}
 // NewSanityChecker creates a new deep test sanity checker for OpenshiftManagedCluster resources.
 func NewSanityChecker(ctx context.Context, log *logrus.Entry, cs *internalapi.OpenShiftManagedCluster) (*SanityChecker, error) {
 	scc := &SanityChecker{
-		log: log,
+		Log: log,
 		cs:  cs,
 	}
 
@@ -67,17 +67,17 @@ func NewSanityChecker(ctx context.Context, log *logrus.Entry, cs *internalapi.Op
 
 func (sc *SanityChecker) CreateTestApp(ctx context.Context) (interface{}, []*TestError) {
 	var errs []*TestError
-	sc.log.Debugf("creating openshift project for test apps")
+	sc.Log.Debugf("creating openshift project for test apps")
 	namespace, err := sc.createProject(ctx)
 	if err != nil {
-		sc.log.Error(err)
+		sc.Log.Error(err)
 		errs = append(errs, &TestError{Err: err, Bucket: "createProject"})
 		return nil, errs
 	}
-	sc.log.Debugf("creating stateful test app in %s", namespace)
+	sc.Log.Debugf("creating stateful test app in %s", namespace)
 	err = sc.createStatefulApp(ctx, namespace)
 	if err != nil {
-		sc.log.Error(err)
+		sc.Log.Error(err)
 		errs = append(errs, &TestError{Err: err, Bucket: "createStatefulApp"})
 	}
 	return namespace, errs
@@ -85,68 +85,68 @@ func (sc *SanityChecker) CreateTestApp(ctx context.Context) (interface{}, []*Tes
 
 func (sc *SanityChecker) ValidateTestApp(ctx context.Context, cookie interface{}) (errs []*TestError) {
 	namespace := cookie.(string)
-	sc.log.Debugf("validating stateful test app in %s", namespace)
+	sc.Log.Debugf("validating stateful test app in %s", namespace)
 	err := sc.validateStatefulApp(ctx, namespace)
 	if err != nil {
-		sc.log.Error(err)
+		sc.Log.Error(err)
 		errs = append(errs, &TestError{Err: err, Bucket: "validateStatefulApp"})
 	}
 	return
 }
 
 func (sc *SanityChecker) ValidateCluster(ctx context.Context) (errs []*TestError) {
-	sc.log.Debugf("validating that nodes are labelled correctly")
+	sc.Log.Debugf("validating that nodes are labelled correctly")
 	err := sc.checkNodesLabelledCorrectly(ctx)
 	if err != nil {
-		sc.log.Error(err)
+		sc.Log.Error(err)
 		errs = append(errs, &TestError{Err: err, Bucket: "checkNodesLabelledCorrectly"})
 	}
-	sc.log.Debugf("validating that all monitoring components are healthy")
+	sc.Log.Debugf("validating that all monitoring components are healthy")
 	err = sc.checkMonitoringStackHealth(ctx)
 	if err != nil {
-		sc.log.Error(err)
+		sc.Log.Error(err)
 		errs = append(errs, &TestError{Err: err, Bucket: "checkMonitoringStackHealth"})
 	}
-	sc.log.Debugf("validating that pod disruption budgets are immutable")
+	sc.Log.Debugf("validating that pod disruption budgets are immutable")
 	err = sc.checkDisallowsPdbMutations(ctx)
 	if err != nil {
-		sc.log.Error(err)
+		sc.Log.Error(err)
 		errs = append(errs, &TestError{Err: err, Bucket: "checkDisallowsPdbMutations"})
 	}
-	sc.log.Debugf("validating that an end user cannot access infrastructure components")
+	sc.Log.Debugf("validating that an end user cannot access infrastructure components")
 	err = sc.checkCannotAccessInfraResources(ctx)
 	if err != nil {
-		sc.log.Error(err)
+		sc.Log.Error(err)
 		errs = append(errs, &TestError{Err: err, Bucket: "checkCannotAccessInfraResources"})
 	}
-	sc.log.Debugf("validating that the cluster can pull redhat.io images")
+	sc.Log.Debugf("validating that the cluster can pull redhat.io images")
 	err = sc.checkCanDeployRedhatIoImages(ctx)
 	if err != nil {
-		sc.log.Error(err)
+		sc.Log.Error(err)
 		errs = append(errs, &TestError{Err: err, Bucket: "checkCanDeployRedhatIoImages"})
 	}
-	sc.log.Debugf("validating that the cluster can create ELB and ILB")
+	sc.Log.Debugf("validating that the cluster can create ELB and ILB")
 	err = sc.checkCanCreateLB(ctx)
 	if err != nil {
-		sc.log.Error(err)
+		sc.Log.Error(err)
 		errs = append(errs, &TestError{Err: err, Bucket: "checkCanCreateLB"})
 	}
-	sc.log.Debugf("validating that cluster services are available")
+	sc.Log.Debugf("validating that cluster services are available")
 	err = sc.checkCanAccessServices(ctx)
 	if err != nil {
-		sc.log.Error(err)
+		sc.Log.Error(err)
 		errs = append(errs, &TestError{Err: err, Bucket: "checkCanAccessServices"})
 	}
-	sc.log.Debugf("validating that the cluster can use azure-file storage")
+	sc.Log.Debugf("validating that the cluster can use azure-file storage")
 	err = sc.checkCanUseAzureFileStorage(ctx)
 	if err != nil {
-		sc.log.Error(err)
+		sc.Log.Error(err)
 		errs = append(errs, &TestError{Err: err, Bucket: "checkCanUseAzureFile"})
 	}
-	sc.log.Debugf("validating that Docker builds are not permitted")
+	sc.Log.Debugf("validating that Docker builds are not permitted")
 	err = sc.checkCantDoDockerBuild(ctx)
 	if err != nil {
-		sc.log.Error(err)
+		sc.Log.Error(err)
 		errs = append(errs, &TestError{Err: err, Bucket: "checkCantDoDockerBuild"})
 	}
 	return
@@ -154,10 +154,10 @@ func (sc *SanityChecker) ValidateCluster(ctx context.Context) (errs []*TestError
 
 func (sc *SanityChecker) DeleteTestApp(ctx context.Context, cookie interface{}) []*TestError {
 	var errs []*TestError
-	sc.log.Debugf("deleting openshift project for test apps")
+	sc.Log.Debugf("deleting openshift project for test apps")
 	err := sc.deleteProject(ctx, cookie.(string))
 	if err != nil {
-		sc.log.Error(err)
+		sc.Log.Error(err)
 		errs = append(errs, &TestError{Err: err, Bucket: "deleteProject"})
 	}
 	return errs

--- a/test/e2e/standard/testapps.go
+++ b/test/e2e/standard/testapps.go
@@ -22,7 +22,7 @@ const (
 )
 
 func (sc *SanityChecker) createStatefulApp(ctx context.Context, namespace string) error {
-	sc.log.Debugf("instantiating %s template", statefulApp)
+	sc.Log.Debugf("instantiating %s template", statefulApp)
 	err := sc.Client.EndUser.InstantiateTemplate(statefulApp, namespace)
 	if err != nil {
 		return err
@@ -31,7 +31,7 @@ func (sc *SanityChecker) createStatefulApp(ctx context.Context, namespace string
 }
 
 func (sc *SanityChecker) createStatelessApp(ctx context.Context, namespace string) error {
-	sc.log.Debugf("instantiating %s template", statelessApp)
+	sc.Log.Debugf("instantiating %s template", statelessApp)
 	err := sc.Client.EndUser.InstantiateTemplate(statelessApp, namespace)
 	if err != nil {
 		return err
@@ -46,7 +46,7 @@ func (sc *SanityChecker) validateStatefulApp(ctx context.Context, namespace stri
 		defer cancel()
 
 		for i := 0; i < times; i++ {
-			resp, err := waitutil.ForHTTPStatusOk(timeout, sc.log, nil, url)
+			resp, err := waitutil.ForHTTPStatusOk(timeout, sc.Log, nil, url)
 			if err != nil {
 				return err
 			}
@@ -86,7 +86,7 @@ func (sc *SanityChecker) validateStatefulApp(ctx context.Context, namespace stri
 	host := route.Status.Ingress[0].Host
 	url := fmt.Sprintf("http://%s", host)
 	regex := regexp.MustCompile(`Page views:\s*(\d+)`)
-	sc.log.Debugf("hitting the route 3 times, expecting counter to increment")
+	sc.Log.Debugf("hitting the route 3 times, expecting counter to increment")
 	err = loopHTTPGet(url, regex, 3)
 	if err != nil {
 		return err
@@ -95,31 +95,31 @@ func (sc *SanityChecker) validateStatefulApp(ctx context.Context, namespace stri
 	// Find the database deploymentconfig and scale down to 0, then back up to 1
 	dcName := "postgresql"
 	for _, i := range []int32{0, 1} {
-		sc.log.Debugf("searching for the database deploymentconfig")
+		sc.Log.Debugf("searching for the database deploymentconfig")
 		dc, err := sc.Client.EndUser.OAppsV1.DeploymentConfigs(namespace).Get(dcName, metav1.GetOptions{})
 		if err != nil {
 			return err
 		}
-		sc.log.Debugf("scaling the database deploymentconfig to %d", i)
+		sc.Log.Debugf("scaling the database deploymentconfig to %d", i)
 		dc.Spec.Replicas = int32(i)
 		_, err = sc.Client.EndUser.OAppsV1.DeploymentConfigs(namespace).Update(dc)
 		if err != nil {
 			return err
 		}
-		sc.log.Debugf("waiting for database deploymentconfig to reflect %d replicas", i)
+		sc.Log.Debugf("waiting for database deploymentconfig to reflect %d replicas", i)
 		waitErr := wait.PollImmediate(2*time.Second, 10*time.Minute, ready.CheckDeploymentConfigIsReady(sc.Client.EndUser.OAppsV1.DeploymentConfigs(namespace), dcName))
 		if waitErr != nil {
 			return waitErr
 		}
 	}
-	sc.log.Debug("waiting for app to recover from database outage") // it might be crash looping
+	sc.Log.Debug("waiting for app to recover from database outage") // it might be crash looping
 	waitErr := wait.PollImmediate(2*time.Second, 10*time.Minute, ready.CheckDeploymentConfigIsReady(sc.Client.EndUser.OAppsV1.DeploymentConfigs(namespace), "django-psql-persistent"))
 	if waitErr != nil {
 		return waitErr
 	}
 
 	// hit it again, will hit 3 times as specified initially
-	sc.log.Debugf("hitting the route again, expecting counter to increment from last")
+	sc.Log.Debugf("hitting the route again, expecting counter to increment from last")
 	err = loopHTTPGet(url, regex, 3)
 	if err != nil {
 		return err
@@ -141,10 +141,10 @@ func (sc *SanityChecker) validateStatelessApp(ctx context.Context, namespace str
 	url := fmt.Sprintf("http://%s", host)
 
 	// Curl the endpoint and search for a string
-	sc.log.Debugf("hitting the route %s and verifying the response", url)
+	sc.Log.Debugf("hitting the route %s and verifying the response", url)
 	timeout, cancel := context.WithTimeout(ctx, 30*time.Second)
 	defer cancel()
-	resp, err := waitutil.ForHTTPStatusOk(timeout, sc.log, nil, url)
+	resp, err := waitutil.ForHTTPStatusOk(timeout, sc.Log, nil, url)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR exposes the logger so that the SanityChecker (that initialize various structs and the openshift client for testing) can be reused in isolated test.


```release-note
- E2E: standard exports the Log field from the SanityChecker for better reusability 
```
