### PR TITLE
fakerp refactor

### DIFF
--- a/pkg/fakerp/admin_handlers.go
+++ b/pkg/fakerp/admin_handlers.go
@@ -10,11 +10,7 @@ import (
 
 // handleBackup handles admin requests to backup an etcd cluster
 func (s *Server) handleBackup(w http.ResponseWriter, req *http.Request) {
-	cs := s.read()
-	if cs == nil {
-		s.badRequest(w, "Failed to read the internal config")
-		return
-	}
+	cs := req.Context().Value(ContainerServicesKey).(*api.OpenShiftManagedCluster)
 
 	backupName := chi.URLParam(req, "backupName")
 
@@ -24,11 +20,7 @@ func (s *Server) handleBackup(w http.ResponseWriter, req *http.Request) {
 
 // handleGetControlPlanePods handles admin requests for the list of control plane pods
 func (s *Server) handleGetControlPlanePods(w http.ResponseWriter, req *http.Request) {
-	cs := s.read()
-	if cs == nil {
-		s.badRequest(w, "Failed to read the internal config")
-		return
-	}
+	cs := req.Context().Value(ContainerServicesKey).(*api.OpenShiftManagedCluster)
 
 	pods, err := s.plugin.GetControlPlanePods(req.Context(), cs)
 	s.adminreply(w, err, pods)
@@ -36,11 +28,7 @@ func (s *Server) handleGetControlPlanePods(w http.ResponseWriter, req *http.Requ
 
 // handleListClusterVMs handles admin requests for the list of cluster VMs
 func (s *Server) handleListClusterVMs(w http.ResponseWriter, req *http.Request) {
-	cs := s.read()
-	if cs == nil {
-		s.badRequest(w, "Failed to read the internal config")
-		return
-	}
+	cs := req.Context().Value(ContainerServicesKey).(*api.OpenShiftManagedCluster)
 
 	vms, err := s.plugin.ListClusterVMs(req.Context(), cs)
 	s.adminreply(w, err, vms)
@@ -48,11 +36,7 @@ func (s *Server) handleListClusterVMs(w http.ResponseWriter, req *http.Request) 
 
 // handleReimage handles reimaging a vm in the cluster
 func (s *Server) handleReimage(w http.ResponseWriter, req *http.Request) {
-	cs := s.read()
-	if cs == nil {
-		s.badRequest(w, "Failed to read the internal config")
-		return
-	}
+	cs := req.Context().Value(ContainerServicesKey).(*api.OpenShiftManagedCluster)
 
 	hostname := chi.URLParam(req, "hostname")
 
@@ -62,11 +46,7 @@ func (s *Server) handleReimage(w http.ResponseWriter, req *http.Request) {
 
 // handleListBackups handles admin requests to list etcd backups
 func (s *Server) handleListBackups(w http.ResponseWriter, req *http.Request) {
-	cs := s.read()
-	if cs == nil {
-		s.badRequest(w, "Failed to read the internal config")
-		return
-	}
+	cs := req.Context().Value(ContainerServicesKey).(*api.OpenShiftManagedCluster)
 
 	backups, pluginErr := s.plugin.ListEtcdBackups(req.Context(), cs)
 	var err error
@@ -79,11 +59,7 @@ func (s *Server) handleListBackups(w http.ResponseWriter, req *http.Request) {
 
 // handleRestore handles admin requests to restore an etcd cluster from a backup
 func (s *Server) handleRestore(w http.ResponseWriter, req *http.Request) {
-	cs := s.read()
-	if cs == nil {
-		s.badRequest(w, "Failed to read the internal config")
-		return
-	}
+	cs := req.Context().Value(ContainerServicesKey).(*api.OpenShiftManagedCluster)
 
 	backupName := chi.URLParam(req, "backupName")
 
@@ -98,11 +74,7 @@ func (s *Server) handleRestore(w http.ResponseWriter, req *http.Request) {
 
 // handleRotateSecrets handles admin requests for the rotation of cluster secrets
 func (s *Server) handleRotateSecrets(w http.ResponseWriter, req *http.Request) {
-	cs := s.read()
-	if cs == nil {
-		s.badRequest(w, "Failed to read the internal config")
-		return
-	}
+	cs := req.Context().Value(ContainerServicesKey).(*api.OpenShiftManagedCluster)
 
 	deployer := GetDeployer(s.log, cs, s.testConfig)
 	pluginErr := s.plugin.RotateClusterSecrets(req.Context(), cs, deployer)
@@ -117,11 +89,7 @@ func (s *Server) handleRotateSecrets(w http.ResponseWriter, req *http.Request) {
 
 // handleForceUpdate handles admin requests for the force updates of clusters
 func (s *Server) handleForceUpdate(w http.ResponseWriter, req *http.Request) {
-	cs := s.read()
-	if cs == nil {
-		s.badRequest(w, "Failed to read the internal config")
-		return
-	}
+	cs := req.Context().Value(ContainerServicesKey).(*api.OpenShiftManagedCluster)
 
 	pluginErr := s.plugin.ForceUpdate(req.Context(), cs, GetDeployer(s.log, cs, s.testConfig))
 	var err error
@@ -134,11 +102,7 @@ func (s *Server) handleForceUpdate(w http.ResponseWriter, req *http.Request) {
 
 // handleRunCommand handles running generic commands on a given vm within a scaleset in the cluster
 func (s *Server) handleRunCommand(w http.ResponseWriter, req *http.Request) {
-	cs := s.read()
-	if cs == nil {
-		s.badRequest(w, "Failed to read the internal config")
-		return
-	}
+	cs := req.Context().Value(ContainerServicesKey).(*api.OpenShiftManagedCluster)
 
 	hostname := chi.URLParam(req, "hostname")
 	command := chi.URLParam(req, "command")

--- a/pkg/fakerp/admin_handlers.go
+++ b/pkg/fakerp/admin_handlers.go
@@ -10,7 +10,7 @@ import (
 
 // handleBackup handles admin requests to backup an etcd cluster
 func (s *Server) handleBackup(w http.ResponseWriter, req *http.Request) {
-	cs := req.Context().Value(ContainerServicesKey).(*api.OpenShiftManagedCluster)
+	cs := req.Context().Value(ContainerService).(*api.OpenShiftManagedCluster)
 
 	backupName := chi.URLParam(req, "backupName")
 
@@ -20,7 +20,7 @@ func (s *Server) handleBackup(w http.ResponseWriter, req *http.Request) {
 
 // handleGetControlPlanePods handles admin requests for the list of control plane pods
 func (s *Server) handleGetControlPlanePods(w http.ResponseWriter, req *http.Request) {
-	cs := req.Context().Value(ContainerServicesKey).(*api.OpenShiftManagedCluster)
+	cs := req.Context().Value(ContainerService).(*api.OpenShiftManagedCluster)
 
 	pods, err := s.plugin.GetControlPlanePods(req.Context(), cs)
 	s.adminreply(w, err, pods)
@@ -28,7 +28,7 @@ func (s *Server) handleGetControlPlanePods(w http.ResponseWriter, req *http.Requ
 
 // handleListClusterVMs handles admin requests for the list of cluster VMs
 func (s *Server) handleListClusterVMs(w http.ResponseWriter, req *http.Request) {
-	cs := req.Context().Value(ContainerServicesKey).(*api.OpenShiftManagedCluster)
+	cs := req.Context().Value(ContainerService).(*api.OpenShiftManagedCluster)
 
 	vms, err := s.plugin.ListClusterVMs(req.Context(), cs)
 	s.adminreply(w, err, vms)
@@ -36,7 +36,7 @@ func (s *Server) handleListClusterVMs(w http.ResponseWriter, req *http.Request) 
 
 // handleReimage handles reimaging a vm in the cluster
 func (s *Server) handleReimage(w http.ResponseWriter, req *http.Request) {
-	cs := req.Context().Value(ContainerServicesKey).(*api.OpenShiftManagedCluster)
+	cs := req.Context().Value(ContainerService).(*api.OpenShiftManagedCluster)
 
 	hostname := chi.URLParam(req, "hostname")
 
@@ -46,7 +46,7 @@ func (s *Server) handleReimage(w http.ResponseWriter, req *http.Request) {
 
 // handleListBackups handles admin requests to list etcd backups
 func (s *Server) handleListBackups(w http.ResponseWriter, req *http.Request) {
-	cs := req.Context().Value(ContainerServicesKey).(*api.OpenShiftManagedCluster)
+	cs := req.Context().Value(ContainerService).(*api.OpenShiftManagedCluster)
 
 	backups, pluginErr := s.plugin.ListEtcdBackups(req.Context(), cs)
 	var err error
@@ -59,7 +59,7 @@ func (s *Server) handleListBackups(w http.ResponseWriter, req *http.Request) {
 
 // handleRestore handles admin requests to restore an etcd cluster from a backup
 func (s *Server) handleRestore(w http.ResponseWriter, req *http.Request) {
-	cs := req.Context().Value(ContainerServicesKey).(*api.OpenShiftManagedCluster)
+	cs := req.Context().Value(ContainerService).(*api.OpenShiftManagedCluster)
 
 	backupName := chi.URLParam(req, "backupName")
 
@@ -74,7 +74,7 @@ func (s *Server) handleRestore(w http.ResponseWriter, req *http.Request) {
 
 // handleRotateSecrets handles admin requests for the rotation of cluster secrets
 func (s *Server) handleRotateSecrets(w http.ResponseWriter, req *http.Request) {
-	cs := req.Context().Value(ContainerServicesKey).(*api.OpenShiftManagedCluster)
+	cs := req.Context().Value(ContainerService).(*api.OpenShiftManagedCluster)
 
 	deployer := GetDeployer(s.log, cs, s.testConfig)
 	pluginErr := s.plugin.RotateClusterSecrets(req.Context(), cs, deployer)
@@ -89,7 +89,7 @@ func (s *Server) handleRotateSecrets(w http.ResponseWriter, req *http.Request) {
 
 // handleForceUpdate handles admin requests for the force updates of clusters
 func (s *Server) handleForceUpdate(w http.ResponseWriter, req *http.Request) {
-	cs := req.Context().Value(ContainerServicesKey).(*api.OpenShiftManagedCluster)
+	cs := req.Context().Value(ContainerService).(*api.OpenShiftManagedCluster)
 
 	pluginErr := s.plugin.ForceUpdate(req.Context(), cs, GetDeployer(s.log, cs, s.testConfig))
 	var err error
@@ -102,7 +102,7 @@ func (s *Server) handleForceUpdate(w http.ResponseWriter, req *http.Request) {
 
 // handleRunCommand handles running generic commands on a given vm within a scaleset in the cluster
 func (s *Server) handleRunCommand(w http.ResponseWriter, req *http.Request) {
-	cs := req.Context().Value(ContainerServicesKey).(*api.OpenShiftManagedCluster)
+	cs := req.Context().Value(ContainerService).(*api.OpenShiftManagedCluster)
 
 	hostname := chi.URLParam(req, "hostname")
 	command := chi.URLParam(req, "command")

--- a/pkg/fakerp/admin_handlers.go
+++ b/pkg/fakerp/admin_handlers.go
@@ -1,39 +1,12 @@
 package fakerp
 
 import (
-	"encoding/json"
 	"net/http"
 
 	"github.com/go-chi/chi"
 
 	"github.com/openshift/openshift-azure/pkg/api"
 )
-
-func (s *Server) adminreply(w http.ResponseWriter, err error, out interface{}) {
-	if err != nil {
-		s.badRequest(w, err.Error())
-		return
-	}
-
-	if out == nil {
-		return
-	}
-
-	if b, ok := out.([]byte); ok {
-		w.Header().Set("Content-Type", "application/octet-stream")
-		w.Write(b)
-		return
-	}
-
-	b, err := json.Marshal(out)
-	if err != nil {
-		s.badRequest(w, err.Error())
-		return
-	}
-	w.Header().Set("Content-Type", "application/json")
-	w.Write(b)
-	return
-}
 
 // handleBackup handles admin requests to backup an etcd cluster
 func (s *Server) handleBackup(w http.ResponseWriter, req *http.Request) {

--- a/pkg/fakerp/config.go
+++ b/pkg/fakerp/config.go
@@ -13,6 +13,10 @@ import (
 	"github.com/openshift/openshift-azure/pkg/util/tls"
 )
 
+const (
+	ContainerServicesKey = "containerservice.yaml"
+)
+
 func GetTestConfig() api.TestConfig {
 	return api.TestConfig{
 		RunningUnderTest:   os.Getenv("RUNNING_UNDER_TEST") == "true",

--- a/pkg/fakerp/config.go
+++ b/pkg/fakerp/config.go
@@ -14,7 +14,8 @@ import (
 )
 
 const (
-	ContainerServicesKey = "containerservice.yaml"
+	ContainerService    api.ContextKey = "ContainerService"
+	ContainerServiceKey string         = "containerservice.yaml"
 )
 
 func GetTestConfig() api.TestConfig {

--- a/pkg/fakerp/customer_handlers.go
+++ b/pkg/fakerp/customer_handlers.go
@@ -16,12 +16,11 @@ import (
 	internalapi "github.com/openshift/openshift-azure/pkg/api"
 	v20190430 "github.com/openshift/openshift-azure/pkg/api/2019-04-30"
 	admin "github.com/openshift/openshift-azure/pkg/api/admin"
-	"github.com/openshift/openshift-azure/pkg/fakerp/shared"
 	"github.com/openshift/openshift-azure/pkg/util/azureclient"
 )
 
 func (s *Server) handleDelete(w http.ResponseWriter, req *http.Request) {
-	cs := req.Context().Value(ContainerServicesKey).(*internalapi.OpenShiftManagedCluster)
+	cs := req.Context().Value(ContainerService).(*internalapi.OpenShiftManagedCluster)
 
 	authorizer, err := azureclient.GetAuthorizerFromContext(req.Context(), internalapi.ContextKeyClientAuthorizer)
 	if err != nil {
@@ -74,28 +73,15 @@ func (s *Server) handleDelete(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	s.writeState(internalapi.Deleting)
+	cs.Properties.ProvisioningState = internalapi.Deleting
+	s.store.Put(ContainerServiceKey, cs)
 	ctx, cancel := context.WithTimeout(context.Background(), 30*time.Minute)
 	defer cancel()
 	if err := future.WaitForCompletionRef(ctx, gc.Client); err != nil {
 		s.badRequest(w, fmt.Sprintf("Failed to wait for resource group deletion: %v", err))
 		return
 	}
-	resp, err := future.Result(gc)
-	if err != nil {
-		s.badRequest(w, fmt.Sprintf("Failed to get resource group deletion response: %v", err))
-		return
-	}
-	// If the resource group deletion is successful, cleanup the object
-	// from the memory so the next GET from the client waiting for this
-	// long-running operation can exit successfully.
-	if resp.StatusCode == http.StatusOK {
-		s.log.Infof("deleted resource group %s", resourceGroup)
-		s.store.Delete(ContainerServicesKey)
-	}
-	// And last but not least, we have accepted this DELETE request
-	// and are processing it in the background.
-	w.WriteHeader(http.StatusAccepted)
+	w.WriteHeader(http.StatusOK)
 }
 
 func (s *Server) handleGet(w http.ResponseWriter, req *http.Request) {
@@ -103,14 +89,7 @@ func (s *Server) handleGet(w http.ResponseWriter, req *http.Request) {
 }
 
 func (s *Server) handlePut(w http.ResponseWriter, req *http.Request) {
-	oldCs := req.Context().Value(ContainerServicesKey).(*internalapi.OpenShiftManagedCluster)
-
-	var err error
-	if !shared.IsUpdate() {
-		s.writeState(internalapi.Creating)
-	} else {
-		s.writeState(internalapi.Updating)
-	}
+	oldCs := req.Context().Value(ContainerService).(*internalapi.OpenShiftManagedCluster)
 
 	// TODO: Align with the production RP once it supports the admin API
 	isAdminRequest := strings.HasPrefix(req.URL.Path, "/admin")
@@ -118,15 +97,16 @@ func (s *Server) handlePut(w http.ResponseWriter, req *http.Request) {
 	// convert the external API manifest into the internal API representation
 	s.log.Info("read request and convert to internal")
 	var cs *internalapi.OpenShiftManagedCluster
+	var err error
 	if isAdminRequest {
 		var oc *admin.OpenShiftManagedCluster
-		oc, err = s.readAdminRequest(req.Body)
+		oc, err := s.readAdminRequest(req.Body)
 		if err == nil {
 			cs, err = admin.ToInternal(oc, oldCs)
 		}
 	} else {
 		var oc *v20190430.OpenShiftManagedCluster
-		oc, err = s.read20190430Request(req.Body)
+		oc, err := s.read20190430Request(req.Body)
 		if err == nil {
 			cs, err = v20190430.ToInternal(oc, oldCs)
 		}
@@ -135,17 +115,20 @@ func (s *Server) handlePut(w http.ResponseWriter, req *http.Request) {
 		s.badRequest(w, fmt.Sprintf("Failed to convert to internal type: %v", err))
 		return
 	}
-	s.write(cs)
+	// HACK: We persist new ContainerService early.
+	// This will overwrite old copy cs with new req version
+	s.store.Put(ContainerServiceKey, cs)
 
 	// apply the request
 	cs, err = createOrUpdateWrapper(req.Context(), s.plugin, s.log, cs, oldCs, isAdminRequest, s.testConfig)
 	if err != nil {
-		s.writeState(internalapi.Failed)
+		oldCs.Properties.ProvisioningState = internalapi.Failed
+		s.store.Put(ContainerServiceKey, oldCs)
 		s.badRequest(w, fmt.Sprintf("Failed to apply request: %v", err))
 		return
 	}
-	s.write(cs)
-	s.writeState(internalapi.Succeeded)
+	cs.Properties.ProvisioningState = internalapi.Succeeded
+	s.store.Put(ContainerServiceKey, cs)
 	// TODO: Should return status.Accepted similar to how we handle DELETEs
 	s.reply(w, req)
 }

--- a/pkg/fakerp/fakerp.go
+++ b/pkg/fakerp/fakerp.go
@@ -130,7 +130,7 @@ func parsePluginVersion(pluginVersion string) (major, minor int, err error) {
 	return
 }
 
-func createOrUpdate(ctx context.Context, p api.Plugin, log *logrus.Entry, cs, oldCs *api.OpenShiftManagedCluster, isAdmin bool, testConfig api.TestConfig) (*api.OpenShiftManagedCluster, error) {
+func createOrUpdateWrapper(ctx context.Context, p api.Plugin, log *logrus.Entry, cs, oldCs *api.OpenShiftManagedCluster, isAdmin bool, testConfig api.TestConfig) (*api.OpenShiftManagedCluster, error) {
 	log.Info("enrich")
 	err := enrich(cs)
 	if err != nil {

--- a/pkg/fakerp/middleware.go
+++ b/pkg/fakerp/middleware.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/ghodss/yaml"
-
 	"github.com/openshift/openshift-azure/pkg/api"
 	"github.com/openshift/openshift-azure/pkg/util/azureclient"
 )
@@ -58,19 +56,9 @@ func (s *Server) context(handler http.Handler) http.Handler {
 		}
 		ctx = context.WithValue(ctx, api.ContextKeyVaultClientAuthorizer, vaultauthorizer)
 
-		// add containerservices.yaml object to ctx
-		data, err := s.store.Get(ContainerServicesKey)
-		if err != nil {
-			s.log.Debugf("record %s not found. If this is create, ignore", ContainerServicesKey)
-		}
-
-		var cs *api.OpenShiftManagedCluster
-		err = yaml.Unmarshal(data, &cs)
-		if err == nil {
-			ctx = context.WithValue(ctx, ContainerServicesKey, cs)
-		} else {
-			ctx = context.WithValue(ctx, ContainerServicesKey, nil)
-		}
+		// we ignore errors, as those are handled by code using the object
+		cs, _ := s.store.Get(ContainerServiceKey)
+		ctx = context.WithValue(ctx, ContainerService, cs)
 
 		handler.ServeHTTP(w, r.WithContext(ctx))
 	})

--- a/pkg/fakerp/routes.go
+++ b/pkg/fakerp/routes.go
@@ -6,7 +6,7 @@ import (
 	"github.com/go-chi/chi/middleware"
 )
 
-func (s *Server) SetupRoutes() {
+func (s *Server) setupRoutes() {
 	s.router.Use(middleware.DefaultCompress)
 	s.router.Use(middleware.RedirectSlashes)
 	s.router.Use(middleware.Recoverer)

--- a/pkg/fakerp/server.go
+++ b/pkg/fakerp/server.go
@@ -45,20 +45,17 @@ type Server struct {
 }
 
 func NewServer(log *logrus.Entry, resourceGroup, address string) *Server {
-	st, err := store.New(log, "_data")
-	if err != nil {
-		log.Fatal(err)
-	}
 	s := &Server{
 		router:     chi.NewRouter(),
 		inProgress: make(chan struct{}, 1),
 		log:        log,
 		address:    address,
-		store:      st,
+		store:      store.New(log, "_data"),
 		basePath:   "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{provider}/openShiftManagedClusters/{resourceName}",
 	}
 
 	var errs []error
+	var err error
 	s.testConfig = GetTestConfig()
 	s.pluginTemplate, err = GetPluginTemplate()
 	if err != nil {

--- a/pkg/fakerp/server.go
+++ b/pkg/fakerp/server.go
@@ -6,7 +6,6 @@ import (
 	"io"
 	"io/ioutil"
 	"net/http"
-	"os"
 	"sync"
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
@@ -19,6 +18,7 @@ import (
 	v20190430 "github.com/openshift/openshift-azure/pkg/api/2019-04-30"
 	admin "github.com/openshift/openshift-azure/pkg/api/admin"
 	pluginapi "github.com/openshift/openshift-azure/pkg/api/plugin"
+	"github.com/openshift/openshift-azure/pkg/fakerp/store"
 	"github.com/openshift/openshift-azure/pkg/plugin"
 )
 
@@ -33,8 +33,7 @@ type Server struct {
 	gc resources.GroupsClient
 
 	sync.RWMutex
-	state internalapi.ProvisioningState
-	cs    *internalapi.OpenShiftManagedCluster
+	store *store.Storage
 
 	log      *logrus.Entry
 	address  string
@@ -46,14 +45,19 @@ type Server struct {
 }
 
 func NewServer(log *logrus.Entry, resourceGroup, address string) *Server {
+	st, err := store.New(log, "_data")
+	if err != nil {
+		log.Fatal(err)
+	}
 	s := &Server{
 		router:     chi.NewRouter(),
 		inProgress: make(chan struct{}, 1),
 		log:        log,
 		address:    address,
+		store:      st,
 		basePath:   "/subscriptions/{subscriptionId}/resourceGroups/{resourceGroupName}/providers/{provider}/openShiftManagedClusters/{resourceName}",
 	}
-	var err error
+
 	var errs []error
 	s.testConfig = GetTestConfig()
 	s.pluginTemplate, err = GetPluginTemplate()
@@ -69,42 +73,13 @@ func NewServer(log *logrus.Entry, resourceGroup, address string) *Server {
 	if len(errs) > 0 {
 		s.log.Fatal(errs)
 	}
-	// We need to restore the internal cluster state into memory for GETs
-	// and DELETEs to work appropriately.
-	if err := s.load(); err != nil {
-		s.log.Fatal(err)
-	}
 	return s
 }
 
 func (s *Server) Run() {
-	s.SetupRoutes()
+	s.setupRoutes()
 	s.log.Infof("starting server on %s", s.address)
 	s.log.WithError(http.ListenAndServe(s.address, s.router)).Warn("Server exited.")
-}
-
-// The way we run the fake RP during development cannot really
-// be consistent with how the RP runs in production so we need
-// to restore the internal state of the cluster from the
-// filesystem. Whether the file that holds the state exists or
-// not is returned and any other error that was encountered.
-func (s *Server) load() error {
-	b, err := ioutil.ReadFile("_data/containerservice.yaml")
-	switch {
-	case os.IsNotExist(err):
-		return nil
-	case err != nil:
-		return err
-	}
-
-	var cs *api.OpenShiftManagedCluster
-	if err := yaml.Unmarshal(b, &cs); err != nil {
-		return err
-	}
-
-	s.write(cs)
-
-	return nil
 }
 
 func (s *Server) read20190430Request(body io.ReadCloser) (*v20190430.OpenShiftManagedCluster, error) {
@@ -129,28 +104,4 @@ func (s *Server) readAdminRequest(body io.ReadCloser) (*admin.OpenShiftManagedCl
 		return nil, fmt.Errorf("failed to unmarshal request: %v", err)
 	}
 	return oc, nil
-}
-
-func (s *Server) write(cs *internalapi.OpenShiftManagedCluster) {
-	s.Lock()
-	defer s.Unlock()
-	s.cs = cs
-}
-
-func (s *Server) read() *internalapi.OpenShiftManagedCluster {
-	s.RLock()
-	defer s.RUnlock()
-	return s.cs
-}
-
-func (s *Server) writeState(state internalapi.ProvisioningState) {
-	s.Lock()
-	defer s.Unlock()
-	s.state = state
-}
-
-func (s *Server) readState() internalapi.ProvisioningState {
-	s.RLock()
-	defer s.RUnlock()
-	return s.state
 }

--- a/pkg/fakerp/store/codecov_dummy_test.go
+++ b/pkg/fakerp/store/codecov_dummy_test.go
@@ -1,0 +1,12 @@
+package store
+
+import (
+	"testing"
+)
+
+// This file exists because this package has no unit tests.  Codecov does not
+// report packages with no unit tests as 0% coverage, incorrectly inflating our
+// coverage statistics.  When unit tests are added to this package, this file
+// can be removed.
+
+func TestDummyCodeCov(t *testing.T) {}

--- a/pkg/fakerp/store/store.go
+++ b/pkg/fakerp/store/store.go
@@ -1,0 +1,123 @@
+package store
+
+import (
+	"fmt"
+	"io/ioutil"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/sirupsen/logrus"
+)
+
+type Store interface {
+	Put(key string, b []byte) error
+	Get(key string) ([]byte, error)
+	Delete(key string) error
+}
+
+type Storage struct {
+	mutex   *sync.Mutex
+	mutexes map[string]*sync.Mutex
+	dir     string
+	log     *logrus.Entry
+}
+
+var _ Store = &Storage{}
+
+func New(log *logrus.Entry, dir string) (Store, error) {
+	dir = filepath.Clean(dir)
+
+	s := &Storage{
+		dir:     dir,
+		log:     log,
+		mutexes: make(map[string]*sync.Mutex),
+	}
+
+	// if the database already exists, just use it
+	if _, err := os.Stat(dir); err == nil {
+		s.log.Debugf("Using '%s' (database already exists)", dir)
+		return s, nil
+	}
+
+	// if the database doesn't exist create it
+	s.log.Debugf("Creating database at '%s'", dir)
+	return s, os.MkdirAll(dir, 0755)
+}
+
+func (s *Storage) Put(key string, b []byte) error {
+	if key == "" {
+		return fmt.Errorf("missing key - unable to save")
+	}
+
+	mutex := s.getMutex(key)
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	fnlPath := filepath.Join(s.dir, key)
+	tmpPath := fnlPath + ".tmp"
+
+	if err := os.MkdirAll(s.dir, 0755); err != nil {
+		return err
+	}
+
+	if err := ioutil.WriteFile(tmpPath, b, 0644); err != nil {
+		return err
+	}
+
+	return os.Rename(tmpPath, fnlPath)
+}
+
+// Get a record from the database
+func (s *Storage) Get(key string) ([]byte, error) {
+	if key == "" {
+		return nil, fmt.Errorf("missing key - unable to read")
+	}
+	record := filepath.Join(s.dir, key)
+
+	if _, err := stat(record); err != nil {
+		return nil, err
+	}
+
+	return ioutil.ReadFile(record)
+}
+
+func (s *Storage) Delete(key string) error {
+	mutex := s.getMutex(key)
+	mutex.Lock()
+	defer mutex.Unlock()
+
+	record := filepath.Join(s.dir, key)
+
+	switch fi, err := stat(record); {
+	case fi == nil, err != nil:
+		return fmt.Errorf("unable to find file or directory named %v", record)
+	case fi.Mode().IsDir():
+		return os.RemoveAll(record)
+	case fi.Mode().IsRegular():
+		return os.RemoveAll(record)
+	}
+
+	return nil
+}
+
+func stat(path string) (fi os.FileInfo, err error) {
+	// check for dir, if path isn't a directory check to see if it's a file
+	if fi, err = os.Stat(path); os.IsNotExist(err) {
+		fi, err = os.Stat(path)
+	}
+	return
+}
+
+func (s *Storage) getMutex(collection string) *sync.Mutex {
+	s.mutex.Lock()
+	defer s.mutex.Unlock()
+
+	m, ok := s.mutexes[collection]
+	// if the mutex doesn't exist make it
+	if !ok {
+		m = &sync.Mutex{}
+		s.mutexes[collection] = m
+	}
+	return m
+}

--- a/pkg/fakerp/store/store.go
+++ b/pkg/fakerp/store/store.go
@@ -17,7 +17,7 @@ type Store interface {
 }
 
 type Storage struct {
-	mutex   *sync.Mutex
+	mutex   sync.Mutex
 	mutexes map[string]*sync.Mutex
 	dir     string
 	log     *logrus.Entry
@@ -25,7 +25,7 @@ type Storage struct {
 
 var _ Store = &Storage{}
 
-func New(log *logrus.Entry, dir string) (Store, error) {
+func New(log *logrus.Entry, dir string) (*Storage, error) {
 	dir = filepath.Clean(dir)
 
 	s := &Storage{

--- a/pkg/fakerp/store/store.go
+++ b/pkg/fakerp/store/store.go
@@ -5,59 +5,48 @@ import (
 	"io/ioutil"
 	"os"
 	"path/filepath"
-	"sync"
 
+	"github.com/ghodss/yaml"
 	"github.com/sirupsen/logrus"
+
+	"github.com/openshift/openshift-azure/pkg/api"
 )
 
 type Store interface {
-	Put(key string, b []byte) error
-	Get(key string) ([]byte, error)
+	Put(key string, cs *api.OpenShiftManagedCluster) error
+	Get(key string) (*api.OpenShiftManagedCluster, error)
 	Delete(key string) error
 }
 
 type Storage struct {
-	mutex   sync.Mutex
-	mutexes map[string]*sync.Mutex
-	dir     string
-	log     *logrus.Entry
+	dir string
+	log *logrus.Entry
 }
 
 var _ Store = &Storage{}
 
-func New(log *logrus.Entry, dir string) (*Storage, error) {
+func New(log *logrus.Entry, dir string) *Storage {
 	dir = filepath.Clean(dir)
-
-	s := &Storage{
-		dir:     dir,
-		log:     log,
-		mutexes: make(map[string]*sync.Mutex),
+	return &Storage{
+		dir: dir,
+		log: log,
 	}
-
-	// if the database already exists, just use it
-	if _, err := os.Stat(dir); err == nil {
-		s.log.Debugf("Using '%s' (database already exists)", dir)
-		return s, nil
-	}
-
-	// if the database doesn't exist create it
-	s.log.Debugf("Creating database at '%s'", dir)
-	return s, os.MkdirAll(dir, 0755)
 }
 
-func (s *Storage) Put(key string, b []byte) error {
+func (s *Storage) Put(key string, cs *api.OpenShiftManagedCluster) error {
 	if key == "" {
 		return fmt.Errorf("missing key - unable to save")
 	}
-
-	mutex := s.getMutex(key)
-	mutex.Lock()
-	defer mutex.Unlock()
 
 	fnlPath := filepath.Join(s.dir, key)
 	tmpPath := fnlPath + ".tmp"
 
 	if err := os.MkdirAll(s.dir, 0755); err != nil {
+		return err
+	}
+
+	b, err := yaml.Marshal(cs)
+	if err != nil {
 		return err
 	}
 
@@ -69,55 +58,23 @@ func (s *Storage) Put(key string, b []byte) error {
 }
 
 // Get a record from the database
-func (s *Storage) Get(key string) ([]byte, error) {
+func (s *Storage) Get(key string) (*api.OpenShiftManagedCluster, error) {
 	if key == "" {
 		return nil, fmt.Errorf("missing key - unable to read")
 	}
 	record := filepath.Join(s.dir, key)
 
-	if _, err := stat(record); err != nil {
+	b, err := ioutil.ReadFile(record)
+	if err != nil {
 		return nil, err
 	}
 
-	return ioutil.ReadFile(record)
+	var cs *api.OpenShiftManagedCluster
+	err = yaml.Unmarshal(b, &cs)
+	return cs, err
 }
 
 func (s *Storage) Delete(key string) error {
-	mutex := s.getMutex(key)
-	mutex.Lock()
-	defer mutex.Unlock()
-
 	record := filepath.Join(s.dir, key)
-
-	switch fi, err := stat(record); {
-	case fi == nil, err != nil:
-		return fmt.Errorf("unable to find file or directory named %v", record)
-	case fi.Mode().IsDir():
-		return os.RemoveAll(record)
-	case fi.Mode().IsRegular():
-		return os.RemoveAll(record)
-	}
-
-	return nil
-}
-
-func stat(path string) (fi os.FileInfo, err error) {
-	// check for dir, if path isn't a directory check to see if it's a file
-	if fi, err = os.Stat(path); os.IsNotExist(err) {
-		fi, err = os.Stat(path)
-	}
-	return
-}
-
-func (s *Storage) getMutex(collection string) *sync.Mutex {
-	s.mutex.Lock()
-	defer s.mutex.Unlock()
-
-	m, ok := s.mutexes[collection]
-	// if the mutex doesn't exist make it
-	if !ok {
-		m = &sync.Mutex{}
-		s.mutexes[collection] = m
-	}
-	return m
+	return os.RemoveAll(record)
 }

--- a/pkg/fakerp/util.go
+++ b/pkg/fakerp/util.go
@@ -130,16 +130,7 @@ func writeHelpers(log *logrus.Entry, cs *api.OpenShiftManagedCluster) error {
 	if err != nil {
 		return err
 	}
-	err = ioutil.WriteFile("_data/_out/admin.kubeconfig", b, 0600)
-	if err != nil {
-		return err
-	}
-
-	bytes, err := yaml.Marshal(cs)
-	if err != nil {
-		return err
-	}
-	return ioutil.WriteFile("_data/containerservice.yaml", bytes, 0600)
+	return ioutil.WriteFile("_data/_out/admin.kubeconfig", b, 0600)
 }
 
 func (s *Server) writeState(state api.ProvisioningState) error {

--- a/pkg/fakerp/util.go
+++ b/pkg/fakerp/util.go
@@ -1,9 +1,13 @@
 package fakerp
 
 import (
+	"encoding/json"
 	"fmt"
 	"net/http"
 	"strings"
+
+	v20190430 "github.com/openshift/openshift-azure/pkg/api/2019-04-30"
+	admin "github.com/openshift/openshift-azure/pkg/api/admin"
 )
 
 func (s *Server) badRequest(w http.ResponseWriter, msg string) {
@@ -15,4 +19,59 @@ func (s *Server) badRequest(w http.ResponseWriter, msg string) {
 func (s *Server) isAdminRequest(req *http.Request) bool {
 	// TODO: Align with the production RP once it supports the admin API
 	return strings.HasPrefix(req.URL.Path, "/admin")
+}
+
+// adminreply returns admin requests data
+func (s *Server) adminreply(w http.ResponseWriter, err error, out interface{}) {
+	if err != nil {
+		s.badRequest(w, err.Error())
+		return
+	}
+
+	if out == nil {
+		return
+	}
+
+	if b, ok := out.([]byte); ok {
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Write(b)
+		return
+	}
+
+	b, err := json.Marshal(out)
+	if err != nil {
+		s.badRequest(w, err.Error())
+		return
+	}
+	w.Header().Set("Content-Type", "application/json")
+	w.Write(b)
+	return
+}
+
+// reply return either admin or external api response
+func (s *Server) reply(w http.ResponseWriter, req *http.Request) {
+	cs := s.read()
+	if cs == nil {
+		// If the object is not found in memory then
+		// it must have been deleted or never existed.
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	state := s.readState()
+	cs.Properties.ProvisioningState = state
+
+	var res []byte
+	var err error
+	if strings.HasPrefix(req.URL.Path, "/admin") {
+		oc := admin.FromInternal(cs)
+		res, err = json.Marshal(oc)
+	} else {
+		oc := v20190430.FromInternal(cs)
+		res, err = json.Marshal(oc)
+	}
+	if err != nil {
+		s.badRequest(w, fmt.Sprintf("Failed to marshal response: %v", err))
+		return
+	}
+	w.Write(res)
 }

--- a/pkg/fakerp/util.go
+++ b/pkg/fakerp/util.go
@@ -1,13 +1,22 @@
 package fakerp
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
+	"io/ioutil"
 	"net/http"
+	"os"
 	"strings"
 
+	"github.com/ghodss/yaml"
+	"github.com/sirupsen/logrus"
+
+	"github.com/openshift/openshift-azure/pkg/api"
 	v20190430 "github.com/openshift/openshift-azure/pkg/api/2019-04-30"
 	admin "github.com/openshift/openshift-azure/pkg/api/admin"
+	"github.com/openshift/openshift-azure/pkg/util/derived"
+	"github.com/openshift/openshift-azure/pkg/util/tls"
 )
 
 func (s *Server) badRequest(w http.ResponseWriter, msg string) {
@@ -50,15 +59,14 @@ func (s *Server) adminreply(w http.ResponseWriter, err error, out interface{}) {
 
 // reply return either admin or external api response
 func (s *Server) reply(w http.ResponseWriter, req *http.Request) {
-	cs := s.read()
-	if cs == nil {
+	cs := req.Context().Value(ContainerServicesKey).(*api.OpenShiftManagedCluster)
+
+	if &cs == nil {
 		// If the object is not found in memory then
 		// it must have been deleted or never existed.
 		w.WriteHeader(http.StatusNoContent)
 		return
 	}
-	state := s.readState()
-	cs.Properties.ProvisioningState = state
 
 	var res []byte
 	var err error
@@ -67,11 +75,97 @@ func (s *Server) reply(w http.ResponseWriter, req *http.Request) {
 		res, err = json.Marshal(oc)
 	} else {
 		oc := v20190430.FromInternal(cs)
-		res, err = json.Marshal(oc)
+		res, err = json.Marshal(&oc)
 	}
 	if err != nil {
 		s.badRequest(w, fmt.Sprintf("Failed to marshal response: %v", err))
 		return
 	}
 	w.Write(res)
+}
+
+func writeHelpers(log *logrus.Entry, cs *api.OpenShiftManagedCluster) error {
+	b, err := derived.MasterCloudProviderConf(cs, true, true)
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile("_data/_out/azure.conf", b, 0600)
+	if err != nil {
+		return err
+	}
+
+	b, err = derived.AadGroupSyncConf(cs)
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile("_data/_out/aad-group-sync.yaml", b, 0600)
+	if err != nil {
+		return err
+	}
+
+	b, err = tls.PrivateKeyAsBytes(cs.Config.SSHKey)
+	if err != nil {
+		return err
+	}
+	// ensure both the new key and the old key are on disk so
+	// you can SSH in regardless of the state of a VM after an update
+	if _, err = os.Stat("_data/_out/id_rsa"); err == nil {
+		oldb, err := ioutil.ReadFile("_data/_out/id_rsa")
+		if err != nil {
+			return err
+		}
+		if !bytes.Equal(b, oldb) {
+			err = ioutil.WriteFile("_data/_out/id_rsa.old", oldb, 0600)
+			if err != nil {
+				return err
+			}
+		}
+	}
+	err = ioutil.WriteFile("_data/_out/id_rsa", b, 0600)
+	if err != nil {
+		return err
+	}
+
+	b, err = yaml.Marshal(cs.Config.AdminKubeconfig)
+	if err != nil {
+		return err
+	}
+	err = ioutil.WriteFile("_data/_out/admin.kubeconfig", b, 0600)
+	if err != nil {
+		return err
+	}
+
+	bytes, err := yaml.Marshal(cs)
+	if err != nil {
+		return err
+	}
+	return ioutil.WriteFile("_data/containerservice.yaml", bytes, 0600)
+}
+
+func (s *Server) writeState(state api.ProvisioningState) error {
+	data, err := s.store.Get(ContainerServicesKey)
+	if err != nil {
+		return err
+	}
+
+	var cs *api.OpenShiftManagedCluster
+	err = yaml.Unmarshal(data, &cs)
+	if err != nil {
+		return err
+	}
+
+	cs.Properties.ProvisioningState = state
+	data, err = yaml.Marshal(cs)
+	if err != nil {
+		return err
+	}
+	return s.store.Put(ContainerServicesKey, data)
+}
+
+func (s *Server) write(cs *api.OpenShiftManagedCluster) error {
+	data, err := yaml.Marshal(cs)
+	if err != nil {
+		return err
+	}
+	return s.store.Put(ContainerServicesKey, data)
 }

--- a/test/e2e/specs/fakerp/admin.go
+++ b/test/e2e/specs/fakerp/admin.go
@@ -75,7 +75,6 @@ var _ = Describe("Openshift on Azure admin e2e tests [Fake][EveryPR]", func() {
 		external, err := azurecli.OpenShiftManagedClusters.Get(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(external).NotTo(BeNil())
-		external.Properties.ProvisioningState = nil // TODO: should not need to do this
 
 		updated, err := azurecli.OpenShiftManagedClusters.CreateOrUpdateAndWait(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"), external)
 		Expect(err).NotTo(HaveOccurred())

--- a/test/e2e/specs/scaleupdown.go
+++ b/test/e2e/specs/scaleupdown.go
@@ -56,7 +56,6 @@ var _ = Describe("Scale Up/Down E2E tests [ScaleUpDown][Fake][EveryPR][LongRunni
 		By("Fetching the manifest")
 		external, err := azurecli.OpenShiftManagedClusters.Get(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
 		Expect(err).NotTo(HaveOccurred())
-		external.Properties.ProvisioningState = nil // TODO: should not need to do this
 		err = setCount(&external, count)
 		Expect(err).NotTo(HaveOccurred())
 


### PR DESCRIPTION
```release-note
NONE
```

Refactor fake RP to use files as "storage"
Persist state into "storage" on methods
Split some of the methods where logic started to become overcomplicated.
