### PR TITLE
New fake azure client

### DIFF
--- a/pkg/cluster/kubeclient/roundtrip.go
+++ b/pkg/cluster/kubeclient/roundtrip.go
@@ -7,8 +7,10 @@ import (
 	"time"
 
 	security "github.com/openshift/client-go/security/clientset/versioned"
+	fakesec "github.com/openshift/client-go/security/clientset/versioned/fake"
 	"github.com/sirupsen/logrus"
 	"k8s.io/client-go/kubernetes"
+	"k8s.io/client-go/kubernetes/fake"
 	v1 "k8s.io/client-go/tools/clientcmd/api/v1"
 
 	"github.com/openshift/openshift-azure/pkg/util/managedcluster"
@@ -167,5 +169,12 @@ func NewKubeclient(log *logrus.Entry, config *v1.Config, disableKeepAlives bool)
 		client: cli,
 		seccli: seccli,
 	}, nil
+}
 
+func NewFakeKubeclient(log *logrus.Entry, cli *fake.Clientset, seccli *fakesec.Clientset) Kubeclient {
+	return &kubeclient{
+		log:    log,
+		client: cli,
+		seccli: seccli,
+	}
 }

--- a/pkg/plugin/integration_test.go
+++ b/pkg/plugin/integration_test.go
@@ -1,0 +1,318 @@
+package plugin
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"io/ioutil"
+	"os"
+	"reflect"
+	"testing"
+	"time"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/keyvault/2016-10-01/keyvault"
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
+	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2018-02-01/storage"
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/davecgh/go-spew/spew"
+	"github.com/ghodss/yaml"
+	securityapi "github.com/openshift/api/security/v1"
+	fakesec "github.com/openshift/client-go/security/clientset/versioned/fake"
+	uuid "github.com/satori/go.uuid"
+	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/client-go/kubernetes/fake"
+	restclient "k8s.io/client-go/rest"
+	k8stesting "k8s.io/client-go/testing"
+
+	"github.com/openshift/openshift-azure/pkg/api"
+	pluginapi "github.com/openshift/openshift-azure/pkg/api/plugin"
+	"github.com/openshift/openshift-azure/pkg/cluster"
+	"github.com/openshift/openshift-azure/pkg/cluster/kubeclient"
+	"github.com/openshift/openshift-azure/pkg/cluster/updateblob"
+	"github.com/openshift/openshift-azure/pkg/config"
+	fakecloud "github.com/openshift/openshift-azure/pkg/util/azureclient/fake"
+	"github.com/openshift/openshift-azure/pkg/util/random"
+	"github.com/openshift/openshift-azure/pkg/util/resourceid"
+	"github.com/openshift/openshift-azure/pkg/util/tls"
+	testtls "github.com/openshift/openshift-azure/test/util/tls"
+)
+
+const (
+	vaultKeyNamePublicHostname = "PublicHostname"
+	vaultKeyNameRouter         = "Router"
+)
+
+func getFakeDeployer(log *logrus.Entry, cs *api.OpenShiftManagedCluster, az *fakecloud.AzureCloud) api.DeployFn {
+	return func(ctx context.Context, azuretemplate map[string]interface{}) error {
+		log.Info("applying arm template deployment")
+
+		future, err := az.DeploymentsClient.CreateOrUpdate(ctx, cs.Properties.AzProfile.ResourceGroup, "azuredeploy", resources.Deployment{
+			Properties: &resources.DeploymentProperties{
+				Template: azuretemplate,
+				Mode:     resources.Incremental,
+			},
+		})
+		if err != nil {
+			return err
+		}
+
+		cli := az.DeploymentsClient.Client()
+
+		log.Info("waiting for arm template deployment to complete")
+		err = future.WaitForCompletionRef(ctx, cli)
+		if err != nil {
+			log.Warnf("deployment failed: %#v", err)
+			return err
+		}
+
+		return nil
+	}
+}
+
+func enrich(cs *api.OpenShiftManagedCluster) error {
+	tenantID := uuid.NewV4().String()
+	clientID := uuid.NewV4().String()
+	secret := "suspicious"
+	cs.Properties.AzProfile = api.AzProfile{
+		TenantID:       tenantID,
+		SubscriptionID: uuid.NewV4().String(),
+		ResourceGroup:  "testRG",
+	}
+	cs.Properties.AuthProfile.IdentityProviders = make([]api.IdentityProvider, 1)
+	cs.Properties.AuthProfile.IdentityProviders[0].Provider = &api.AADIdentityProvider{
+		Kind:     "AADIdentityProvider",
+		ClientID: clientID,
+		Secret:   secret,
+		TenantID: tenantID,
+	}
+
+	cs.Properties.MasterServicePrincipalProfile = api.ServicePrincipalProfile{
+		ClientID: uuid.NewV4().String(),
+		Secret:   uuid.NewV4().String(),
+	}
+	cs.Properties.WorkerServicePrincipalProfile = api.ServicePrincipalProfile{
+		ClientID: uuid.NewV4().String(),
+		Secret:   uuid.NewV4().String(),
+	}
+
+	// /subscriptions/{subscription}/resourcegroups/{resource_group}/providers/Microsoft.ContainerService/openshiftmanagedClusters/{cluster_name}
+	cs.ID = resourceid.ResourceID(cs.Properties.AzProfile.SubscriptionID, cs.Properties.AzProfile.ResourceGroup, "Microsoft.ContainerService/openshiftmanagedClusters", cs.Name)
+
+	if len(cs.Properties.RouterProfiles) == 0 {
+		cs.Properties.RouterProfiles = []api.RouterProfile{
+			{
+				Name: "default",
+			},
+		}
+	}
+
+	var vaultURL string
+	var err error
+	vaultURL, err = random.VaultURL("kv-")
+	if err != nil {
+		return err
+	}
+
+	cs.Properties.APICertProfile.KeyVaultSecretURL = vaultURL + "/secrets/" + vaultKeyNamePublicHostname
+	cs.Properties.RouterProfiles[0].RouterCertProfile.KeyVaultSecretURL = vaultURL + "/secrets/" + vaultKeyNameRouter
+
+	cs.Properties.PublicHostname = "openshift." + os.Getenv("RESOURCEGROUP") + "." + os.Getenv("DNS_DOMAIN")
+	cs.Properties.RouterProfiles[0].PublicSubdomain = "apps." + os.Getenv("RESOURCEGROUP") + "." + os.Getenv("DNS_DOMAIN")
+
+	if cs.Properties.FQDN == "" {
+		cs.Properties.FQDN, err = random.FQDN(cs.Location+".cloudapp.azure.com", 20)
+		if err != nil {
+			return err
+		}
+	}
+
+	if cs.Properties.RouterProfiles[0].FQDN == "" {
+		cs.Properties.RouterProfiles[0].FQDN, err = random.FQDN(cs.Location+".cloudapp.azure.com", 20)
+		if err != nil {
+			return err
+		}
+	}
+
+	return nil
+}
+
+func (w fakeResponseWrapper) DoRaw() ([]byte, error) {
+	return w.raw, nil
+}
+
+func (w fakeResponseWrapper) Stream() (io.ReadCloser, error) {
+	return nil, nil
+}
+
+func newFakeResponseWrapper(raw []byte) fakeResponseWrapper {
+	return fakeResponseWrapper{raw: raw}
+}
+
+type fakeResponseWrapper struct {
+	raw []byte
+}
+
+func TestCreateThenUpdateCausesNoRotations(t *testing.T) {
+	cs := &api.OpenShiftManagedCluster{
+		Config: api.Config{
+			ConfigStorageAccount:      "config",
+			RegistryStorageAccount:    "registry",
+			RegistryStorageAccountKey: "foo",
+
+			SSHKey: testtls.DummyPrivateKey,
+			Certificates: api.CertificateConfig{
+				Ca:            api.CertKeyPair{Cert: testtls.DummyCertificate, Key: testtls.DummyPrivateKey},
+				NodeBootstrap: api.CertKeyPair{Cert: testtls.DummyCertificate, Key: testtls.DummyPrivateKey},
+			},
+		},
+		Properties: api.Properties{
+			AgentPoolProfiles: []api.AgentPoolProfile{
+				{Role: api.AgentPoolProfileRoleMaster, Count: 3, Name: "master", VMSize: "Standard_D2s_v3"},
+				{Role: api.AgentPoolProfileRoleCompute, Count: 1, Name: "compute", VMSize: "Standard_D2s_v3"},
+				{Role: api.AgentPoolProfileRoleInfra, Count: 2, Name: "infra", VMSize: "Standard_D2s_v3"},
+			},
+		},
+	}
+	log := logrus.NewEntry(logrus.StandardLogger())
+	ctx := context.Background()
+
+	bKey, _ := tls.PrivateKeyAsBytes(testtls.DummyPrivateKey)
+	bCert, _ := tls.CertAsBytes(testtls.DummyCertificate)
+
+	secret := "PRIVATE KEY\n" + string(bKey) + "CERTIFICATE\n" + string(bCert)
+	secrets := []keyvault.SecretBundle{
+		{
+			ID:    to.StringPtr("PublicHostname"),
+			Value: to.StringPtr(secret),
+		},
+		{
+			ID:    to.StringPtr("Router"),
+			Value: to.StringPtr(secret),
+		},
+	}
+
+	data, err := ioutil.ReadFile("../../pluginconfig/pluginconfig-311.yaml")
+	if err != nil {
+		t.Fatal(err)
+	}
+	var template *pluginapi.Config
+	if err := yaml.Unmarshal(data, &template); err != nil {
+		t.Fatal(err)
+	}
+
+	template.Certificates.GenevaLogging.Cert = testtls.DummyCertificate
+	template.Certificates.GenevaLogging.Key = testtls.DummyPrivateKey
+	template.Certificates.GenevaMetrics.Cert = testtls.DummyCertificate
+	template.Certificates.GenevaMetrics.Key = testtls.DummyPrivateKey
+	template.GenevaImagePullSecret = []byte("pullSecret")
+	template.ImagePullSecret = []byte("imagePullSecret")
+
+	az := fakecloud.NewFakeAzureCloud(log, []compute.VirtualMachineScaleSetVM{}, []compute.VirtualMachineScaleSet{}, secrets, []storage.Account{}, map[string]map[string][]byte{})
+	cli := fake.NewSimpleClientset()
+	cli.PrependReactor("get", "pods", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		get := action.(k8stesting.GetAction)
+		pod := &corev1.Pod{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      get.GetName(),
+				Namespace: get.GetNamespace(),
+			},
+			Status: corev1.PodStatus{
+				Conditions: []corev1.PodCondition{
+					{
+						Type:   corev1.PodReady,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
+		}
+		return true, pod, nil
+	})
+	cli.PrependReactor("get", "nodes", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		get := action.(k8stesting.GetAction)
+		node := &corev1.Node{
+			ObjectMeta: metav1.ObjectMeta{
+				Name:      get.GetName(),
+				Namespace: get.GetNamespace(),
+			},
+			Status: corev1.NodeStatus{
+				Conditions: []corev1.NodeCondition{
+					{
+						Type:   corev1.NodeReady,
+						Status: corev1.ConditionTrue,
+					},
+				},
+			},
+		}
+		return true, node, nil
+	})
+
+	cli.AddProxyReactor("services", func(action k8stesting.Action) (handled bool, ret restclient.ResponseWrapper, err error) {
+		return true, newFakeResponseWrapper(nil), nil
+	})
+
+	priv := securityapi.SecurityContextConstraints{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "securitycontextconstraints",
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name: "privileged",
+		},
+		AllowPrivilegedContainer: true,
+		Users:                    []string{"system:admin"},
+	}
+	seccli := fakesec.NewSimpleClientset()
+	seccli.PrependReactor("get", "*", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		get := action.(k8stesting.GetAction)
+		if get.GetResource().Resource == "securitycontextconstraints" {
+			return true, &priv, nil
+		}
+		return false, nil, fmt.Errorf("does not exist")
+	})
+	seccli.PrependReactor("update", "*", func(action k8stesting.Action) (bool, runtime.Object, error) {
+		get := action.(k8stesting.UpdateAction)
+		if get.GetResource().Resource == "securitycontextconstraints" {
+			return true, &priv, nil
+		}
+		return false, nil, fmt.Errorf("does not exist")
+	})
+	kc := kubeclient.NewFakeKubeclient(log, cli, seccli)
+	p := &plugin{
+		pluginConfig: template,
+		testConfig:   api.TestConfig{RunningUnderTest: true},
+		upgraderFactory: func(ctx context.Context, log *logrus.Entry, cs *api.OpenShiftManagedCluster, initializeStorageClients, disableKeepAlives bool, testConfig api.TestConfig) (cluster.Upgrader, error) {
+			return cluster.NewFakeUpgrader(ctx, log, cs, testConfig, kc, az)
+		},
+		configInterfaceFactory: config.New,
+		log:                    log,
+		now:                    time.Now,
+	}
+	err = enrich(cs)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	err = p.GenerateConfig(ctx, cs, false)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if err := p.CreateOrUpdate(ctx, cs, false, getFakeDeployer(log, cs, az)); err != nil {
+		t.Errorf("plugin.CreateOrUpdate [create] error = %v", err)
+	}
+	bsc := az.StorageClient.GetBlobService()
+	updateBlobService := updateblob.NewBlobService(bsc)
+	beforeBlob, err := updateBlobService.Read()
+	// - update
+	if err := p.CreateOrUpdate(ctx, cs, true, getFakeDeployer(log, cs, az)); err != nil {
+		t.Errorf("plugin.CreateOrUpdate [update] error = %v", err)
+	}
+	// - assert that the hashes are the same
+	afterBlob, err := updateBlobService.Read()
+	if !reflect.DeepEqual(beforeBlob, afterBlob) {
+		t.Errorf("unexpected result:\n%#v\nexpected:\n%#v", spew.Sprint(beforeBlob), spew.Sprint(afterBlob))
+	}
+}

