### PR TITLE
moved azure client init to BeforeSuite for reuse.

### DIFF
--- a/test/e2e/specs/beforesuite.go
+++ b/test/e2e/specs/beforesuite.go
@@ -1,0 +1,31 @@
+package specs
+
+import (
+	"context"
+
+	. "github.com/onsi/ginkgo"
+
+	"github.com/openshift/openshift-azure/test/clients/azure"
+	"github.com/openshift/openshift-azure/test/util/log"
+)
+
+var _ = BeforeSuite(func() {
+	var err error
+	testlogger := log.GetTestLogger()
+
+	//so far none of the RealRP tests required the Storage Client
+	azure.RealRPClient, err = azure.NewClientFromEnvironment(context.Background(), testlogger, false, true)
+	testlogger.Debugf("new real rp client: %v", azure.RealRPClient)
+	if err != nil {
+		testlogger.Error(err)
+	}
+	azure.FakeRPClient, err = azure.NewClientFromEnvironment(context.Background(), testlogger, true, false)
+	testlogger.Debugf("new fake rp client: %v", azure.FakeRPClient)
+	if err != nil {
+		testlogger.Error(err)
+	}
+	if azure.RealRPClient == nil && azure.FakeRPClient == nil {
+		testlogger.Error("unable to provision either of the azure clients")
+		panic("No Azure clients")
+	}
+})

--- a/test/e2e/specs/beforesuite.go
+++ b/test/e2e/specs/beforesuite.go
@@ -2,29 +2,52 @@ package specs
 
 import (
 	"context"
+	"fmt"
+	"regexp"
+	"strings"
 
 	. "github.com/onsi/ginkgo"
+
+	"github.com/onsi/ginkgo/config"
 
 	"github.com/openshift/openshift-azure/test/clients/azure"
 	"github.com/openshift/openshift-azure/test/util/log"
 )
 
