### PR TITLE
use mail attribute instead of userPrincipalName to map groups and users

### DIFF
--- a/pkg/controllers/customeradmin/group_mapping.go
+++ b/pkg/controllers/customeradmin/group_mapping.go
@@ -31,7 +31,7 @@ func fromMSGraphGroup(log *logrus.Entry, kubeGroup *v1.Group, kubeGroupName stri
 	}
 	g.Users = []string{}
 	for _, user := range msGroupMembers {
-		g.Users = append(g.Users, *user.UserPrincipalName)
+		g.Users = append(g.Users, *user.Mail)
 	}
 	sort.Strings(g.Users)
 	return g, !reflect.DeepEqual(kubeGroup, g)

--- a/pkg/controllers/customeradmin/group_mapping_test.go
+++ b/pkg/controllers/customeradmin/group_mapping_test.go
@@ -38,7 +38,7 @@ func TestFromMSGraphGroup(t *testing.T) {
 			kubeGroupName: osaCustomerAdmins,
 			msGroupMembers: []graphrbac.User{
 				{
-					UserPrincipalName: to.StringPtr("foo@somewhere.com"),
+					Mail: to.StringPtr("foo@somewhere.com"),
 				},
 			},
 			want: &v1.Group{
@@ -59,7 +59,7 @@ func TestFromMSGraphGroup(t *testing.T) {
 			},
 			msGroupMembers: []graphrbac.User{
 				{
-					UserPrincipalName: to.StringPtr("foo@somewhere.com"),
+					Mail: to.StringPtr("foo@somewhere.com"),
 				},
 			},
 			want: &v1.Group{
@@ -81,10 +81,10 @@ func TestFromMSGraphGroup(t *testing.T) {
 			},
 			msGroupMembers: []graphrbac.User{
 				{
-					UserPrincipalName: to.StringPtr("foo@somewhere.com"),
+					Mail: to.StringPtr("foo@somewhere.com"),
 				},
 				{
-					UserPrincipalName: to.StringPtr("tim@somewhere.com"),
+					Mail: to.StringPtr("tim@somewhere.com"),
 				},
 			},
 			want: &v1.Group{
@@ -106,7 +106,7 @@ func TestFromMSGraphGroup(t *testing.T) {
 			},
 			msGroupMembers: []graphrbac.User{
 				{
-					UserPrincipalName: to.StringPtr("foo@somewhere.com"),
+					Mail: to.StringPtr("foo@somewhere.com"),
 				},
 			},
 			want: &v1.Group{


### PR DESCRIPTION
otherwise guest AAD user's don't work correctly (get #EXT# and more interposed in username)

```release-note
NONE
```

@asalkeld you were right about this, ptal ;-)