--- a/pkg/util/azureclient/fake/accounts.go
+++ b/pkg/util/azureclient/fake/accounts.go
@@ -1,0 +1,48 @@
+package fake
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2018-02-01/storage"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/to"
+)
+
+// FakeAccountsClient is a mock of AccountsClient interface
+type FakeAccountsClient struct {
+	az *AzureCloud
+}
+
+// NewFakeAccountsClient creates a new mock instance
+func NewFakeAccountsClient(az *AzureCloud) *FakeAccountsClient {
+	return &FakeAccountsClient{az: az}
+}
+
+// Client mocks base method
+func (a *FakeAccountsClient) Client() autorest.Client {
+	return allwaysDoneClient()
+}
+
+// Create mocks base method
+func (a *FakeAccountsClient) Create(ctx context.Context, resourceGroupName string, accountName string, parameters storage.AccountCreateParameters) error {
+	acct := storage.Account{
+		Name: &accountName,
+		Sku:  parameters.Sku,
+		Kind: parameters.Kind,
+		Tags: parameters.Tags,
+		Type: to.StringPtr("Microsoft.Storage/storageAccounts"),
+	}
+	a.az.Accts = append(a.az.Accts, acct)
+	return nil
+}
+
+// ListByResourceGroup mocks base method
+func (a *FakeAccountsClient) ListByResourceGroup(context context.Context, resourceGroup string) (storage.AccountListResult, error) {
+	return storage.AccountListResult{Value: &a.az.Accts}, nil
+}
+
+// ListKeys mocks base method
+func (a *FakeAccountsClient) ListKeys(context context.Context, resourceGroup, accountName string) (storage.AccountListKeysResult, error) {
+	return storage.AccountListKeysResult{}, fmt.Errorf("FakeAccountsClient.ListKeys() not implemented")
+}

