### PR TITLE
convert webconsole image change test to go

### DIFF
--- a/hack/tests/e2e-upgrade.sh
+++ b/hack/tests/e2e-upgrade.sh
@@ -49,19 +49,8 @@ cp -a "$T/src/github.com/openshift/openshift-azure/_data" .
 
 set_build_images
 
-# try upgrading just a single image to latest - TODO: need to improve this hack
-WEBCONSOLE=$(python -c 'import yaml; c=yaml.safe_load(open("pluginconfig/pluginconfig-311.yaml")); print c["versions"][c["pluginVersion"]]["images"]["webConsole"]')
-cat >/tmp/admin-update-console.yaml <<EOF
-config:
-  images:
-    webConsole: $WEBCONSOLE
-EOF
-ADMIN_MANIFEST=/tmp/admin-update-console.yaml make upgrade
-RUNNING_WEBCONSOLE=$(KUBECONFIG=_data/_out/admin.kubeconfig oc get deployment -n openshift-web-console webconsole -o jsonpath='{.spec.template.spec.containers[0].image}')
-if [[ "$WEBCONSOLE" != "$RUNNING_WEBCONSOLE" ]]; then
-    echo "expected webconsole image $WEBCONSOLE, got $RUNNING_WEBCONSOLE"
-    exit 1
-fi
+# try upgrading just a single image to latest
+( FOCUS="\[ChangeImage\]\[Fake\]\[LongRunning\]" TIMEOUT=50m ./hack/e2e.sh )
 
 # now upgrade the whole lot
 ADMIN_MANIFEST=test/manifests/fakerp/admin-update.yaml make upgrade e2e

--- a/test/e2e/specs/fakerp/setcontainerimage.go
+++ b/test/e2e/specs/fakerp/setcontainerimage.go
@@ -1,0 +1,62 @@
+package fakerp
+
+import (
+	"context"
+	"io/ioutil"
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/ghodss/yaml"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+
+	"github.com/openshift/openshift-azure/pkg/api/admin"
+	pluginapi "github.com/openshift/openshift-azure/pkg/api/plugin"
+	"github.com/openshift/openshift-azure/test/clients/azure"
+	"github.com/openshift/openshift-azure/test/sanity"
+)
+
+var _ = Describe("Change a single image to latest E2E tests [ChangeImage][Fake][LongRunning]", func() {
+	var (
+		azurecli *azure.Client
+		ctx      = context.Background()
+	)
+
+	BeforeEach(func() {
+		var err error
+		azurecli, err = azure.NewClientFromEnvironment(false)
+		Expect(err).NotTo(HaveOccurred())
+	})
+
+	It("should be possible for an SRE to update a single container image", func() {
+		By("Executing a cluster update with updated image.")
+		data, err := ioutil.ReadFile("../../pluginconfig/pluginconfig-311.yaml")
+		Expect(err).NotTo(HaveOccurred())
+		var template *pluginapi.Config
+		if err := yaml.Unmarshal(data, &template); err != nil {
+			Expect(err).NotTo(HaveOccurred())
+		}
+		before := admin.OpenShiftManagedCluster{
+			Config: &admin.Config{
+				Images: &admin.ImageConfig{
+					WebConsole: to.StringPtr(template.Versions[template.PluginVersion].Images.WebConsole),
+				},
+			},
+		}
+
+		update, err := azurecli.OpenShiftManagedClustersAdmin.CreateOrUpdate(ctx, os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"), &before)
+		Expect(err).NotTo(HaveOccurred())
+		Expect(update).NotTo(BeNil())
+
+		By("checking running webconsole image")
+		webconsole, err := sanity.Checker.Client.Admin.AppsV1.Deployments("openshift-web-console").Get("webconsole", metav1.GetOptions{})
+		Expect(err).NotTo(HaveOccurred())
+		Expect(webconsole.Spec.Template.Spec.Containers[0].Image).To(Equal(template.Versions[template.PluginVersion].Images.WebConsole))
+
+		By("Validating the cluster")
+		errs := sanity.Checker.ValidateCluster(context.Background())
+		Expect(errs).To(BeEmpty())
+	})
+})


### PR DESCRIPTION
```release-note
NONE
```

So @jim-minter we chatted about this earlier. I think this is a good incremental improvement.
from looking at the e2e tests, the admin action or createOrUpdate call is really minimal compared
with the setup and verify code. So I am not sure how the infrastructure that we talked about would save over just making use of the current e2e tests.
