### PR TITLE
Fix secrets generation command

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -25,7 +25,7 @@ version:
 secrets:
 	rm -rf secrets
 	mkdir secrets
-	oc extract secret/cluster-secrets-azure --to=secrets
+	oc extract -n azure secret/cluster-secrets-azure --to=secrets
 
 clean:
 	rm -f coverage.out $(ALL_BINARIES) releasenotes


### PR DESCRIPTION
```release-note
NONE
```

When this make target was added in #1453, the azure namespacing was accidentally removed.

/cc @jim-minter 