--- a/pkg/util/azureclient/fake/cloud.go
+++ b/pkg/util/azureclient/fake/cloud.go
@@ -1,0 +1,59 @@
+package fake
+
+import (
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/keyvault/2016-10-01/keyvault"
+	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2018-02-01/storage"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/sirupsen/logrus"
+
+	"github.com/openshift/openshift-azure/pkg/util/azureclient"
+	azurestorage "github.com/openshift/openshift-azure/pkg/util/azureclient/storage"
+)
+
+type AzureCloud struct {
+	log     *logrus.Entry
+	Vms     []compute.VirtualMachineScaleSetVM
+	Ssc     []compute.VirtualMachineScaleSet
+	Secrets []keyvault.SecretBundle
+	Accts   []storage.Account
+	Blobs   map[string]map[string][]byte
+
+	AccountsClient                  azureclient.AccountsClient
+	StorageClient                   azurestorage.Client
+	DeploymentsClient               azureclient.DeploymentsClient
+	KeyVaultClient                  azureclient.KeyVaultClient
+	VirtualMachineScaleSetVMsClient azureclient.VirtualMachineScaleSetVMsClient
+	VirtualMachineScaleSetsClient   azureclient.VirtualMachineScaleSetsClient
+}
+
+func NewFakeAzureCloud(log *logrus.Entry, vms []compute.VirtualMachineScaleSetVM, ssc []compute.VirtualMachineScaleSet, secrets []keyvault.SecretBundle, accts []storage.Account, blobs map[string]map[string][]byte) *AzureCloud {
+	az := &AzureCloud{
+		log:     log,
+		Vms:     vms,
+		Ssc:     ssc,
+		Secrets: secrets,
+		Accts:   accts,
+		Blobs:   blobs,
+	}
+	az.AccountsClient = NewFakeAccountsClient(az)
+	az.StorageClient = NewFakeStorageClient(az)
+	az.KeyVaultClient = NewFakeKeyVaultClient(az)
+	az.DeploymentsClient = NewFakeDeploymentsClient(az)
+	az.VirtualMachineScaleSetVMsClient = NewFakeVirtualMachineScaleSetVMsClient(az)
+	az.VirtualMachineScaleSetsClient = NewFakeVirtualMachineScaleSetsClient(az)
+	return az
+}
+
+type fakeClient struct {
+}
+
+func (f *fakeClient) Do(req *http.Request) (*http.Response, error) {
+	return &http.Response{StatusCode: 200}, nil
+}
+
+func allwaysDoneClient() autorest.Client {
+	return autorest.Client{Sender: &fakeClient{}}
+}