+// rpFocus represents the supported RP APIs which e2e tests use to create their azure clients,
+// The client will be configured to work either against the real, fake or admin apis
+type rpFocus string
+
+var (
+	fakeRpFocus = rpFocus(regexp.QuoteMeta("[Fake]"))
+	realRpFocus = rpFocus(regexp.QuoteMeta("[Real]"))
+)
+
+func (rpf rpFocus) match(focusString string) bool {
+	return strings.Contains(focusString, string(rpf))
+}
+
 var _ = BeforeSuite(func() {
 	var err error
 	testlogger := log.GetTestLogger()
-
-	//so far none of the RealRP tests required the Storage Client
-	azure.RealRPClient, err = azure.NewClientFromEnvironment(context.Background(), testlogger, false, true)
-	testlogger.Debugf("new real rp client: %v", azure.RealRPClient)
-	if err != nil {
-		testlogger.Error(err)
+	focus := config.GinkgoConfig.FocusString
+	switch {
+	case fakeRpFocus.match(focus):
+		fmt.Println("configuring the fake resource provider")
+		err = azure.NewClientFromEnvironment(context.Background(), testlogger, false)
+		if err != nil {
+			testlogger.Error(err)
+		}
+	case realRpFocus.match(focus):
+		fmt.Println("configuring the real resource provider")
+		err = azure.NewClientFromEnvironment(context.Background(), testlogger, true)
+		if err != nil {
+			testlogger.Error(err)
+		}
+	default:
+		panic(fmt.Sprintf("invalid focus %q - need to -ginkgo.focus=\\[Fake\\] or -ginkgo.focus=\\[Real\\]", config.GinkgoConfig.FocusString))
 	}
-	azure.FakeRPClient, err = azure.NewClientFromEnvironment(context.Background(), testlogger, true, false)
-	testlogger.Debugf("new fake rp client: %v", azure.FakeRPClient)
-	if err != nil {
-		testlogger.Error(err)
-	}
-	if azure.RealRPClient == nil && azure.FakeRPClient == nil {
+	if azure.RPClient == nil {
 		testlogger.Error("unable to provision either of the azure clients")
 		panic("No Azure clients")
 	}

--- a/test/e2e/specs/fakerp/admin.go
+++ b/test/e2e/specs/fakerp/admin.go
@@ -57,7 +57,7 @@ var _ = Describe("Openshift on Azure admin e2e tests [Fake][EveryPR]", func() {
 
 	It("should ensure no unnecessary VM rotations occured", func() {
 		Expect(os.Getenv("RESOURCEGROUP")).ToNot(BeEmpty())
-		ubs := updateblob.NewBlobService(azure.FakeRPClient.BlobStorage)
+		ubs := updateblob.NewBlobService(azure.RPClient.BlobStorage)
 
 		By("reading the update blob before running an update")
 		before, err := ubs.Read()
@@ -68,11 +68,11 @@ var _ = Describe("Openshift on Azure admin e2e tests [Fake][EveryPR]", func() {
 		Expect(len(before.ScalesetHashes)).To(Equal(2)) // one per worker scaleset
 
 		By("running an update")
-		external, err := azure.FakeRPClient.OpenShiftManagedClusters.Get(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
+		external, err := azure.RPClient.OpenShiftManagedClusters.Get(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(external).NotTo(BeNil())
 
-		updated, err := azure.FakeRPClient.OpenShiftManagedClusters.CreateOrUpdateAndWait(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"), external)
+		updated, err := azure.RPClient.OpenShiftManagedClusters.CreateOrUpdateAndWait(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"), external)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(updated.StatusCode).To(Equal(http.StatusOK))
 		Expect(updated).NotTo(BeNil())
@@ -88,7 +88,7 @@ var _ = Describe("Openshift on Azure admin e2e tests [Fake][EveryPR]", func() {
 	It("should be possible for an SRE to fetch the RP plugin version", func() {
 		Expect(os.Getenv("RESOURCEGROUP")).ToNot(BeEmpty())
 		By("Using the OSA admin client to fetch the RP plugin version")
-		result, err := azure.FakeRPClient.OpenShiftManagedClustersAdmin.GetPluginVersion(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
+		result, err := azure.RPClient.OpenShiftManagedClustersAdmin.GetPluginVersion(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).NotTo(BeNil())
 		Expect(*result.PluginVersion).NotTo(BeEmpty())

--- a/test/e2e/specs/fakerp/clusterstatus.go
+++ b/test/e2e/specs/fakerp/clusterstatus.go
@@ -12,23 +12,12 @@ import (
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/openshift/openshift-azure/test/clients/azure"
-	"github.com/openshift/openshift-azure/test/util/log"
 )
 
 var _ = Describe("Control Plane Pods Status E2E tests [Fake][EveryPR]", func() {
-	var (
-		cli *azure.Client
-	)
-
-	BeforeEach(func() {
-		var err error
-		cli, err = azure.NewClientFromEnvironment(context.Background(), log.GetTestLogger(), false)
-		Expect(err).NotTo(HaveOccurred())
-	})
-
 	It("should allow an SRE to fetch the status of control plane pods", func() {
 		By("Using the OSA admin client to fetch the raw cluster status")
-		b, err := cli.OpenShiftManagedClustersAdmin.GetControlPlanePods(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
+		b, err := azure.FakeRPClient.OpenShiftManagedClustersAdmin.GetControlPlanePods(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(b).NotTo(BeNil())
 

--- a/test/e2e/specs/fakerp/clusterstatus.go
+++ b/test/e2e/specs/fakerp/clusterstatus.go
@@ -17,7 +17,7 @@ import (
 var _ = Describe("Control Plane Pods Status E2E tests [Fake][EveryPR]", func() {
 	It("should allow an SRE to fetch the status of control plane pods", func() {
 		By("Using the OSA admin client to fetch the raw cluster status")
-		b, err := azure.FakeRPClient.OpenShiftManagedClustersAdmin.GetControlPlanePods(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
+		b, err := azure.RPClient.OpenShiftManagedClustersAdmin.GetControlPlanePods(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(b).NotTo(BeNil())
 

--- a/test/e2e/specs/fakerp/command.go
+++ b/test/e2e/specs/fakerp/command.go
@@ -15,33 +15,21 @@ import (
 	"github.com/openshift/openshift-azure/pkg/util/resourceid"
 	"github.com/openshift/openshift-azure/test/clients/azure"
 	"github.com/openshift/openshift-azure/test/sanity"
-	"github.com/openshift/openshift-azure/test/util/log"
 )
 
 var _ = Describe("Command tests [Command][Fake][LongRunning]", func() {
-	var (
-		azurecli *azure.Client
-	)
-
-	BeforeEach(func() {
-		var err error
-		azurecli, err = azure.NewClientFromEnvironment(context.Background(), log.GetTestLogger(), false)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(azurecli).NotTo(BeNil())
-	})
-
 	It("should be possible for an SRE to restart system services on vms", func() {
 		vm := "master-000000"
 
 		startTime := time.Now()
 
-		err := azurecli.OpenShiftManagedClustersAdmin.RunCommand(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"), vm, "RestartKubelet")
+		err := azure.FakeRPClient.OpenShiftManagedClustersAdmin.RunCommand(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"), vm, "RestartKubelet")
 		Expect(err).NotTo(HaveOccurred())
 
-		err = azurecli.OpenShiftManagedClustersAdmin.RunCommand(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"), vm, "RestartDocker")
+		err = azure.FakeRPClient.OpenShiftManagedClustersAdmin.RunCommand(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"), vm, "RestartDocker")
 		Expect(err).NotTo(HaveOccurred())
 
-		err = azurecli.OpenShiftManagedClustersAdmin.RunCommand(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"), vm, "RestartNetworkManager")
+		err = azure.FakeRPClient.OpenShiftManagedClustersAdmin.RunCommand(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"), vm, "RestartNetworkManager")
 		Expect(err).NotTo(HaveOccurred())
 
 		scaleset, _, err := names.GetScaleSetNameAndInstanceID(vm)
@@ -49,7 +37,7 @@ var _ = Describe("Command tests [Command][Fake][LongRunning]", func() {
 
 		wait.PollImmediate(10*time.Second, 2*time.Minute, func() (bool, error) {
 			By("Verifying through azure activity logs that the command ran")
-			logs, err := azurecli.ActivityLogs.List(
+			logs, err := azure.FakeRPClient.ActivityLogs.List(
 				context.Background(),
 				fmt.Sprintf("eventTimestamp ge '%s' and resourceUri eq %s",
 					startTime.Format(time.RFC3339),

--- a/test/e2e/specs/fakerp/command.go
+++ b/test/e2e/specs/fakerp/command.go
@@ -23,13 +23,13 @@ var _ = Describe("Command tests [Command][Fake][LongRunning]", func() {
 
 		startTime := time.Now()
 
-		err := azure.FakeRPClient.OpenShiftManagedClustersAdmin.RunCommand(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"), vm, "RestartKubelet")
+		err := azure.RPClient.OpenShiftManagedClustersAdmin.RunCommand(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"), vm, "RestartKubelet")
 		Expect(err).NotTo(HaveOccurred())
 
-		err = azure.FakeRPClient.OpenShiftManagedClustersAdmin.RunCommand(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"), vm, "RestartDocker")
+		err = azure.RPClient.OpenShiftManagedClustersAdmin.RunCommand(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"), vm, "RestartDocker")
 		Expect(err).NotTo(HaveOccurred())
 
-		err = azure.FakeRPClient.OpenShiftManagedClustersAdmin.RunCommand(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"), vm, "RestartNetworkManager")
+		err = azure.RPClient.OpenShiftManagedClustersAdmin.RunCommand(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"), vm, "RestartNetworkManager")
 		Expect(err).NotTo(HaveOccurred())
 
 		scaleset, _, err := names.GetScaleSetNameAndInstanceID(vm)
@@ -37,7 +37,7 @@ var _ = Describe("Command tests [Command][Fake][LongRunning]", func() {
 
 		wait.PollImmediate(10*time.Second, 2*time.Minute, func() (bool, error) {
 			By("Verifying through azure activity logs that the command ran")
-			logs, err := azure.FakeRPClient.ActivityLogs.List(
+			logs, err := azure.RPClient.ActivityLogs.List(
 				context.Background(),
 				fmt.Sprintf("eventTimestamp ge '%s' and resourceUri eq %s",
 					startTime.Format(time.RFC3339),

--- a/test/e2e/specs/fakerp/etcdbackuprecovery.go
+++ b/test/e2e/specs/fakerp/etcdbackuprecovery.go
@@ -64,10 +64,10 @@ var _ = Describe("Etcd Recovery E2E tests [EtcdBackupRecovery][Fake][LongRunning
 		Expect(cm1.Data).To(HaveKeyWithValue("value", "before-backup"))
 
 		By(fmt.Sprintf("Running an etcd backup"))
-		err = azure.FakeRPClient.OpenShiftManagedClustersAdmin.Backup(context.Background(), resourceGroup, resourceGroup, backup)
+		err = azure.RPClient.OpenShiftManagedClustersAdmin.Backup(context.Background(), resourceGroup, resourceGroup, backup)
 		Expect(err).NotTo(HaveOccurred())
 
-		backups, err := azure.FakeRPClient.OpenShiftManagedClustersAdmin.ListBackups(context.Background(), resourceGroup, resourceGroup)
+		backups, err := azure.RPClient.OpenShiftManagedClustersAdmin.ListBackups(context.Background(), resourceGroup, resourceGroup)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(backups).To(ContainElement(MatchFields(IgnoreExtras, Fields{"Name": Equal(backup)})))
 
@@ -85,7 +85,7 @@ var _ = Describe("Etcd Recovery E2E tests [EtcdBackupRecovery][Fake][LongRunning
 		Expect(cm2.Data).To(HaveKeyWithValue("value", "after-backup"))
 
 		By("Restore from the backup")
-		err = azure.FakeRPClient.OpenShiftManagedClustersAdmin.Restore(context.Background(), resourceGroup, resourceGroup, backup)
+		err = azure.RPClient.OpenShiftManagedClustersAdmin.Restore(context.Background(), resourceGroup, resourceGroup, backup)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Confirm the state of the backup")

--- a/test/e2e/specs/fakerp/forceupdate.go
+++ b/test/e2e/specs/fakerp/forceupdate.go
@@ -15,7 +15,7 @@ import (
 var _ = Describe("Force Update E2E tests [ForceUpdate][Fake][LongRunning]", func() {
 	It("should be possible for an SRE to force update a cluster", func() {
 		By("Reading the update blob before the force update")
-		ubs := updateblob.NewBlobService(azure.FakeRPClient.BlobStorage)
+		ubs := updateblob.NewBlobService(azure.RPClient.BlobStorage)
 		before, err := ubs.Read()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(before).NotTo(BeNil())
@@ -23,7 +23,7 @@ var _ = Describe("Force Update E2E tests [ForceUpdate][Fake][LongRunning]", func
 		Expect(len(before.ScalesetHashes)).To(Equal(2)) // one per worker scaleset
 
 		By("Executing force update on the cluster.")
-		err = azure.FakeRPClient.OpenShiftManagedClustersAdmin.ForceUpdate(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
+		err = azure.RPClient.OpenShiftManagedClustersAdmin.ForceUpdate(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Reading the update blob after the force update")

--- a/test/e2e/specs/fakerp/forceupdate.go
+++ b/test/e2e/specs/fakerp/forceupdate.go
@@ -10,23 +10,12 @@ import (
 	"github.com/openshift/openshift-azure/pkg/cluster/updateblob"
 	"github.com/openshift/openshift-azure/test/clients/azure"
 	"github.com/openshift/openshift-azure/test/sanity"
-	"github.com/openshift/openshift-azure/test/util/log"
 )
 
 var _ = Describe("Force Update E2E tests [ForceUpdate][Fake][LongRunning]", func() {
-	var (
-		azurecli *azure.Client
-	)
-
-	BeforeEach(func() {
-		var err error
-		azurecli, err = azure.NewClientFromEnvironment(context.Background(), log.GetTestLogger(), true)
-		Expect(err).NotTo(HaveOccurred())
-	})
-
 	It("should be possible for an SRE to force update a cluster", func() {
 		By("Reading the update blob before the force update")
-		ubs := updateblob.NewBlobService(azurecli.BlobStorage)
+		ubs := updateblob.NewBlobService(azure.FakeRPClient.BlobStorage)
 		before, err := ubs.Read()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(before).NotTo(BeNil())
@@ -34,7 +23,7 @@ var _ = Describe("Force Update E2E tests [ForceUpdate][Fake][LongRunning]", func
 		Expect(len(before.ScalesetHashes)).To(Equal(2)) // one per worker scaleset
 
 		By("Executing force update on the cluster.")
-		err = azurecli.OpenShiftManagedClustersAdmin.ForceUpdate(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
+		err = azure.FakeRPClient.OpenShiftManagedClustersAdmin.ForceUpdate(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Reading the update blob after the force update")

--- a/test/e2e/specs/fakerp/keyrotation.go
+++ b/test/e2e/specs/fakerp/keyrotation.go
@@ -14,16 +14,16 @@ import (
 var _ = Describe("Key Rotation E2E tests [KeyRotation][Fake][LongRunning]", func() {
 	It("should be possible to maintain a healthy cluster after rotating all credentials", func() {
 		By("Reading the cluster state")
-		before, err := azure.FakeRPClient.OpenShiftManagedClustersAdmin.Get(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
+		before, err := azure.RPClient.OpenShiftManagedClustersAdmin.Get(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(before).NotTo(BeNil())
 
 		By("Executing key rotation on the cluster.")
-		err = azure.FakeRPClient.OpenShiftManagedClustersAdmin.RotateSecrets(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
+		err = azure.RPClient.OpenShiftManagedClustersAdmin.RotateSecrets(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Reading the cluster state after the update")
-		after, err := azure.FakeRPClient.OpenShiftManagedClustersAdmin.Get(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
+		after, err := azure.RPClient.OpenShiftManagedClustersAdmin.Get(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(after).NotTo(BeNil())
 

--- a/test/e2e/specs/fakerp/keyrotation.go
+++ b/test/e2e/specs/fakerp/keyrotation.go
@@ -9,33 +9,21 @@ import (
 
 	"github.com/openshift/openshift-azure/test/clients/azure"
 	"github.com/openshift/openshift-azure/test/sanity"
-	"github.com/openshift/openshift-azure/test/util/log"
 )
 
 var _ = Describe("Key Rotation E2E tests [KeyRotation][Fake][LongRunning]", func() {
-	var (
-		azurecli *azure.Client
-	)
-
-	BeforeEach(func() {
-		var err error
-		azurecli, err = azure.NewClientFromEnvironment(context.Background(), log.GetTestLogger(), false)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(azurecli).NotTo(BeNil())
-	})
-
 	It("should be possible to maintain a healthy cluster after rotating all credentials", func() {
 		By("Reading the cluster state")
-		before, err := azurecli.OpenShiftManagedClustersAdmin.Get(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
+		before, err := azure.FakeRPClient.OpenShiftManagedClustersAdmin.Get(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(before).NotTo(BeNil())
 
 		By("Executing key rotation on the cluster.")
-		err = azurecli.OpenShiftManagedClustersAdmin.RotateSecrets(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
+		err = azure.FakeRPClient.OpenShiftManagedClustersAdmin.RotateSecrets(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Reading the cluster state after the update")
-		after, err := azurecli.OpenShiftManagedClustersAdmin.Get(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
+		after, err := azure.FakeRPClient.OpenShiftManagedClustersAdmin.Get(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(after).NotTo(BeNil())
 

--- a/test/e2e/specs/fakerp/loglevel.go
+++ b/test/e2e/specs/fakerp/loglevel.go
@@ -11,24 +11,15 @@ import (
 
 	"github.com/openshift/openshift-azure/test/clients/azure"
 	"github.com/openshift/openshift-azure/test/sanity"
-	"github.com/openshift/openshift-azure/test/util/log"
 )
 
 var _ = Describe("Change OpenShift Component Log Level E2E tests [ChangeLogLevel][Fake][LongRunning]", func() {
 	var (
-		azurecli *azure.Client
-		ctx      = context.Background()
+		ctx = context.Background()
 	)
-
-	BeforeEach(func() {
-		var err error
-		azurecli, err = azure.NewClientFromEnvironment(context.Background(), log.GetTestLogger(), true)
-		Expect(err).NotTo(HaveOccurred())
-	})
-
 	It("should be possible for an SRE to update the OpenShift component log level of a cluster", func() {
 		By("Reading the internal config before the log level update")
-		before, err := azurecli.OpenShiftManagedClustersAdmin.Get(ctx, os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
+		before, err := azure.FakeRPClient.OpenShiftManagedClustersAdmin.Get(ctx, os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(before).NotTo(BeNil())
 
@@ -36,12 +27,12 @@ var _ = Describe("Change OpenShift Component Log Level E2E tests [ChangeLogLevel
 		before.Config.ComponentLogLevel.APIServer = to.IntPtr(*before.Config.ComponentLogLevel.APIServer - 2)
 		before.Config.ComponentLogLevel.ControllerManager = to.IntPtr(*before.Config.ComponentLogLevel.ControllerManager - 2)
 		before.Config.ComponentLogLevel.Node = to.IntPtr(*before.Config.ComponentLogLevel.Node - 2)
-		update, err := azurecli.OpenShiftManagedClustersAdmin.CreateOrUpdate(ctx, os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"), before)
+		update, err := azure.FakeRPClient.OpenShiftManagedClustersAdmin.CreateOrUpdate(ctx, os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"), before)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(update).NotTo(BeNil())
 
 		By("Reading the internal config after the log level update")
-		after, err := azurecli.OpenShiftManagedClustersAdmin.Get(ctx, os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
+		after, err := azure.FakeRPClient.OpenShiftManagedClustersAdmin.Get(ctx, os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(after).NotTo(BeNil())
 

--- a/test/e2e/specs/fakerp/loglevel.go
+++ b/test/e2e/specs/fakerp/loglevel.go
@@ -19,7 +19,7 @@ var _ = Describe("Change OpenShift Component Log Level E2E tests [ChangeLogLevel
 	)
 	It("should be possible for an SRE to update the OpenShift component log level of a cluster", func() {
 		By("Reading the internal config before the log level update")
-		before, err := azure.FakeRPClient.OpenShiftManagedClustersAdmin.Get(ctx, os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
+		before, err := azure.RPClient.OpenShiftManagedClustersAdmin.Get(ctx, os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(before).NotTo(BeNil())
 
@@ -27,12 +27,12 @@ var _ = Describe("Change OpenShift Component Log Level E2E tests [ChangeLogLevel
 		before.Config.ComponentLogLevel.APIServer = to.IntPtr(*before.Config.ComponentLogLevel.APIServer - 2)
 		before.Config.ComponentLogLevel.ControllerManager = to.IntPtr(*before.Config.ComponentLogLevel.ControllerManager - 2)
 		before.Config.ComponentLogLevel.Node = to.IntPtr(*before.Config.ComponentLogLevel.Node - 2)
-		update, err := azure.FakeRPClient.OpenShiftManagedClustersAdmin.CreateOrUpdate(ctx, os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"), before)
+		update, err := azure.RPClient.OpenShiftManagedClustersAdmin.CreateOrUpdate(ctx, os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"), before)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(update).NotTo(BeNil())
 
 		By("Reading the internal config after the log level update")
-		after, err := azure.FakeRPClient.OpenShiftManagedClustersAdmin.Get(ctx, os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
+		after, err := azure.RPClient.OpenShiftManagedClustersAdmin.Get(ctx, os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(after).NotTo(BeNil())
 

--- a/test/e2e/specs/fakerp/prometheus.go
+++ b/test/e2e/specs/fakerp/prometheus.go
@@ -33,7 +33,7 @@ type targetsResponse struct {
 	} `json:"data"`
 }
 
-var _ = Describe("Prometheus E2E tests [Fake][EveryPR]", func() {
+var _ = Describe("Prometheus E2E tests [Fake]", func() {
 	It("should register all the necessary prometheus targets", func() {
 		token, err := sanity.Checker.Client.Admin.GetServiceAccountToken("openshift-monitoring", "prometheus-k8s")
 		Expect(err).NotTo(HaveOccurred())
@@ -70,7 +70,7 @@ var _ = Describe("Prometheus E2E tests [Fake][EveryPR]", func() {
 			}
 		}
 
-		cs, err := azure.FakeRPClient.OpenShiftManagedClusters.Get(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
+		cs, err := azure.RPClient.OpenShiftManagedClusters.Get(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
 		Expect(err).NotTo(HaveOccurred())
 
 		nodes, masters := int(*cs.Properties.MasterPoolProfile.Count), int(*cs.Properties.MasterPoolProfile.Count)

--- a/test/e2e/specs/fakerp/prometheus.go
+++ b/test/e2e/specs/fakerp/prometheus.go
@@ -14,7 +14,6 @@ import (
 
 	"github.com/openshift/openshift-azure/test/clients/azure"
 	"github.com/openshift/openshift-azure/test/sanity"
-	"github.com/openshift/openshift-azure/test/util/log"
 )
 
 type target struct {
@@ -34,17 +33,7 @@ type targetsResponse struct {
 	} `json:"data"`
 }
 
-var _ = Describe("Prometheus E2E tests [Fake]", func() {
-	var (
-		azurecli *azure.Client
-	)
-
-	BeforeEach(func() {
-		var err error
-		azurecli, err = azure.NewClientFromEnvironment(context.Background(), log.GetTestLogger(), false)
-		Expect(err).NotTo(HaveOccurred())
-	})
-
+var _ = Describe("Prometheus E2E tests [Fake][EveryPR]", func() {
 	It("should register all the necessary prometheus targets", func() {
 		token, err := sanity.Checker.Client.Admin.GetServiceAccountToken("openshift-monitoring", "prometheus-k8s")
 		Expect(err).NotTo(HaveOccurred())
@@ -81,7 +70,7 @@ var _ = Describe("Prometheus E2E tests [Fake]", func() {
 			}
 		}
 
-		cs, err := azurecli.OpenShiftManagedClusters.Get(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
+		cs, err := azure.FakeRPClient.OpenShiftManagedClusters.Get(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
 		Expect(err).NotTo(HaveOccurred())
 
 		nodes, masters := int(*cs.Properties.MasterPoolProfile.Count), int(*cs.Properties.MasterPoolProfile.Count)

--- a/test/e2e/specs/fakerp/reimagevm.go
+++ b/test/e2e/specs/fakerp/reimagevm.go
@@ -21,19 +21,19 @@ import (
 var _ = Describe("Reimage VM E2E tests [ReimageVM][Fake][LongRunning]", func() {
 	It("should be possible for an SRE to reimage a VM in a scale set", func() {
 		By("Reading the cluster state")
-		before, err := azure.FakeRPClient.OpenShiftManagedClustersAdmin.Get(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
+		before, err := azure.RPClient.OpenShiftManagedClustersAdmin.Get(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(before).NotTo(BeNil())
 
 		By("Executing reimage on a vm in the cluster")
-		vmlist, err := azure.FakeRPClient.OpenShiftManagedClustersAdmin.ListClusterVMs(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
+		vmlist, err := azure.RPClient.OpenShiftManagedClustersAdmin.ListClusterVMs(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(len(*vmlist.VMs)).To(BeNumerically(">=", 6))
 		rand.Seed(time.Now().Unix())
 		vm := (*vmlist.VMs)[rand.Intn(len(*vmlist.VMs))]
 		By(fmt.Sprintf("Reimaging %s", vm))
 		startTime := time.Now()
-		err = azure.FakeRPClient.OpenShiftManagedClustersAdmin.Reimage(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"), vm)
+		err = azure.RPClient.OpenShiftManagedClustersAdmin.Reimage(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"), vm)
 		Expect(err).NotTo(HaveOccurred())
 
 		scaleset, instanceID, err := names.GetScaleSetNameAndInstanceID(vm)
@@ -41,7 +41,7 @@ var _ = Describe("Reimage VM E2E tests [ReimageVM][Fake][LongRunning]", func() {
 
 		wait.PollImmediate(10*time.Second, 2*time.Minute, func() (bool, error) {
 			By("Verifying through azure activity logs that the reimage happened")
-			logs, err := azure.FakeRPClient.ActivityLogs.List(
+			logs, err := azure.RPClient.ActivityLogs.List(
 				context.Background(),
 				fmt.Sprintf("eventTimestamp ge '%s' and resourceUri eq %s",
 					startTime.Format(time.RFC3339),

--- a/test/e2e/specs/fakerp/setcontainerimage.go
+++ b/test/e2e/specs/fakerp/setcontainerimage.go
@@ -16,21 +16,12 @@ import (
 	pluginapi "github.com/openshift/openshift-azure/pkg/api/plugin"
 	"github.com/openshift/openshift-azure/test/clients/azure"
 	"github.com/openshift/openshift-azure/test/sanity"
-	"github.com/openshift/openshift-azure/test/util/log"
 )
 
 var _ = Describe("Change a single image to latest E2E tests [ChangeImage][Fake][LongRunning]", func() {
 	var (
-		azurecli *azure.Client
-		ctx      = context.Background()
+		ctx = context.Background()
 	)
-
-	BeforeEach(func() {
-		var err error
-		azurecli, err = azure.NewClientFromEnvironment(context.Background(), log.GetTestLogger(), false)
-		Expect(err).NotTo(HaveOccurred())
-	})
-
 	It("should be possible for an SRE to update a single container image", func() {
 		By("Executing a cluster update with updated image.")
 		data, err := ioutil.ReadFile("../../pluginconfig/pluginconfig-311.yaml")
@@ -47,7 +38,7 @@ var _ = Describe("Change a single image to latest E2E tests [ChangeImage][Fake][
 			},
 		}
 
-		update, err := azurecli.OpenShiftManagedClustersAdmin.CreateOrUpdate(ctx, os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"), &before)
+		update, err := azure.FakeRPClient.OpenShiftManagedClustersAdmin.CreateOrUpdate(ctx, os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"), &before)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(update).NotTo(BeNil())
 

--- a/test/e2e/specs/fakerp/setcontainerimage.go
+++ b/test/e2e/specs/fakerp/setcontainerimage.go
@@ -38,7 +38,7 @@ var _ = Describe("Change a single image to latest E2E tests [ChangeImage][Fake][
 			},
 		}
 
-		update, err := azure.FakeRPClient.OpenShiftManagedClustersAdmin.CreateOrUpdate(ctx, os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"), &before)
+		update, err := azure.RPClient.OpenShiftManagedClustersAdmin.CreateOrUpdate(ctx, os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"), &before)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(update).NotTo(BeNil())
 

--- a/test/e2e/specs/realrp/realrp.go
+++ b/test/e2e/specs/realrp/realrp.go
@@ -40,22 +40,22 @@ var _ = Describe("Resource provider e2e tests [Default][Real]", func() {
 		Expect(err).ToNot(HaveOccurred())
 		deployCtx, cancelFn := context.WithTimeout(context.Background(), 30*time.Minute)
 		defer cancelFn()
-		_, err = azure.RealRPClient.OpenShiftManagedClusters.CreateOrUpdateAndWait(deployCtx, cfg.ResourceGroup, cfg.ResourceGroup, config)
+		_, err = azure.RPClient.OpenShiftManagedClusters.CreateOrUpdateAndWait(deployCtx, cfg.ResourceGroup, cfg.ResourceGroup, config)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
 	It("should keep the end user from deleting any azure resources", func() {
-		resourcegroup, err := azure.RealRPClient.OSAResourceGroup(ctx, cfg.ResourceGroup, cfg.ResourceGroup, cfg.Region)
+		resourcegroup, err := azure.RPClient.OSAResourceGroup(ctx, cfg.ResourceGroup, cfg.ResourceGroup, cfg.Region)
 		Expect(err).NotTo(HaveOccurred())
 		By(fmt.Sprintf("OSA resource group is %s", resourcegroup))
 
-		pages, err := azure.RealRPClient.Resources.ListByResourceGroup(ctx, resourcegroup, "", "", nil)
+		pages, err := azure.RPClient.Resources.ListByResourceGroup(ctx, resourcegroup, "", "", nil)
 		Expect(err).ToNot(HaveOccurred())
 		// attempt to delete all resources in the resourcegroup
 		for pages.NotDone() {
 			for _, v := range pages.Values() {
 				By(fmt.Sprintf("trying to delete %s/%s", *v.Type, *v.Name))
-				_, err := azure.RealRPClient.Resources.DeleteByID(ctx, *v.ID)
+				_, err := azure.RPClient.Resources.DeleteByID(ctx, *v.ID)
 				Expect(err).To(HaveOccurred())
 				Expect(err.Error()).Should(ContainSubstring(`StatusCode=409`))
 			}
@@ -65,16 +65,16 @@ var _ = Describe("Resource provider e2e tests [Default][Real]", func() {
 	})
 
 	It("should keep the end user from reading the config blob", func() {
-		resourcegroup, err := azure.RealRPClient.OSAResourceGroup(ctx, cfg.ResourceGroup, cfg.ResourceGroup, cfg.Region)
+		resourcegroup, err := azure.RPClient.OSAResourceGroup(ctx, cfg.ResourceGroup, cfg.ResourceGroup, cfg.Region)
 		Expect(err).NotTo(HaveOccurred())
 		By(fmt.Sprintf("OSA resource group is %s", resourcegroup))
 
-		accts, err := azure.RealRPClient.Accounts.ListByResourceGroup(ctx, resourcegroup)
+		accts, err := azure.RPClient.Accounts.ListByResourceGroup(ctx, resourcegroup)
 		Expect(err).NotTo(HaveOccurred())
 
 		for _, acct := range *accts.Value {
 			By(fmt.Sprintf("trying to read account %s", *acct.Name))
-			_, err := azure.RealRPClient.Accounts.ListKeys(ctx, resourcegroup, *acct.Name)
+			_, err := azure.RPClient.Accounts.ListKeys(ctx, resourcegroup, *acct.Name)
 			Expect(err).To(HaveOccurred())
 		}
 	})
@@ -84,20 +84,20 @@ var _ = Describe("Resource provider e2e tests [Default][Real]", func() {
 			fakepubkey = "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABAQC7laRyN4B3YZmVrDEZLZoIuUA72pQ0DpGuZBZWykCofIfCPrFZAJgFvonKGgKJl6FGKIunkZL9Us/mV4ZPkZhBlE7uX83AAf5i9Q8FmKpotzmaxN10/1mcnEE7pFvLoSkwqrQSkrrgSm8zaJ3g91giXSbtqvSIj/vk2f05stYmLfhAwNo3Oh27ugCakCoVeuCrZkvHMaJgcYrIGCuFo6q0Pfk9rsZyriIqEa9AtiUOtViInVYdby7y71wcbl0AbbCZsTSqnSoVxm2tRkOsXV6+8X4SnwcmZbao3H+zfO1GBhQOLxJ4NQbzAa8IJh810rYARNLptgmsd4cYXVOSosTX azureuser"
 		)
 
-		resourcegroup, err := azure.RealRPClient.OSAResourceGroup(ctx, cfg.ResourceGroup, cfg.ResourceGroup, cfg.Region)
+		resourcegroup, err := azure.RPClient.OSAResourceGroup(ctx, cfg.ResourceGroup, cfg.ResourceGroup, cfg.Region)
 		Expect(err).NotTo(HaveOccurred())
 		By(fmt.Sprintf("OSA resource group is %s", resourcegroup))
 
-		scaleSets, err := azure.RealRPClient.VirtualMachineScaleSets.List(ctx, resourcegroup)
+		scaleSets, err := azure.RPClient.VirtualMachineScaleSets.List(ctx, resourcegroup)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(scaleSets).Should(HaveLen(3))
 
 		for _, scaleSet := range scaleSets {
-			vms, err := azure.RealRPClient.VirtualMachineScaleSetVMs.List(ctx, resourcegroup, *scaleSet.Name, "", "", "")
+			vms, err := azure.RPClient.VirtualMachineScaleSetVMs.List(ctx, resourcegroup, *scaleSet.Name, "", "", "")
 			Expect(err).NotTo(HaveOccurred())
 
 			By("trying to update the scale set capacity")
-			err = azure.RealRPClient.VirtualMachineScaleSets.Update(ctx, resourcegroup, *scaleSet.Name, compute.VirtualMachineScaleSetUpdate{
+			err = azure.RPClient.VirtualMachineScaleSets.Update(ctx, resourcegroup, *scaleSet.Name, compute.VirtualMachineScaleSetUpdate{
 				Sku: &compute.Sku{
 					Capacity: to.Int64Ptr(int64(len(vms) + 1)),
 				},
@@ -105,7 +105,7 @@ var _ = Describe("Resource provider e2e tests [Default][Real]", func() {
 			Expect(err).To(HaveOccurred())
 
 			By("trying to update the scale set type")
-			err = azure.RealRPClient.VirtualMachineScaleSets.Update(ctx, resourcegroup, *scaleSet.Name, compute.VirtualMachineScaleSetUpdate{
+			err = azure.RPClient.VirtualMachineScaleSets.Update(ctx, resourcegroup, *scaleSet.Name, compute.VirtualMachineScaleSetUpdate{
 				Sku: &compute.Sku{
 					Name: to.StringPtr("Standard_DS1_v2"),
 				},
@@ -113,7 +113,7 @@ var _ = Describe("Resource provider e2e tests [Default][Real]", func() {
 			Expect(err).To(HaveOccurred())
 
 			By("trying to update the scale set SSH key")
-			err = azure.RealRPClient.VirtualMachineScaleSets.Update(ctx, resourcegroup, *scaleSet.Name, compute.VirtualMachineScaleSetUpdate{
+			err = azure.RPClient.VirtualMachineScaleSets.Update(ctx, resourcegroup, *scaleSet.Name, compute.VirtualMachineScaleSetUpdate{
 				VirtualMachineScaleSetUpdateProperties: &compute.VirtualMachineScaleSetUpdateProperties{
 					VirtualMachineProfile: &compute.VirtualMachineScaleSetUpdateVMProfile{
 						OsProfile: &compute.VirtualMachineScaleSetUpdateOSProfile{
@@ -135,7 +135,7 @@ var _ = Describe("Resource provider e2e tests [Default][Real]", func() {
 			Expect(err).To(HaveOccurred())
 
 			By("trying to create scale set script extension")
-			_, err = azure.RealRPClient.VirtualMachineScaleSetExtensions.CreateOrUpdate(ctx, resourcegroup, *scaleSet.Name, "test", compute.VirtualMachineScaleSetExtension{
+			_, err = azure.RPClient.VirtualMachineScaleSetExtensions.CreateOrUpdate(ctx, resourcegroup, *scaleSet.Name, "test", compute.VirtualMachineScaleSetExtension{
 				VirtualMachineScaleSetExtensionProperties: &compute.VirtualMachineScaleSetExtensionProperties{
 					Type:     to.StringPtr("CustomScript"),
 					Settings: `{"fileUris":["https://raw.githubusercontent.com/Azure-Samples/compute-automation-configurations/master/automate_nginx.sh"],"commandToExecute":"./automate_nginx.sh"}`,
@@ -145,7 +145,7 @@ var _ = Describe("Resource provider e2e tests [Default][Real]", func() {
 
 			for _, vm := range vms {
 				By("trying to restart scale set instance vm")
-				err = azure.RealRPClient.VirtualMachineScaleSetVMs.Restart(ctx, resourcegroup, *scaleSet.Name, *vm.InstanceID)
+				err = azure.RPClient.VirtualMachineScaleSetVMs.Restart(ctx, resourcegroup, *scaleSet.Name, *vm.InstanceID)
 				Expect(err).To(HaveOccurred())
 			}
 		}
@@ -156,21 +156,21 @@ var _ = Describe("Resource provider e2e tests [Default][Real]", func() {
 		deleteCtx, cancelFn := context.WithTimeout(context.Background(), time.Hour)
 		defer cancelFn()
 		By("deleting OSA resource")
-		future, err := azure.RealRPClient.OpenShiftManagedClusters.Delete(deleteCtx, cfg.ResourceGroup, cfg.ResourceGroup)
+		future, err := azure.RPClient.OpenShiftManagedClusters.Delete(deleteCtx, cfg.ResourceGroup, cfg.ResourceGroup)
 		Expect(err).NotTo(HaveOccurred())
 		// Avoid failing while waiting for the OSA resource to get cleaned up
 		// since the delete code is not super-stable atm.
-		err = future.WaitForCompletionRef(deleteCtx, azure.RealRPClient.OpenShiftManagedClusters.Client)
+		err = future.WaitForCompletionRef(deleteCtx, azure.RPClient.OpenShiftManagedClusters.Client)
 		if err != nil {
 			fmt.Fprintf(GinkgoWriter, "error while waiting for OSA resource to get cleaned up: %v", err)
 		} else {
-			resp, err := future.Result(azure.RealRPClient.OpenShiftManagedClusters)
+			resp, err := future.Result(azure.RPClient.OpenShiftManagedClusters)
 			Expect(err).NotTo(HaveOccurred())
 			Expect(resp.StatusCode).To(Equal(http.StatusOK))
 		}
 
 		By(fmt.Sprintf("deleting resource group %s", cfg.ResourceGroup))
-		err = azure.RealRPClient.Groups.Delete(deleteCtx, cfg.ResourceGroup)
+		err = azure.RPClient.Groups.Delete(deleteCtx, cfg.ResourceGroup)
 		Expect(err).NotTo(HaveOccurred())
 	})
 })

--- a/test/e2e/specs/realrp/vnetpeering.go
+++ b/test/e2e/specs/realrp/vnetpeering.go
@@ -36,7 +36,7 @@ var _ = Describe("Peer Vnet tests [Vnet][Real][LongRunning]", func() {
 		ctx, cancelFn := context.WithTimeout(context.Background(), 30*time.Minute)
 		defer cancelFn()
 		By(fmt.Sprintf("deleting resource group %s", cfg.ResourceGroup))
-		err := azure.RealRPClient.Groups.Delete(ctx, cfg.ResourceGroup)
+		err := azure.RPClient.Groups.Delete(ctx, cfg.ResourceGroup)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -48,7 +48,7 @@ var _ = Describe("Peer Vnet tests [Vnet][Real][LongRunning]", func() {
 		subnetName := "vnetPeerSubnet"
 		subnetAddressPrefix := "192.168.0.0/24"
 		By("creating a custom vnet")
-		future, err := azure.RealRPClient.VirtualNetworks.CreateOrUpdate(ctx, cfg.ResourceGroup, vnetPeerName, network.VirtualNetwork{
+		future, err := azure.RPClient.VirtualNetworks.CreateOrUpdate(ctx, cfg.ResourceGroup, vnetPeerName, network.VirtualNetwork{
 			VirtualNetworkPropertiesFormat: &network.VirtualNetworkPropertiesFormat{
 				AddressSpace: &network.AddressSpace{
 					AddressPrefixes: &[]string{
@@ -67,11 +67,11 @@ var _ = Describe("Peer Vnet tests [Vnet][Real][LongRunning]", func() {
 			Location: &cfg.Region,
 		})
 		Expect(err).ToNot(HaveOccurred())
-		err = future.WaitForCompletionRef(ctx, azure.RealRPClient.VirtualNetworks.Client())
+		err = future.WaitForCompletionRef(ctx, azure.RPClient.VirtualNetworks.Client())
 		Expect(err).ToNot(HaveOccurred())
 
 		By("setting the custom vnet id in the osa request for peering")
-		vnet, err := azure.RealRPClient.VirtualNetworks.Get(ctx, cfg.ResourceGroup, vnetPeerName, "")
+		vnet, err := azure.RPClient.VirtualNetworks.Get(ctx, cfg.ResourceGroup, vnetPeerName, "")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(len(*vnet.VirtualNetworkPeerings)).To(Equal(0))
 
@@ -85,11 +85,11 @@ var _ = Describe("Peer Vnet tests [Vnet][Real][LongRunning]", func() {
 
 		// create a cluster with the peerVnet
 		By("creating an OSA cluster")
-		_, err = azure.RealRPClient.OpenShiftManagedClusters.CreateOrUpdateAndWait(ctx, cfg.ResourceGroup, cfg.ResourceGroup, config)
+		_, err = azure.RPClient.OpenShiftManagedClusters.CreateOrUpdateAndWait(ctx, cfg.ResourceGroup, cfg.ResourceGroup, config)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("ensuring the OSA cluster vnet is peered with the custom vnet")
-		vnetPeer, err := azure.RealRPClient.VirtualNetworks.Get(ctx, cfg.ResourceGroup, vnetPeerName, "")
+		vnetPeer, err := azure.RPClient.VirtualNetworks.Get(ctx, cfg.ResourceGroup, vnetPeerName, "")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(len(*vnetPeer.VirtualNetworkPeerings)).To(Equal(1))
 		for _, vnetPeering := range *vnetPeer.VirtualNetworkPeerings {

--- a/test/e2e/specs/realrp/vnetpeering.go
+++ b/test/e2e/specs/realrp/vnetpeering.go
@@ -13,22 +13,17 @@ import (
 	v20190430 "github.com/openshift/openshift-azure/pkg/api/2019-04-30"
 	"github.com/openshift/openshift-azure/pkg/fakerp/client"
 	"github.com/openshift/openshift-azure/test/clients/azure"
-	"github.com/openshift/openshift-azure/test/util/log"
 	tlog "github.com/openshift/openshift-azure/test/util/log"
 )
 
 var _ = Describe("Peer Vnet tests [Vnet][Real][LongRunning]", func() {
 	var (
 		cfg          *client.Config
-		cli          *azure.Client
 		vnetPeerName = "vnetPeer"
 	)
 
 	BeforeEach(func() {
 		var err error
-		cli, err = azure.NewClientFromEnvironment(context.Background(), log.GetTestLogger(), false)
-		Expect(err).NotTo(HaveOccurred())
-
 		cfg, err = client.NewConfig(tlog.GetTestLogger())
 		Expect(err).NotTo(HaveOccurred())
 
@@ -41,7 +36,7 @@ var _ = Describe("Peer Vnet tests [Vnet][Real][LongRunning]", func() {
 		ctx, cancelFn := context.WithTimeout(context.Background(), 30*time.Minute)
 		defer cancelFn()
 		By(fmt.Sprintf("deleting resource group %s", cfg.ResourceGroup))
-		err := cli.Groups.Delete(ctx, cfg.ResourceGroup)
+		err := azure.RealRPClient.Groups.Delete(ctx, cfg.ResourceGroup)
 		Expect(err).NotTo(HaveOccurred())
 	})
 
@@ -53,7 +48,7 @@ var _ = Describe("Peer Vnet tests [Vnet][Real][LongRunning]", func() {
 		subnetName := "vnetPeerSubnet"
 		subnetAddressPrefix := "192.168.0.0/24"
 		By("creating a custom vnet")
-		future, err := cli.VirtualNetworks.CreateOrUpdate(ctx, cfg.ResourceGroup, vnetPeerName, network.VirtualNetwork{
+		future, err := azure.RealRPClient.VirtualNetworks.CreateOrUpdate(ctx, cfg.ResourceGroup, vnetPeerName, network.VirtualNetwork{
 			VirtualNetworkPropertiesFormat: &network.VirtualNetworkPropertiesFormat{
 				AddressSpace: &network.AddressSpace{
 					AddressPrefixes: &[]string{
@@ -72,11 +67,11 @@ var _ = Describe("Peer Vnet tests [Vnet][Real][LongRunning]", func() {
 			Location: &cfg.Region,
 		})
 		Expect(err).ToNot(HaveOccurred())
-		err = future.WaitForCompletionRef(ctx, cli.VirtualNetworks.Client())
+		err = future.WaitForCompletionRef(ctx, azure.RealRPClient.VirtualNetworks.Client())
 		Expect(err).ToNot(HaveOccurred())
 
 		By("setting the custom vnet id in the osa request for peering")
-		vnet, err := cli.VirtualNetworks.Get(ctx, cfg.ResourceGroup, vnetPeerName, "")
+		vnet, err := azure.RealRPClient.VirtualNetworks.Get(ctx, cfg.ResourceGroup, vnetPeerName, "")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(len(*vnet.VirtualNetworkPeerings)).To(Equal(0))
 
@@ -90,11 +85,11 @@ var _ = Describe("Peer Vnet tests [Vnet][Real][LongRunning]", func() {
 
 		// create a cluster with the peerVnet
 		By("creating an OSA cluster")
-		_, err = cli.OpenShiftManagedClusters.CreateOrUpdateAndWait(ctx, cfg.ResourceGroup, cfg.ResourceGroup, config)
+		_, err = azure.RealRPClient.OpenShiftManagedClusters.CreateOrUpdateAndWait(ctx, cfg.ResourceGroup, cfg.ResourceGroup, config)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("ensuring the OSA cluster vnet is peered with the custom vnet")
-		vnetPeer, err := cli.VirtualNetworks.Get(ctx, cfg.ResourceGroup, vnetPeerName, "")
+		vnetPeer, err := azure.RealRPClient.VirtualNetworks.Get(ctx, cfg.ResourceGroup, vnetPeerName, "")
 		Expect(err).ToNot(HaveOccurred())
 		Expect(len(*vnetPeer.VirtualNetworkPeerings)).To(Equal(1))
 		for _, vnetPeering := range *vnetPeer.VirtualNetworkPeerings {

--- a/test/e2e/specs/scaleupdown.go
+++ b/test/e2e/specs/scaleupdown.go
@@ -48,13 +48,13 @@ var _ = Describe("Scale Up/Down E2E tests [ScaleUpDown][Fake][EveryPR][LongRunni
 
 	scale := func(ubs updateblob.BlobService, before *updateblob.UpdateBlob, count int64) {
 		By("Fetching the manifest")
-		external, err := azure.FakeRPClient.OpenShiftManagedClusters.Get(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
+		external, err := azure.RPClient.OpenShiftManagedClusters.Get(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
 		Expect(err).NotTo(HaveOccurred())
 		err = setCount(&external, count)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Calling CreateOrUpdate on the rp with the scale up manifest")
-		_, err = azure.FakeRPClient.OpenShiftManagedClusters.CreateOrUpdateAndWait(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"), external)
+		_, err = azure.RPClient.OpenShiftManagedClusters.CreateOrUpdateAndWait(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"), external)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Reading the update blob after the scale up")
@@ -83,7 +83,7 @@ var _ = Describe("Scale Up/Down E2E tests [ScaleUpDown][Fake][EveryPR][LongRunni
 
 	It("should be possible to maintain a healthy cluster after scaling it out and in", func() {
 		By("Reading the update blob before the scales")
-		ubs := updateblob.NewBlobService(azure.FakeRPClient.BlobStorage)
+		ubs := updateblob.NewBlobService(azure.RPClient.BlobStorage)
 		before, err := ubs.Read()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(len(before.HostnameHashes)).To(Equal(3)) // one per master instance

--- a/test/e2e/specs/scaleupdown.go
+++ b/test/e2e/specs/scaleupdown.go
@@ -22,7 +22,6 @@ import (
 	"github.com/openshift/openshift-azure/pkg/util/ready"
 	"github.com/openshift/openshift-azure/test/clients/azure"
 	"github.com/openshift/openshift-azure/test/sanity"
-	"github.com/openshift/openshift-azure/test/util/log"
 )
 
 var _ = Describe("Scale Up/Down E2E tests [ScaleUpDown][Fake][EveryPR][LongRunning]", func() {
@@ -30,16 +29,11 @@ var _ = Describe("Scale Up/Down E2E tests [ScaleUpDown][Fake][EveryPR][LongRunni
 		sampleDeployment = "hello-openshift"
 	)
 	var (
-		azurecli  *azure.Client
 		namespace string
 	)
 
 	BeforeEach(func() {
 		var err error
-		azurecli, err = azure.NewClientFromEnvironment(context.Background(), log.GetTestLogger(), true)
-		Expect(err).NotTo(HaveOccurred())
-		Expect(azurecli).NotTo(BeNil())
-
 		namespace, err = random.LowerCaseAlphanumericString(5)
 		Expect(err).ToNot(HaveOccurred())
 		namespace = "e2e-test-" + namespace
@@ -54,13 +48,13 @@ var _ = Describe("Scale Up/Down E2E tests [ScaleUpDown][Fake][EveryPR][LongRunni
 
 	scale := func(ubs updateblob.BlobService, before *updateblob.UpdateBlob, count int64) {
 		By("Fetching the manifest")
-		external, err := azurecli.OpenShiftManagedClusters.Get(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
+		external, err := azure.FakeRPClient.OpenShiftManagedClusters.Get(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
 		Expect(err).NotTo(HaveOccurred())
 		err = setCount(&external, count)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Calling CreateOrUpdate on the rp with the scale up manifest")
-		_, err = azurecli.OpenShiftManagedClusters.CreateOrUpdateAndWait(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"), external)
+		_, err = azure.FakeRPClient.OpenShiftManagedClusters.CreateOrUpdateAndWait(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"), external)
 		Expect(err).NotTo(HaveOccurred())
 
 		By("Reading the update blob after the scale up")
@@ -89,7 +83,7 @@ var _ = Describe("Scale Up/Down E2E tests [ScaleUpDown][Fake][EveryPR][LongRunni
 
 	It("should be possible to maintain a healthy cluster after scaling it out and in", func() {
 		By("Reading the update blob before the scales")
-		ubs := updateblob.NewBlobService(azurecli.BlobStorage)
+		ubs := updateblob.NewBlobService(azure.FakeRPClient.BlobStorage)
 		before, err := ubs.Read()
 		Expect(err).ToNot(HaveOccurred())
 		Expect(len(before.HostnameHashes)).To(Equal(3)) // one per master instance


### PR DESCRIPTION
```release-note
NONE
```
Moving azure client (fake for now, since real e2e seems broken) to the sanitychecker singleton to keep it from reinitializing at every BeforeEach.
In the end the realRP client should also be in the singleton.