### PR TITLE
allow admin API to change image versions

### DIFF
--- a/pkg/api/validate/admin.go
+++ b/pkg/api/validate/admin.go
@@ -71,12 +71,19 @@ func (v *AdminAPIValidator) validateUpdateContainerService(cs, oldCs *api.OpenSh
 		}
 	}
 
-	old.Config.ComponentLogLevel = cs.Config.ComponentLogLevel
-
 	oldMajor, _, err := parsePluginVersion(oldCs.Config.PluginVersion)
 	if cs.Config.PluginVersion == "latest" && err == nil && oldMajor >= 3 {
 		old.Config.PluginVersion = cs.Config.PluginVersion
 	}
+
+	old.Config.ComponentLogLevel = cs.Config.ComponentLogLevel
+
+	old.Config.ImageOffer = cs.Config.ImageOffer
+	old.Config.ImagePublisher = cs.Config.ImagePublisher
+	old.Config.ImageSKU = cs.Config.ImageSKU
+	old.Config.ImageVersion = cs.Config.ImageVersion
+
+	old.Config.Images = cs.Config.Images
 
 	if !reflect.DeepEqual(cs, old) {
 		errs = append(errs, fmt.Errorf("invalid change %s", deep.Equal(cs, old)))


### PR DESCRIPTION
```release-note
make vm image configuration and individual container image configuration writeable via the admin API
```

@mjudeikis @asalkeld the testing is grotty here - Angus, I'm hoping the work you're doing will improve coverage across all the images; MJ it feels like we should end up with some sort of Go test suite around updates, but I'm not sure what that ends up looking like.