--- a/pkg/util/azureclient/fake/codecov_dummy_test.go
+++ b/pkg/util/azureclient/fake/codecov_dummy_test.go
@@ -1,0 +1,12 @@
+package fake
+
+import (
+	"testing"
+)
+
+// This file exists because this package has no unit tests.  Codecov does not
+// report packages with no unit tests as 0% coverage, incorrectly inflating our
+// coverage statistics.  When unit tests are added to this package, this file
+// can be removed.
+
+func TestDummyCodeCov(t *testing.T) {}

--- a/pkg/util/azureclient/fake/compute.go
+++ b/pkg/util/azureclient/fake/compute.go
@@ -1,0 +1,206 @@
+package fake
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/to"
+	uuid "github.com/satori/go.uuid"
+)
+
+type FakeVirtualMachineScaleSetVMsClient struct {
+	az *AzureCloud
+}
+
+// NewFakeVirtualMachineScaleSetVMsClient creates a new Fake instance
+func NewFakeVirtualMachineScaleSetVMsClient(az *AzureCloud) *FakeVirtualMachineScaleSetVMsClient {
+	return &FakeVirtualMachineScaleSetVMsClient{az: az}
+}
+
+// Client Fakes base method
+func (v *FakeVirtualMachineScaleSetVMsClient) Client() autorest.Client {
+	return allwaysDoneClient()
+}
+
+// Deallocate Fakes base method
+func (v *FakeVirtualMachineScaleSetVMsClient) Deallocate(ctx context.Context, resourceGroupName string, VMScaleSetName string, instanceID string) error {
+	for _, vm := range v.az.Vms {
+		if *vm.InstanceID == instanceID {
+			vm.VirtualMachineScaleSetVMProperties.ProvisioningState = to.StringPtr("Stopped")
+			return nil
+		}
+	}
+	return fmt.Errorf("VM %s/%s not found", VMScaleSetName, instanceID)
+}
+
+// Delete Fakes base method
+func (v *FakeVirtualMachineScaleSetVMsClient) Delete(ctx context.Context, resourceGroupName string, VMScaleSetName string, instanceID string) error {
+	for s, vm := range v.az.Vms {
+		if *vm.InstanceID == instanceID {
+			v.az.Vms = append(v.az.Vms[:s], v.az.Vms[s+1:]...)
+			return nil
+		}
+	}
+	return nil
+}
+
+// List Fakes base method
+func (v *FakeVirtualMachineScaleSetVMsClient) List(ctx context.Context, resourceGroupName, virtualMachineScaleSetName, filter, selectParameter, expand string) ([]compute.VirtualMachineScaleSetVM, error) {
+	prefix := virtualMachineScaleSetName[3:]
+	result := []compute.VirtualMachineScaleSetVM{}
+	for _, vm := range v.az.Vms {
+		if strings.HasPrefix(*vm.Name, prefix) {
+			result = append(result, vm)
+		}
+	}
+
+	return result, nil
+}
+
+// Reimage Fakes base method
+func (v *FakeVirtualMachineScaleSetVMsClient) Reimage(ctx context.Context, resourceGroupName, VMScaleSetName, instanceID string, VMScaleSetVMReimageInput *compute.VirtualMachineScaleSetVMReimageParameters) error {
+	for _, vm := range v.az.Vms {
+		if *vm.InstanceID == instanceID {
+			vm.VirtualMachineScaleSetVMProperties.ProvisioningState = to.StringPtr("Reimaged")
+			return nil
+		}
+	}
+	return fmt.Errorf("VM %s/%s not found", VMScaleSetName, instanceID)
+}
+
+// Restart Fakes base method
+func (v *FakeVirtualMachineScaleSetVMsClient) Restart(ctx context.Context, resourceGroupName, VMScaleSetName, instanceID string) error {
+	err := v.Deallocate(ctx, resourceGroupName, VMScaleSetName, instanceID)
+	if err != nil {
+		return err
+	}
+	return v.Start(ctx, resourceGroupName, VMScaleSetName, instanceID)
+}
+
+// RunCommand Fakes base method
+func (v *FakeVirtualMachineScaleSetVMsClient) RunCommand(ctx context.Context, resourceGroupName string, VMScaleSetName string, instanceID string, parameters compute.RunCommandInput) error {
+	return nil
+}
+
+// Start Fakes base method
+func (v *FakeVirtualMachineScaleSetVMsClient) Start(ctx context.Context, resourceGroupName, VMScaleSetName, instanceID string) error {
+	for _, vm := range v.az.Vms {
+		if *vm.InstanceID == instanceID {
+			vm.VirtualMachineScaleSetVMProperties.ProvisioningState = to.StringPtr("Started")
+			return nil
+		}
+	}
+	return fmt.Errorf("VM %s/%s not found", VMScaleSetName, instanceID)
+}
+
+////////////////////////////////////////////////////////////////////////////////
+
+type FakeVirtualMachineScaleSetsClient struct {
+	az *AzureCloud
+}
+
+// NewFakeVirtualMachineScaleSetsClient creates a new Fake instance
+func NewFakeVirtualMachineScaleSetsClient(az *AzureCloud) *FakeVirtualMachineScaleSetsClient {
+	return &FakeVirtualMachineScaleSetsClient{az: az}
+}
+
+// Client Fakes base method
+func (s *FakeVirtualMachineScaleSetsClient) Client() autorest.Client {
+	return allwaysDoneClient()
+}
+
+func (s *FakeVirtualMachineScaleSetsClient) scale(ctx context.Context, resourceGroupName string, ss *compute.VirtualMachineScaleSet) error {
+	var have int64
+	for _, vm := range s.az.Vms {
+		if *ss.Name == *vm.Tags["scaleset"] {
+			have++
+		}
+	}
+	s.az.log.Debugf("scale have:%d, cap:%d", have, *ss.Sku.Capacity)
+	if have > *ss.Sku.Capacity {
+		return fmt.Errorf("should not be automatically scaling down")
+	}
+	for v := have; *ss.Sku.Capacity > have; v++ {
+		name := fmt.Sprintf("%s-%d", (*ss.Name)[3:], v)
+		compName := fmt.Sprintf("%s-%06d", (*ss.Name)[3:], v)
+		s.az.log.Infof("scale have:%d, cap:%d, v:%d, name:%s, compName:%s", have, *ss.Sku.Capacity, v, name, compName)
+		tags := ss.Tags
+		if tags == nil {
+			tags = map[string]*string{}
+		}
+		tags["scaleset"] = ss.Name
+		vm := compute.VirtualMachineScaleSetVM{
+			ID:         to.StringPtr(uuid.NewV4().String()),
+			InstanceID: to.StringPtr(uuid.NewV4().String()),
+			Name:       &name,
+			VirtualMachineScaleSetVMProperties: &compute.VirtualMachineScaleSetVMProperties{
+				OsProfile: &compute.OSProfile{ComputerName: &compName},
+			},
+			Location: ss.Location,
+			Plan:     ss.Plan,
+			Tags:     tags,
+			Zones:    ss.Zones,
+		}
+		s.az.Vms = append(s.az.Vms, vm)
+		s.az.VirtualMachineScaleSetVMsClient.Start(ctx, resourceGroupName, *ss.Name, *vm.InstanceID)
+		have++
+	}
+	return nil
+}
+
+// CreateOrUpdate Fakes base method
+func (s *FakeVirtualMachineScaleSetsClient) CreateOrUpdate(ctx context.Context, resourceGroupName, VMScaleSetName string, parameters compute.VirtualMachineScaleSet) error {
+	found := false
+	for i, ss := range s.az.Ssc {
+		if VMScaleSetName == *ss.Name {
+			found = true
+			s.az.Ssc[i] = parameters
+			break
+		}
+	}
+	if !found {
+		s.az.Ssc = append(s.az.Ssc, parameters)
+	}
+	s.scale(ctx, resourceGroupName, &parameters)
+	return nil
+}
+
+// Delete Fakes base method
+func (s *FakeVirtualMachineScaleSetsClient) Delete(ctx context.Context, resourceGroupName, VMScaleSetName string) error {
+	for i, ss := range s.az.Ssc {
+		if VMScaleSetName == *ss.Name {
+			*ss.Sku.Capacity = 0
+			s.scale(ctx, resourceGroupName, &ss)
+			s.az.Ssc = append(s.az.Ssc[:i], s.az.Ssc[i+1:]...)
+			return nil
+		}
+	}
+	return nil
+}
+
+// List Fakes base method
+func (s *FakeVirtualMachineScaleSetsClient) List(ctx context.Context, resourceGroup string) ([]compute.VirtualMachineScaleSet, error) {
+	return s.az.Ssc, nil
+}
+
+// Update Fakes base method
+func (s *FakeVirtualMachineScaleSetsClient) Update(ctx context.Context, resourceGroupName, VMScaleSetName string, parameters compute.VirtualMachineScaleSetUpdate) error {
+	for _, ss := range s.az.Ssc {
+		if VMScaleSetName == *ss.Name {
+			// the scaler changes the capacity
+			ss.Sku.Capacity = parameters.Sku.Capacity
+			s.scale(ctx, resourceGroupName, &ss)
+			return nil
+		}
+	}
+	return nil
+}
+
+// UpdateInstances Fakes base method
+func (s *FakeVirtualMachineScaleSetsClient) UpdateInstances(ctx context.Context, resourceGroupName, VMScaleSetName string, VMInstanceIDs compute.VirtualMachineScaleSetVMInstanceRequiredIDs) error {
+	// not implemented yet
+	return nil
+}

--- a/pkg/util/azureclient/fake/deployments.go
+++ b/pkg/util/azureclient/fake/deployments.go
@@ -1,0 +1,82 @@
+package fake
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
+	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2018-02-01/storage"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+)
+
+// FakeDeploymentsClient is a Fake of DeploymentsClient interface
+type FakeDeploymentsClient struct {
+	az *AzureCloud
+}
+
+// NewFakeDeploymentsClient creates a new Fake instance
+func NewFakeDeploymentsClient(az *AzureCloud) *FakeDeploymentsClient {
+	return &FakeDeploymentsClient{az: az}
+}
+
+// Client Fakes base method
+func (d *FakeDeploymentsClient) Client() autorest.Client {
+	return allwaysDoneClient()
+}
+
+// CreateOrUpdate Fakes base method
+func (d *FakeDeploymentsClient) CreateOrUpdate(ctx context.Context, resourceGroupName string, deploymentName string, parameters resources.Deployment) (result resources.DeploymentsCreateOrUpdateFuture, err error) {
+	var testURL *url.URL
+	testURL, err = url.Parse("https://example.com/nothing")
+
+	result.Future, _ = azure.NewFutureFromResponse(&http.Response{
+		StatusCode: 200,
+		Request: &http.Request{
+			Method: http.MethodPut,
+			URL:    testURL,
+		},
+	})
+	templ := parameters.Properties.Template.(map[string]interface{})
+	for _, r := range templ["resources"].([]interface{}) {
+		rMap := r.(map[string]interface{})
+		if strings.Contains(rMap["type"].(string), "Microsoft.Storage/storageAccounts") {
+			sa := storage.Account{}
+			var sab []byte
+			sab, err = json.Marshal(rMap)
+			if err != nil {
+				result.Future.Response().StatusCode = 500
+				return
+			}
+			err = sa.UnmarshalJSON(sab)
+			if err != nil {
+				result.Future.Response().StatusCode = 500
+				return
+			}
+
+			updated := false
+			for a, acct := range d.az.Accts {
+				if acct.Name == sa.Name {
+					d.az.Accts[a] = sa
+					updated = true
+				}
+			}
+			if !updated {
+				d.az.Accts = append(d.az.Accts, sa)
+			}
+		} else if strings.Contains(rMap["type"].(string), "Microsoft.Compute/virtualMachineScaleSets") {
+			vm := compute.VirtualMachineScaleSet{}
+			rb, _ := json.Marshal(rMap)
+			vm.UnmarshalJSON(rb)
+			d.az.VirtualMachineScaleSetsClient.CreateOrUpdate(ctx, resourceGroupName, *vm.Name, vm)
+		}
+	}
+
+	// store in memory the resources that are created so that other api requests can work with them
+	err = nil
+	return
+}

--- a/pkg/util/azureclient/fake/keyvault.go
+++ b/pkg/util/azureclient/fake/keyvault.go
@@ -1,0 +1,35 @@
+package fake
+
+import (
+	"context"
+	"fmt"
+
+	keyvault "github.com/Azure/azure-sdk-for-go/services/keyvault/2016-10-01/keyvault"
+
+	"github.com/openshift/openshift-azure/pkg/util/azureclient"
+)
+
+// FakeKeyVaultClient is a Fake of KeyVaultClient interface
+type FakeKeyVaultClient struct {
+	az *AzureCloud
+}
+
+// NewFakeKeyVaultClient creates a new Fake instance
+func NewFakeKeyVaultClient(az *AzureCloud) azureclient.KeyVaultClient {
+	return &FakeKeyVaultClient{az: az}
+}
+
+// GetSecret Fakes base method
+func (kv *FakeKeyVaultClient) GetSecret(ctx context.Context, vaultBaseURL string, secretName string, secretVersion string) (result keyvault.SecretBundle, err error) {
+	for _, s := range kv.az.Secrets {
+		if *s.ID == secretName {
+			return s, nil
+		}
+	}
+	return keyvault.SecretBundle{}, fmt.Errorf("secret %s/%s not found", vaultBaseURL, secretName)
+}
+
+// ImportCertificate Fakes base method
+func (kv *FakeKeyVaultClient) ImportCertificate(arg0 context.Context, arg1, arg2 string, arg3 keyvault.CertificateImportParameters) (keyvault.CertificateBundle, error) {
+	return keyvault.CertificateBundle{}, fmt.Errorf("not supported as a fake")
+}

--- a/pkg/util/azureclient/fake/storage.go
+++ b/pkg/util/azureclient/fake/storage.go
@@ -1,0 +1,130 @@
+package fake
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"io/ioutil"
+
+	"github.com/Azure/azure-sdk-for-go/storage"
+	"github.com/Azure/go-autorest/autorest"
+
+	azurestorage "github.com/openshift/openshift-azure/pkg/util/azureclient/storage"
+)
+
+// FakeStorageClient is a mock of StorageClient interface
+type FakeStorageClient struct {
+	az *AzureCloud
+}
+
+// NewFakeStorageClient creates a new mock instance
+func NewFakeStorageClient(az *AzureCloud) *FakeStorageClient {
+	return &FakeStorageClient{az: az}
+}
+
+// Client mocks base method
+func (s *FakeStorageClient) Client() autorest.Client {
+	return allwaysDoneClient()
+}
+
+func (s *FakeStorageClient) GetBlobService() azurestorage.BlobStorageClient {
+	return &FakeBlobStorageClient{az: s.az}
+}
+
+type FakeBlobStorageClient struct {
+	az *AzureCloud
+}
+
+func (bs *FakeBlobStorageClient) GetContainerReference(name string) azurestorage.Container {
+	return &FakeContainerClient{az: bs.az, name: name}
+}
+
+type FakeContainerClient struct {
+	az   *AzureCloud
+	name string
+}
+
+func (c *FakeContainerClient) CreateIfNotExists(options *storage.CreateContainerOptions) (bool, error) {
+	_, exist := c.az.Blobs[c.name]
+	if !exist {
+		c.az.Blobs[c.name] = map[string][]byte{}
+	}
+	return !exist, nil
+}
+
+func (c *FakeContainerClient) GetBlobReference(name string) azurestorage.Blob {
+	return &FakeBlobClient{az: c.az, container: c, name: name}
+}
+
+func (c *FakeContainerClient) Exists() (bool, error) {
+	_, exist := c.az.Blobs[c.name]
+	return exist, nil
+}
+
+func (c *FakeContainerClient) ListBlobs(params storage.ListBlobsParameters) (storage.BlobListResponse, error) {
+	bl := storage.BlobListResponse{}
+	for key := range c.az.Blobs[c.name] {
+		bl.Blobs = append(bl.Blobs, storage.Blob{Name: key, Container: &storage.Container{Name: c.name}})
+	}
+	return bl, nil
+}
+
+type FakeBlobClient struct {
+	az        *AzureCloud
+	container *FakeContainerClient
+	name      string
+}
+
+// NewFakeStorageClient creates a new mock instance
+func NewFakeBlobClient(az *AzureCloud) *FakeBlobClient {
+	return &FakeBlobClient{az: az}
+}
+
+func (b *FakeBlobClient) CreateBlockBlobFromReader(blob io.Reader, options *storage.PutBlobOptions) error {
+	buf, err := ioutil.ReadAll(blob)
+	if err != nil {
+		return err
+	}
+	b.az.Blobs[b.container.name][b.name] = buf
+	return nil
+}
+
+func (b *FakeBlobClient) CreateBlockBlob(options *storage.PutBlobOptions) error {
+	// nothing to do
+	return nil
+}
+
+func (b *FakeBlobClient) PutBlock(blockID string, chunk []byte, options *storage.PutBlockOptions) error {
+	b.az.Blobs[b.container.name][b.name] = append(b.az.Blobs[b.container.name][b.name], chunk...)
+	return nil
+}
+
+func (b *FakeBlobClient) PutBlockList(blocks []storage.Block, options *storage.PutBlockListOptions) error {
+	// nothing to do
+	return nil
+}
+
+func (b *FakeBlobClient) Get(options *storage.GetBlobOptions) (io.ReadCloser, error) {
+	blob, exist := b.az.Blobs[b.container.name][b.name]
+	if !exist {
+		return nil, fmt.Errorf("%s does not exist", b.name)
+	}
+	return ioutil.NopCloser(bytes.NewReader(blob)), nil
+}
+
+func (b *FakeBlobClient) GetSASURI(options storage.BlobSASOptions) (string, error) {
+	return fmt.Sprintf("http://example.com/somewhere/%s/%s", b.container.name, b.name), nil
+}
+
+func (b *FakeBlobClient) Delete(options *storage.DeleteBlobOptions) error {
+	exist, _ := b.Exists()
+	if exist {
+		delete(b.az.Blobs[b.container.name], b.name)
+	}
+	return nil
+}
+
+func (b *FakeBlobClient) Exists() (bool, error) {
+	_, exist := b.az.Blobs[b.container.name][b.name]
+	return exist, nil
+}

--- a/pkg/util/wait/wait.go
+++ b/pkg/util/wait/wait.go
@@ -38,7 +38,18 @@ type SimpleHTTPClient interface {
 	Do(req *http.Request) (*http.Response, error)
 }
 
-// ForHTTPStatusOk polls until URL returns 200
+func NewFakeHTTPClient() SimpleHTTPClient {
+	return &fakeHTTPClient{}
+}
+
+type fakeHTTPClient struct {
+}
+
+func (f *fakeHTTPClient) Do(req *http.Request) (*http.Response, error) {
+	return &http.Response{StatusCode: 200}, nil
+}
+
+// ForHTTPStatusOk poll until URL returns 200
 func ForHTTPStatusOk(ctx context.Context, log *logrus.Entry, cli SimpleHTTPClient, urltocheck string, interval time.Duration) (*http.Response, error) {
 	req, err := http.NewRequest("GET", urltocheck, nil)
 	if err != nil {


### PR DESCRIPTION
```release-note
NONE
```

The point of this is to have a deeper style of integration test that allows us to test the whole plugin with just azure and kube client fakes. We can then have greater confidence in what actions cause node rotations.
/cc @jim-minter 