### PR TITLE
Add retry logic to fakerp

### DIFF
--- a/cmd/createorupdate/createorupdate.go
+++ b/cmd/createorupdate/createorupdate.go
@@ -173,7 +173,7 @@ func updateAadApplication(ctx context.Context, oc *v20190430.OpenShiftManagedClu
 			return fmt.Errorf("cannot get authorizer: %v", err)
 		}
 
-		aadClient := azureclient.NewRBACApplicationsClient(ctx, conf.TenantID, graphauthorizer)
+		aadClient := azureclient.NewRBACApplicationsClient(ctx, log, conf.TenantID, graphauthorizer)
 		objID, err := aadapp.GetApplicationObjectIDFromAppID(ctx, aadClient, conf.AADClientID)
 		if err != nil {
 			return err

--- a/cmd/monitoring/monitoring.go
+++ b/cmd/monitoring/monitoring.go
@@ -61,7 +61,7 @@ func (m *monitor) init(ctx context.Context, log *logrus.Entry) error {
 	}
 	m.resourceGroup = os.Getenv("RESOURCEGROUP")
 	m.subscriptionID = os.Getenv("AZURE_SUBSCRIPTION_ID")
-	m.pipcli = azureclient.NewPublicIPAddressesClient(ctx, m.subscriptionID, authorizer)
+	m.pipcli = azureclient.NewPublicIPAddressesClient(ctx, log, m.subscriptionID, authorizer)
 
 	if os.Getenv("AZURE_APP_INSIGHTS_KEY") != "" {
 		m.log.Info("application insights configured")

--- a/cmd/vmimage/vmimage.go
+++ b/cmd/vmimage/vmimage.go
@@ -85,8 +85,8 @@ func run(ctx context.Context, log *logrus.Entry) error {
 	builder := vmimage.Builder{
 		GitCommit:                gitCommit,
 		Log:                      log,
-		Deployments:              azureclient.NewDeploymentsClient(ctx, os.Getenv("AZURE_SUBSCRIPTION_ID"), authorizer),
-		Groups:                   azureclient.NewGroupsClient(ctx, os.Getenv("AZURE_SUBSCRIPTION_ID"), authorizer),
+		Deployments:              azureclient.NewDeploymentsClient(ctx, log, os.Getenv("AZURE_SUBSCRIPTION_ID"), authorizer),
+		Groups:                   azureclient.NewGroupsClient(ctx, log, os.Getenv("AZURE_SUBSCRIPTION_ID"), authorizer),
 		SubscriptionID:           os.Getenv("AZURE_SUBSCRIPTION_ID"),
 		Location:                 *location,
 		BuildResourceGroup:       *buildResourceGroup,

--- a/hack/setup-rbac/main.go
+++ b/hack/setup-rbac/main.go
@@ -2,71 +2,25 @@ package main
 
 import (
 	"context"
-	"fmt"
 	"os"
-	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/authorization/mgmt/2015-07-01/authorization"
 	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/openshift-azure/pkg/fakerp"
 	"github.com/openshift/openshift-azure/pkg/util/azureclient"
 )
 
-// listActions lists all the mutating actions carried out on a resource group in
-// the last 6 hours, along with the principal that carried out the action
-func listActions(ctx context.Context, resourceGroupName string) error {
-	authorizer, err := azureclient.NewAuthorizerFromEnvironment("")
-	if err != nil {
-		return err
-	}
-
-	cli := azureclient.NewActivityLogsClient(ctx, os.Getenv("AZURE_SUBSCRIPTION_ID"), authorizer)
-
-	pages, err := cli.List(ctx,
-		fmt.Sprintf("eventTimestamp ge '%s' and resourceGroupName eq '%s'",
-			time.Now().Add(-6*time.Hour).Format(time.RFC3339),
-			resourceGroupName),
-		"")
-	if err != nil {
-		return err
-	}
-
-	m := map[string]map[string]struct{}{}
-
-	for pages.NotDone() {
-		for _, v := range pages.Values() {
-			if m[*v.Caller] == nil {
-				m[*v.Caller] = map[string]struct{}{}
-			}
-			m[*v.Caller][*v.Authorization.Action] = struct{}{}
-		}
-		err = pages.Next()
-		if err != nil {
-			return err
-		}
-	}
-
-	for caller, m := range m {
-		fmt.Printf("*** %s\n", caller)
-		for action := range m {
-			fmt.Printf("    %s\n", action)
-		}
-		fmt.Println()
-	}
-
-	return nil
-}
-
 // ensureRoleDefinitions ensures that the OSA Master and OSA Worker roles are
 // correctly defined in a subscription
-func ensureRoleDefinitions(ctx context.Context) error {
+func ensureRoleDefinitions(ctx context.Context, log *logrus.Entry) error {
 	authorizer, err := azureclient.NewAuthorizerFromEnvironment("")
 	if err != nil {
 		return err
 	}
 
-	cli := azureclient.NewRoleDefinitionsClient(ctx, os.Getenv("AZURE_SUBSCRIPTION_ID"), authorizer)
+	cli := azureclient.NewRoleDefinitionsClient(ctx, log, os.Getenv("AZURE_SUBSCRIPTION_ID"), authorizer)
 
 	_, err = cli.CreateOrUpdate(ctx, "/subscriptions/"+os.Getenv("AZURE_SUBSCRIPTION_ID"), fakerp.OSAMasterRoleDefinitionID, authorization.RoleDefinition{
 		Name: to.StringPtr(fakerp.OSAMasterRoleDefinitionID),
@@ -135,7 +89,7 @@ func ensureRoleDefinitions(ctx context.Context) error {
 }
 
 func main() {
-	if err := ensureRoleDefinitions(context.Background()); err != nil {
+	if err := ensureRoleDefinitions(context.Background(), logrus.NewEntry(logrus.StandardLogger())); err != nil {
 		panic(err)
 	}
 }

--- a/pkg/cluster/types.go
+++ b/pkg/cluster/types.go
@@ -110,10 +110,10 @@ func NewSimpleUpgrader(ctx context.Context, log *logrus.Entry, cs *api.OpenShift
 		Kubeclient: kubeclient,
 
 		testConfig:     testConfig,
-		accountsClient: azureclient.NewAccountsClient(ctx, cs.Properties.AzProfile.SubscriptionID, authorizer),
-		vmc:            azureclient.NewVirtualMachineScaleSetVMsClient(ctx, cs.Properties.AzProfile.SubscriptionID, authorizer),
-		ssc:            azureclient.NewVirtualMachineScaleSetsClient(ctx, cs.Properties.AzProfile.SubscriptionID, authorizer),
-		kvc:            azureclient.NewKeyVaultClient(ctx, vaultauthorizer),
+		accountsClient: azureclient.NewAccountsClient(ctx, log, cs.Properties.AzProfile.SubscriptionID, authorizer),
+		vmc:            azureclient.NewVirtualMachineScaleSetVMsClient(ctx, log, cs.Properties.AzProfile.SubscriptionID, authorizer),
+		ssc:            azureclient.NewVirtualMachineScaleSetsClient(ctx, log, cs.Properties.AzProfile.SubscriptionID, authorizer),
+		kvc:            azureclient.NewKeyVaultClient(ctx, log, vaultauthorizer),
 		log:            log,
 		scalerFactory:  scaler.NewFactory(),
 		hasher: &hasher{

--- a/pkg/controllers/customeradmin/group_controller.go
+++ b/pkg/controllers/customeradmin/group_controller.go
@@ -46,7 +46,7 @@ func addGroupController(ctx context.Context, log *logrus.Entry, m manager.Manage
 
 	r.userV1 = userv1client.NewForConfigOrDie(m.GetConfig())
 
-	r.aadClient, err = newAADGroupsClient(ctx, r.config)
+	r.aadClient, err = newAADGroupsClient(ctx, log, r.config)
 	if err != nil {
 		return err
 	}

--- a/pkg/controllers/customeradmin/group_mapping.go
+++ b/pkg/controllers/customeradmin/group_mapping.go
@@ -41,13 +41,13 @@ func fromMSGraphGroup(log *logrus.Entry, kubeGroup *v1.Group, kubeGroupName stri
 	return g, !reflect.DeepEqual(kubeGroup, g)
 }
 
-func newAADGroupsClient(ctx context.Context, config api.AADIdentityProvider) (azureclient.RBACGroupsClient, error) {
+func newAADGroupsClient(ctx context.Context, log *logrus.Entry, config api.AADIdentityProvider) (azureclient.RBACGroupsClient, error) {
 	graphauthorizer, err := azureclient.NewAuthorizer(config.ClientID, config.Secret, config.TenantID, azure.PublicCloud.GraphEndpoint)
 	if err != nil {
 		return nil, err
 	}
 
-	return azureclient.NewRBACGroupsClient(ctx, config.TenantID, graphauthorizer), nil
+	return azureclient.NewRBACGroupsClient(ctx, log, config.TenantID, graphauthorizer), nil
 }
 
 func getAADGroupMembers(gc azureclient.RBACGroupsClient, groupID string) ([]graphrbac.User, error) {

--- a/pkg/entrypoint/etcdbackup/etcdbackup.go
+++ b/pkg/entrypoint/etcdbackup/etcdbackup.go
@@ -50,7 +50,7 @@ func start(cfg *Config) error {
 		return fmt.Errorf("could not read azure.conf %v", err)
 	}
 
-	bsc, err := configblob.GetService(ctx, cpc)
+	bsc, err := configblob.GetService(ctx, log, cpc)
 	if err != nil {
 		return fmt.Errorf("could not find storage account %v", err)
 	}

--- a/pkg/entrypoint/sync/sync.go
+++ b/pkg/entrypoint/sync/sync.go
@@ -37,16 +37,16 @@ func start(cfg *Config) error {
 		return err
 	}
 
-	azs := azureclient.NewAccountsClient(ctx, cpc.SubscriptionID, authorizer)
+	azs := azureclient.NewAccountsClient(ctx, log, cpc.SubscriptionID, authorizer)
 
 	vaultauthorizer, err := azureclient.NewAuthorizer(cpc.AadClientID, cpc.AadClientSecret, cpc.TenantID, azureclient.KeyVaultEndpoint)
 	if err != nil {
 		return err
 	}
 
-	kvc := azureclient.NewKeyVaultClient(ctx, vaultauthorizer)
+	kvc := azureclient.NewKeyVaultClient(ctx, log, vaultauthorizer)
 
-	bsc, err := configblob.GetService(ctx, cpc)
+	bsc, err := configblob.GetService(ctx, log, cpc)
 	if err != nil {
 		return err
 	}

--- a/pkg/fakerp/aad.go
+++ b/pkg/fakerp/aad.go
@@ -12,6 +12,7 @@ import (
 	"github.com/Azure/go-autorest/autorest/date"
 	"github.com/Azure/go-autorest/autorest/to"
 	uuid "github.com/satori/go.uuid"
+	"github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/util/wait"
 
 	"github.com/openshift/openshift-azure/pkg/api"
@@ -32,7 +33,7 @@ type aadManager struct {
 	cs  *api.OpenShiftManagedCluster
 }
 
-func newAADManager(ctx context.Context, cs *api.OpenShiftManagedCluster) (*aadManager, error) {
+func newAADManager(ctx context.Context, log *logrus.Entry, cs *api.OpenShiftManagedCluster) (*aadManager, error) {
 	authorizer, err := azureclient.NewAuthorizerFromEnvironment("")
 	if err != nil {
 		return nil, err
@@ -44,9 +45,9 @@ func newAADManager(ctx context.Context, cs *api.OpenShiftManagedCluster) (*aadMa
 	}
 
 	return &aadManager{
-		ac:  azureclient.NewRBACApplicationsClient(ctx, cs.Properties.AzProfile.TenantID, graphauthorizer),
-		sc:  azureclient.NewServicePrincipalsClient(ctx, cs.Properties.AzProfile.TenantID, graphauthorizer),
-		rac: azureclient.NewRoleAssignmentsClient(ctx, cs.Properties.AzProfile.SubscriptionID, authorizer),
+		ac:  azureclient.NewRBACApplicationsClient(ctx, log, cs.Properties.AzProfile.TenantID, graphauthorizer),
+		sc:  azureclient.NewServicePrincipalsClient(ctx, log, cs.Properties.AzProfile.TenantID, graphauthorizer),
+		rac: azureclient.NewRoleAssignmentsClient(ctx, log, cs.Properties.AzProfile.SubscriptionID, authorizer),
 		cs:  cs,
 	}, nil
 }

--- a/pkg/fakerp/customer_handlers.go
+++ b/pkg/fakerp/customer_handlers.go
@@ -37,7 +37,7 @@ func (s *Server) handleDelete(w http.ResponseWriter, req *http.Request) {
 	gc := resources.NewGroupsClient(os.Getenv("AZURE_SUBSCRIPTION_ID"))
 	gc.Authorizer = authorizer
 
-	am, err := newAADManager(req.Context(), cs)
+	am, err := newAADManager(req.Context(), s.log, cs)
 	if err != nil {
 		s.badRequest(w, fmt.Sprintf("Failed to delete service principals: %v", err))
 		return
@@ -52,7 +52,7 @@ func (s *Server) handleDelete(w http.ResponseWriter, req *http.Request) {
 
 	// delete dns records
 	// TODO: get resource group from request path
-	dm, err := newDNSManager(req.Context(), os.Getenv("AZURE_SUBSCRIPTION_ID"), os.Getenv("DNS_RESOURCEGROUP"), os.Getenv("DNS_DOMAIN"))
+	dm, err := newDNSManager(req.Context(), s.log, os.Getenv("AZURE_SUBSCRIPTION_ID"), os.Getenv("DNS_RESOURCEGROUP"), os.Getenv("DNS_DOMAIN"))
 	if err != nil {
 		s.badRequest(w, fmt.Sprintf("Failed to delete dns records: %v", err))
 		return

--- a/pkg/fakerp/dns.go
+++ b/pkg/fakerp/dns.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/dns/mgmt/2017-10-01/dns"
 	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/openshift-azure/pkg/api"
 	"github.com/openshift/openshift-azure/pkg/util/azureclient"
@@ -18,15 +19,15 @@ type dnsManager struct {
 	dnsDomain        string
 }
 
-func newDNSManager(ctx context.Context, subscriptionID, dnsResourceGroup, dnsDomain string) (*dnsManager, error) {
+func newDNSManager(ctx context.Context, log *logrus.Entry, subscriptionID, dnsResourceGroup, dnsDomain string) (*dnsManager, error) {
 	authorizer, err := azureclient.GetAuthorizerFromContext(ctx, api.ContextKeyClientAuthorizer)
 	if err != nil {
 		return nil, err
 	}
 
 	return &dnsManager{
-		zc:               azureclient.NewZonesClient(ctx, subscriptionID, authorizer),
-		rsc:              azureclient.NewRecordSetsClient(ctx, subscriptionID, authorizer),
+		zc:               azureclient.NewZonesClient(ctx, log, subscriptionID, authorizer),
+		rsc:              azureclient.NewRecordSetsClient(ctx, log, subscriptionID, authorizer),
 		dnsResourceGroup: dnsResourceGroup,
 		dnsDomain:        dnsDomain,
 	}, nil

--- a/pkg/fakerp/fakerp.go
+++ b/pkg/fakerp/fakerp.go
@@ -31,7 +31,7 @@ func debugDeployerError(ctx context.Context, log *logrus.Entry, cs *api.OpenShif
 		return err
 	}
 
-	deploymentOperations := azureclient.NewDeploymentOperationsClient(ctx, cs.Properties.AzProfile.SubscriptionID, authorizer)
+	deploymentOperations := azureclient.NewDeploymentOperationsClient(ctx, log, cs.Properties.AzProfile.SubscriptionID, authorizer)
 
 	operations, err := deploymentOperations.List(ctx, cs.Properties.AzProfile.ResourceGroup, "azuredeploy", nil)
 	if err != nil {
@@ -50,7 +50,7 @@ func debugDeployerError(ctx context.Context, log *logrus.Entry, cs *api.OpenShif
 		if testConfig.ArtifactDir != "" &&
 			op.Properties.TargetResource != nil &&
 			*op.Properties.TargetResource.ResourceType == "Microsoft.Compute/virtualMachineScaleSets" {
-			s, err := newSSHer(ctx, cs)
+			s, err := newSSHer(ctx, log, cs)
 			if err != nil {
 				log.Warnf("newSSHer failed: %v", err)
 				continue
@@ -103,7 +103,7 @@ func GetDeployer(log *logrus.Entry, cs *api.OpenShiftManagedCluster, testConfig 
 			return err
 		}
 
-		deployments := azureclient.NewDeploymentsClient(ctx, cs.Properties.AzProfile.SubscriptionID, authorizer)
+		deployments := azureclient.NewDeploymentsClient(ctx, log, cs.Properties.AzProfile.SubscriptionID, authorizer)
 		future, err := deployments.CreateOrUpdate(ctx, cs.Properties.AzProfile.ResourceGroup, "azuredeploy", resources.Deployment{
 			Properties: &resources.DeploymentProperties{
 				Template: azuretemplate,
@@ -162,7 +162,7 @@ func createOrUpdate(ctx context.Context, p api.Plugin, log *logrus.Entry, cs, ol
 		cs.Config.PluginVersion = "latest"
 	}
 
-	am, err := newAADManager(ctx, cs)
+	am, err := newAADManager(ctx, log, cs)
 	if err != nil {
 		return nil, err
 	}
@@ -173,7 +173,7 @@ func createOrUpdate(ctx context.Context, p api.Plugin, log *logrus.Entry, cs, ol
 		return nil, err
 	}
 
-	dm, err := newDNSManager(ctx, os.Getenv("AZURE_SUBSCRIPTION_ID"), os.Getenv("DNS_RESOURCEGROUP"), os.Getenv("DNS_DOMAIN"))
+	dm, err := newDNSManager(ctx, log, os.Getenv("AZURE_SUBSCRIPTION_ID"), os.Getenv("DNS_RESOURCEGROUP"), os.Getenv("DNS_DOMAIN"))
 	if err != nil {
 		return nil, err
 	}
@@ -184,7 +184,7 @@ func createOrUpdate(ctx context.Context, p api.Plugin, log *logrus.Entry, cs, ol
 		return nil, err
 	}
 
-	vm, err := newVaultManager(ctx, os.Getenv("AZURE_SUBSCRIPTION_ID"))
+	vm, err := newVaultManager(ctx, log, os.Getenv("AZURE_SUBSCRIPTION_ID"))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/fakerp/ssh.go
+++ b/pkg/fakerp/ssh.go
@@ -9,6 +9,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/sirupsen/logrus"
 	"golang.org/x/crypto/ssh"
 
 	"github.com/openshift/openshift-azure/pkg/api"
@@ -22,14 +23,14 @@ type ssher struct {
 	masterIPs []string
 }
 
-func newSSHer(ctx context.Context, cs *api.OpenShiftManagedCluster) (*ssher, error) {
+func newSSHer(ctx context.Context, log *logrus.Entry, cs *api.OpenShiftManagedCluster) (*ssher, error) {
 	authorizer, err := azureclient.GetAuthorizerFromContext(ctx, api.ContextKeyClientAuthorizer)
 	if err != nil {
 		return nil, err
 	}
 
 	s := &ssher{
-		pipcli: azureclient.NewPublicIPAddressesClient(ctx, cs.Properties.AzProfile.SubscriptionID, authorizer),
+		pipcli: azureclient.NewPublicIPAddressesClient(ctx, log, cs.Properties.AzProfile.SubscriptionID, authorizer),
 		cs:     cs,
 	}
 

--- a/pkg/fakerp/vault.go
+++ b/pkg/fakerp/vault.go
@@ -35,7 +35,7 @@ type vaultManager struct {
 	kvc azureclient.KeyVaultClient
 }
 
-func newVaultManager(ctx context.Context, subscriptionID string) (*vaultManager, error) {
+func newVaultManager(ctx context.Context, log *logrus.Entry, subscriptionID string) (*vaultManager, error) {
 	authorizer, err := azureclient.GetAuthorizerFromContext(ctx, api.ContextKeyClientAuthorizer)
 	if err != nil {
 		return nil, err
@@ -52,9 +52,9 @@ func newVaultManager(ctx context.Context, subscriptionID string) (*vaultManager,
 	}
 
 	return &vaultManager{
-		vc:  azureclient.NewVaultMgmtClient(ctx, os.Getenv("AZURE_SUBSCRIPTION_ID"), authorizer),
-		spc: azureclient.NewServicePrincipalsClient(ctx, os.Getenv("AZURE_TENANT_ID"), graphauthorizer),
-		kvc: azureclient.NewKeyVaultClient(ctx, vaultauthorizer),
+		vc:  azureclient.NewVaultMgmtClient(ctx, log, os.Getenv("AZURE_SUBSCRIPTION_ID"), authorizer),
+		spc: azureclient.NewServicePrincipalsClient(ctx, log, os.Getenv("AZURE_TENANT_ID"), graphauthorizer),
+		kvc: azureclient.NewKeyVaultClient(ctx, log, vaultauthorizer),
 	}, nil
 }
 

--- a/pkg/startup/v3/startup.go
+++ b/pkg/startup/v3/startup.go
@@ -63,7 +63,7 @@ func (s *startup) WriteFiles(ctx context.Context) error {
 			return err
 		}
 
-		kvc := azureclient.NewKeyVaultClient(ctx, vaultauthorizer)
+		kvc := azureclient.NewKeyVaultClient(ctx, s.log, vaultauthorizer)
 
 		s.log.Info("enriching config")
 		err = enrich.CertificatesFromVault(ctx, kvc, s.cs)

--- a/pkg/startup/v4/startup.go
+++ b/pkg/startup/v4/startup.go
@@ -62,7 +62,7 @@ func (s *startup) WriteFiles(ctx context.Context) error {
 			return err
 		}
 
-		kvc := azureclient.NewKeyVaultClient(ctx, vaultauthorizer)
+		kvc := azureclient.NewKeyVaultClient(ctx, s.log, vaultauthorizer)
 
 		s.log.Info("enriching config")
 		err = enrich.CertificatesFromVault(ctx, kvc, s.cs)

--- a/pkg/startup/v5/startup.go
+++ b/pkg/startup/v5/startup.go
@@ -62,7 +62,7 @@ func (s *startup) WriteFiles(ctx context.Context) error {
 			return err
 		}
 
-		kvc := azureclient.NewKeyVaultClient(ctx, vaultauthorizer)
+		kvc := azureclient.NewKeyVaultClient(ctx, s.log, vaultauthorizer)
 
 		s.log.Info("enriching config")
 		err = enrich.CertificatesFromVault(ctx, kvc, s.cs)

--- a/pkg/util/azureclient/authorization.go
+++ b/pkg/util/azureclient/authorization.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/authorization/mgmt/2015-07-01/authorization"
 	"github.com/Azure/go-autorest/autorest"
+	"github.com/sirupsen/logrus"
 )
 
 type RoleAssignmentsClient interface {
@@ -18,9 +19,9 @@ type roleAssignmentsClient struct {
 var _ RoleAssignmentsClient = &roleAssignmentsClient{}
 
 // NewRoleAssignmentsClient creates a new RoleAssignmentsClient
-func NewRoleAssignmentsClient(ctx context.Context, subscriptionID string, authorizer autorest.Authorizer) RoleAssignmentsClient {
+func NewRoleAssignmentsClient(ctx context.Context, log *logrus.Entry, subscriptionID string, authorizer autorest.Authorizer) RoleAssignmentsClient {
 	client := authorization.NewRoleAssignmentsClient(subscriptionID)
-	setupClient(ctx, &client.Client, authorizer)
+	setupClient(ctx, log, "authorization.RoleAssignmentsClient", &client.Client, authorizer)
 
 	return &roleAssignmentsClient{
 		RoleAssignmentsClient: client,
@@ -38,9 +39,9 @@ type roleDefinitionsClient struct {
 var _ RoleDefinitionsClient = &roleDefinitionsClient{}
 
 // NewRoleDefinitionsClient creates a new RoleDefinitionsClient
-func NewRoleDefinitionsClient(ctx context.Context, subscriptionID string, authorizer autorest.Authorizer) RoleDefinitionsClient {
+func NewRoleDefinitionsClient(ctx context.Context, log *logrus.Entry, subscriptionID string, authorizer autorest.Authorizer) RoleDefinitionsClient {
 	client := authorization.NewRoleDefinitionsClient(subscriptionID)
-	setupClient(ctx, &client.Client, authorizer)
+	setupClient(ctx, log, "authorization.RoleDefinitionsClient", &client.Client, authorizer)
 
 	return &roleDefinitionsClient{
 		RoleDefinitionsClient: client,

--- a/pkg/util/azureclient/compute.go
+++ b/pkg/util/azureclient/compute.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
 	"github.com/Azure/go-autorest/autorest"
+	"github.com/sirupsen/logrus"
 )
 
 // VirtualMachineScaleSetsClient is a minimal interface for azure VirtualMachineScaleSetsClient
@@ -21,9 +22,9 @@ type virtualMachineScaleSetsClient struct {
 var _ VirtualMachineScaleSetsClient = &virtualMachineScaleSetsClient{}
 
 // NewVirtualMachineScaleSetsClient creates a new VirtualMachineScaleSetsClient
-func NewVirtualMachineScaleSetsClient(ctx context.Context, subscriptionID string, authorizer autorest.Authorizer) VirtualMachineScaleSetsClient {
+func NewVirtualMachineScaleSetsClient(ctx context.Context, log *logrus.Entry, subscriptionID string, authorizer autorest.Authorizer) VirtualMachineScaleSetsClient {
 	client := compute.NewVirtualMachineScaleSetsClient(subscriptionID)
-	setupClient(ctx, &client.Client, authorizer)
+	setupClient(ctx, log, "compute.VirtualMachineScaleSetsClient", &client.Client, authorizer)
 	client.PollingDuration = 30 * time.Minute
 
 	return &virtualMachineScaleSetsClient{
@@ -47,9 +48,9 @@ type virtualMachineScaleSetVMsClient struct {
 var _ VirtualMachineScaleSetVMsClient = &virtualMachineScaleSetVMsClient{}
 
 // NewVirtualMachineScaleSetVMsClient creates a new VirtualMachineScaleSetVMsClient
-func NewVirtualMachineScaleSetVMsClient(ctx context.Context, subscriptionID string, authorizer autorest.Authorizer) VirtualMachineScaleSetVMsClient {
+func NewVirtualMachineScaleSetVMsClient(ctx context.Context, log *logrus.Entry, subscriptionID string, authorizer autorest.Authorizer) VirtualMachineScaleSetVMsClient {
 	client := compute.NewVirtualMachineScaleSetVMsClient(subscriptionID)
-	setupClient(ctx, &client.Client, authorizer)
+	setupClient(ctx, log, "compute.VirtualMachineScaleSetVMsClient", &client.Client, authorizer)
 	client.PollingDuration = 30 * time.Minute
 
 	return &virtualMachineScaleSetVMsClient{
@@ -76,9 +77,9 @@ type virtualMachineScaleSetExtensionsClient struct {
 var _ VirtualMachineScaleSetExtensionsClient = &virtualMachineScaleSetExtensionsClient{}
 
 // NewVirtualMachineScaleSetExtensionsClient creates a new VirtualMachineScaleSetExtensionsClient
-func NewVirtualMachineScaleSetExtensionsClient(ctx context.Context, subscriptionID string, authorizer autorest.Authorizer) VirtualMachineScaleSetExtensionsClient {
+func NewVirtualMachineScaleSetExtensionsClient(ctx context.Context, log *logrus.Entry, subscriptionID string, authorizer autorest.Authorizer) VirtualMachineScaleSetExtensionsClient {
 	client := compute.NewVirtualMachineScaleSetExtensionsClient(subscriptionID)
-	setupClient(ctx, &client.Client, authorizer)
+	setupClient(ctx, log, "compute.VirtualMachineScaleSetExtensionsClient", &client.Client, authorizer)
 
 	return &virtualMachineScaleSetExtensionsClient{
 		VirtualMachineScaleSetExtensionsClient: client,

--- a/pkg/util/azureclient/dns.go
+++ b/pkg/util/azureclient/dns.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/dns/mgmt/2017-10-01/dns"
 	"github.com/Azure/go-autorest/autorest"
+	"github.com/sirupsen/logrus"
 )
 
 // ZonesClient is a minimal interface for azure ZonesClient
@@ -20,9 +21,9 @@ type zonesClient struct {
 var _ ZonesClient = &zonesClient{}
 
 // NewZonesClient creates a new ZonesClient
-func NewZonesClient(ctx context.Context, subscriptionID string, authorizer autorest.Authorizer) ZonesClient {
+func NewZonesClient(ctx context.Context, log *logrus.Entry, subscriptionID string, authorizer autorest.Authorizer) ZonesClient {
 	client := dns.NewZonesClient(subscriptionID)
-	setupClient(ctx, &client.Client, authorizer)
+	setupClient(ctx, log, "dns.ZonesClient", &client.Client, authorizer)
 
 	return &zonesClient{
 		ZonesClient: client,
@@ -43,9 +44,9 @@ type recordSetsClient struct {
 var _ RecordSetsClient = &recordSetsClient{}
 
 // NewRecordSetsClient creates a new RecordSetsClient
-func NewRecordSetsClient(ctx context.Context, subscriptionID string, authorizer autorest.Authorizer) RecordSetsClient {
+func NewRecordSetsClient(ctx context.Context, log *logrus.Entry, subscriptionID string, authorizer autorest.Authorizer) RecordSetsClient {
 	client := dns.NewRecordSetsClient(subscriptionID)
-	setupClient(ctx, &client.Client, authorizer)
+	setupClient(ctx, log, "dns.RecordSetsClient", &client.Client, authorizer)
 
 	return &recordSetsClient{
 		RecordSetsClient: client,

--- a/pkg/util/azureclient/graphrbac.go
+++ b/pkg/util/azureclient/graphrbac.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/graphrbac/1.6/graphrbac"
 	"github.com/Azure/go-autorest/autorest"
+	"github.com/sirupsen/logrus"
 )
 
 // RBACApplicationsClient is a minimal interface for azure ApplicationsClient
@@ -22,9 +23,9 @@ type rbacApplicationsClient struct {
 var _ RBACApplicationsClient = &rbacApplicationsClient{}
 
 // NewRBACApplicationsClient creates a new ApplicationsClient
-func NewRBACApplicationsClient(ctx context.Context, tenantID string, authorizer autorest.Authorizer) RBACApplicationsClient {
+func NewRBACApplicationsClient(ctx context.Context, log *logrus.Entry, tenantID string, authorizer autorest.Authorizer) RBACApplicationsClient {
 	client := graphrbac.NewApplicationsClient(tenantID)
-	setupClient(ctx, &client.Client, authorizer)
+	setupClient(ctx, log, "graphrbac.ApplicationsClient", &client.Client, authorizer)
 
 	return &rbacApplicationsClient{
 		ApplicationsClient: client,
@@ -43,9 +44,9 @@ type rbacGroupsClient struct {
 var _ RBACGroupsClient = &rbacGroupsClient{}
 
 // NewRBACApplicationsClient creates a new ApplicationsClient
-func NewRBACGroupsClient(ctx context.Context, tenantID string, authorizer autorest.Authorizer) RBACGroupsClient {
+func NewRBACGroupsClient(ctx context.Context, log *logrus.Entry, tenantID string, authorizer autorest.Authorizer) RBACGroupsClient {
 	client := graphrbac.NewGroupsClient(tenantID)
-	setupClient(ctx, &client.Client, authorizer)
+	setupClient(ctx, log, "graphrbac.GroupsClient", &client.Client, authorizer)
 
 	return &rbacGroupsClient{
 		GroupsClient: client,
@@ -64,9 +65,9 @@ type servicePrincipalsClient struct {
 var _ ServicePrincipalsClient = &servicePrincipalsClient{}
 
 // NewServicePrincipalsClient create a client to query ServicePrincipal information
-func NewServicePrincipalsClient(ctx context.Context, tenantID string, authorizer autorest.Authorizer) ServicePrincipalsClient {
+func NewServicePrincipalsClient(ctx context.Context, log *logrus.Entry, tenantID string, authorizer autorest.Authorizer) ServicePrincipalsClient {
 	client := graphrbac.NewServicePrincipalsClient(tenantID)
-	setupClient(ctx, &client.Client, authorizer)
+	setupClient(ctx, log, "graphrbac.ServicePrincipalsClient", &client.Client, authorizer)
 
 	return &servicePrincipalsClient{
 		ServicePrincipalsClient: client,

--- a/pkg/util/azureclient/insights.go
+++ b/pkg/util/azureclient/insights.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/preview/monitor/mgmt/2018-09-01/insights"
 	"github.com/Azure/go-autorest/autorest"
+	"github.com/sirupsen/logrus"
 )
 
 // ActivityLogsClient is a minimal interface for azure ActivityLogsClient
@@ -19,9 +20,9 @@ type activityLogsClient struct {
 var _ ActivityLogsClient = &activityLogsClient{}
 
 // NewActivityLogsClient creates a new ActivityLogsClient
-func NewActivityLogsClient(ctx context.Context, subscriptionID string, authorizer autorest.Authorizer) ActivityLogsClient {
+func NewActivityLogsClient(ctx context.Context, log *logrus.Entry, subscriptionID string, authorizer autorest.Authorizer) ActivityLogsClient {
 	client := insights.NewActivityLogsClient(subscriptionID)
-	setupClient(ctx, &client.Client, authorizer)
+	setupClient(ctx, log, "insights.ActivityLogsClient", &client.Client, authorizer)
 
 	return &activityLogsClient{
 		ActivityLogsClient: client,

--- a/pkg/util/azureclient/keyvault.go
+++ b/pkg/util/azureclient/keyvault.go
@@ -6,6 +6,7 @@ import (
 	"github.com/Azure/azure-sdk-for-go/services/keyvault/2016-10-01/keyvault"
 	mgmtkeyvault "github.com/Azure/azure-sdk-for-go/services/keyvault/mgmt/2016-10-01/keyvault"
 	"github.com/Azure/go-autorest/autorest"
+	"github.com/sirupsen/logrus"
 )
 
 type VaultMgmtClient interface {
@@ -19,9 +20,9 @@ type vaultsMgmtClient struct {
 var _ VaultMgmtClient = &vaultsMgmtClient{}
 
 // NewVaultMgmtClient get a new client for management actions
-func NewVaultMgmtClient(ctx context.Context, subscriptionID string, authorizer autorest.Authorizer) VaultMgmtClient {
+func NewVaultMgmtClient(ctx context.Context, log *logrus.Entry, subscriptionID string, authorizer autorest.Authorizer) VaultMgmtClient {
 	client := mgmtkeyvault.NewVaultsClient(subscriptionID)
-	setupClient(ctx, &client.Client, authorizer)
+	setupClient(ctx, log, "keyvault.VaultsClient", &client.Client, authorizer)
 
 	return &vaultsMgmtClient{
 		VaultsClient: client,
@@ -42,9 +43,9 @@ var _ KeyVaultClient = &keyVaultsClient{}
 // NewKeyVaultClient gets a new client for accessing vault values.  Important:
 // the authorizer supplied must have its resource set to
 // "https://vault.azure.net"
-func NewKeyVaultClient(ctx context.Context, authorizer autorest.Authorizer) KeyVaultClient {
+func NewKeyVaultClient(ctx context.Context, log *logrus.Entry, authorizer autorest.Authorizer) KeyVaultClient {
 	client := keyvault.New()
-	setupClient(ctx, &client.Client, authorizer)
+	setupClient(ctx, log, "keyvault.BaseClient", &client.Client, authorizer)
 
 	return &keyVaultsClient{
 		BaseClient: client,

--- a/pkg/util/azureclient/managedapplications.go
+++ b/pkg/util/azureclient/managedapplications.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/profiles/preview/resources/mgmt/managedapplications"
 	"github.com/Azure/go-autorest/autorest"
+	"github.com/sirupsen/logrus"
 )
 
 // ApplicationsClient is a minimal interface for azure ApplicationsClient
@@ -22,9 +23,9 @@ type applicationsClient struct {
 var _ ApplicationsClient = &applicationsClient{}
 
 // NewApplicationsClient creates a new ApplicationsClient
-func NewApplicationsClient(ctx context.Context, subscriptionID string, authorizer autorest.Authorizer) ApplicationsClient {
+func NewApplicationsClient(ctx context.Context, log *logrus.Entry, subscriptionID string, authorizer autorest.Authorizer) ApplicationsClient {
 	client := managedapplications.NewApplicationsClient(subscriptionID)
-	setupClient(ctx, &client.Client, authorizer)
+	setupClient(ctx, log, "managedapplications.ApplicationsClient", &client.Client, authorizer)
 
 	return &applicationsClient{
 		ApplicationsClient: client,

--- a/pkg/util/azureclient/marketplaceordering.go
+++ b/pkg/util/azureclient/marketplaceordering.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/marketplaceordering/mgmt/2015-06-01/marketplaceordering"
 	"github.com/Azure/go-autorest/autorest"
+	"github.com/sirupsen/logrus"
 )
 
 // MarketPlaceAgreementsClient is a minimal interface for azure MarketPlaceAgreementsClient
@@ -20,9 +21,9 @@ type marketPlaceAgreementsClient struct {
 var _ MarketPlaceAgreementsClient = &marketPlaceAgreementsClient{}
 
 // NewMarketPlaceAgreementsClient creates a new MarketPlaceAgreementsClient
-func NewMarketPlaceAgreementsClient(ctx context.Context, subscriptionID string, authorizer autorest.Authorizer) MarketPlaceAgreementsClient {
+func NewMarketPlaceAgreementsClient(ctx context.Context, log *logrus.Entry, subscriptionID string, authorizer autorest.Authorizer) MarketPlaceAgreementsClient {
 	client := marketplaceordering.NewMarketplaceAgreementsClient(subscriptionID)
-	setupClient(ctx, &client.Client, authorizer)
+	setupClient(ctx, log, "marketplaceordering.MarketplaceAgreementsClient", &client.Client, authorizer)
 
 	return &marketPlaceAgreementsClient{
 		MarketplaceAgreementsClient: client,

--- a/pkg/util/azureclient/network.go
+++ b/pkg/util/azureclient/network.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-06-01/network"
 	"github.com/Azure/go-autorest/autorest"
+	"github.com/sirupsen/logrus"
 )
 
 // VirtualNetworksClient is a minimal interface for azure VirtualNetworkClient
@@ -23,9 +24,9 @@ type virtualNetworksClient struct {
 var _ VirtualNetworksClient = &virtualNetworksClient{}
 
 // NewVirtualNetworkClient creates a new VirtualNetworkClient
-func NewVirtualNetworkClient(ctx context.Context, subscriptionID string, authorizer autorest.Authorizer) VirtualNetworksClient {
+func NewVirtualNetworkClient(ctx context.Context, log *logrus.Entry, subscriptionID string, authorizer autorest.Authorizer) VirtualNetworksClient {
 	client := network.NewVirtualNetworksClient(subscriptionID)
-	setupClient(ctx, &client.Client, authorizer)
+	setupClient(ctx, log, "network.VirtualNetworksClient", &client.Client, authorizer)
 
 	return &virtualNetworksClient{
 		VirtualNetworksClient: client,
@@ -50,9 +51,9 @@ type virtualNetworkPeeringsClient struct {
 var _ VirtualNetworksPeeringsClient = &virtualNetworkPeeringsClient{}
 
 // NewVirtualNetworksPeeringsClient creates a new VirtualMachineScaleSetVMsClient
-func NewVirtualNetworksPeeringsClient(ctx context.Context, subscriptionID string, authorizer autorest.Authorizer) VirtualNetworksPeeringsClient {
+func NewVirtualNetworksPeeringsClient(ctx context.Context, log *logrus.Entry, subscriptionID string, authorizer autorest.Authorizer) VirtualNetworksPeeringsClient {
 	client := network.NewVirtualNetworkPeeringsClient(subscriptionID)
-	setupClient(ctx, &client.Client, authorizer)
+	setupClient(ctx, log, "network.VirtualNetworkPeeringsClient", &client.Client, authorizer)
 
 	return &virtualNetworkPeeringsClient{
 		VirtualNetworkPeeringsClient: client,
@@ -81,9 +82,9 @@ type publicIPAddressesClient struct {
 var _ PublicIPAddressesClient = &publicIPAddressesClient{}
 
 // NewPublicIPAddressesClient creates a new PublicIPAddressesClient
-func NewPublicIPAddressesClient(ctx context.Context, subscriptionID string, authorizer autorest.Authorizer) PublicIPAddressesClient {
+func NewPublicIPAddressesClient(ctx context.Context, log *logrus.Entry, subscriptionID string, authorizer autorest.Authorizer) PublicIPAddressesClient {
 	client := network.NewPublicIPAddressesClient(subscriptionID)
-	setupClient(ctx, &client.Client, authorizer)
+	setupClient(ctx, log, "network.PublicIPAddressesClient", &client.Client, authorizer)
 
 	return &publicIPAddressesClient{
 		PublicIPAddressesClient: client,

--- a/pkg/util/azureclient/resources.go
+++ b/pkg/util/azureclient/resources.go
@@ -6,6 +6,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
 	"github.com/Azure/go-autorest/autorest"
+	"github.com/sirupsen/logrus"
 )
 
 // DeploymentsClient is a minimal interface for azure DeploymentsClient
@@ -21,9 +22,9 @@ type deploymentsClient struct {
 var _ DeploymentsClient = &deploymentsClient{}
 
 // NewDeploymentsClient creates a new DeploymentsClient
-func NewDeploymentsClient(ctx context.Context, subscriptionID string, authorizer autorest.Authorizer) DeploymentsClient {
+func NewDeploymentsClient(ctx context.Context, log *logrus.Entry, subscriptionID string, authorizer autorest.Authorizer) DeploymentsClient {
 	client := resources.NewDeploymentsClient(subscriptionID)
-	setupClient(ctx, &client.Client, authorizer)
+	setupClient(ctx, log, "resources.DeploymentsClient", &client.Client, authorizer)
 	client.PollingDuration = 30 * time.Minute
 
 	return &deploymentsClient{
@@ -47,9 +48,9 @@ type deploymentOperationsClient struct {
 var _ DeploymentOperationsClient = &deploymentOperationsClient{}
 
 // NewDeploymentOperationsClient creates a new DeploymentOperationsClient
-func NewDeploymentOperationsClient(ctx context.Context, subscriptionID string, authorizer autorest.Authorizer) DeploymentOperationsClient {
+func NewDeploymentOperationsClient(ctx context.Context, log *logrus.Entry, subscriptionID string, authorizer autorest.Authorizer) DeploymentOperationsClient {
 	client := resources.NewDeploymentOperationsClient(subscriptionID)
-	setupClient(ctx, &client.Client, authorizer)
+	setupClient(ctx, log, "resources.DeploymentOperationsClient", &client.Client, authorizer)
 
 	return &deploymentOperationsClient{
 		DeploymentOperationsClient: client,
@@ -69,9 +70,9 @@ type resourcesClient struct {
 var _ ResourcesClient = &resourcesClient{}
 
 // NewResourcesClient creates a new ResourcesClient
-func NewResourcesClient(ctx context.Context, subscriptionID string, authorizer autorest.Authorizer) ResourcesClient {
+func NewResourcesClient(ctx context.Context, log *logrus.Entry, subscriptionID string, authorizer autorest.Authorizer) ResourcesClient {
 	client := resources.NewClient(subscriptionID)
-	setupClient(ctx, &client.Client, authorizer)
+	setupClient(ctx, log, "resources.Client", &client.Client, authorizer)
 
 	return &resourcesClient{
 		Client: client,
@@ -93,9 +94,9 @@ type groupsClient struct {
 var _ GroupsClient = &groupsClient{}
 
 // NewGroupsClient creates a new ResourcesClient
-func NewGroupsClient(ctx context.Context, subscriptionID string, authorizer autorest.Authorizer) GroupsClient {
+func NewGroupsClient(ctx context.Context, log *logrus.Entry, subscriptionID string, authorizer autorest.Authorizer) GroupsClient {
 	client := resources.NewGroupsClient(subscriptionID)
-	setupClient(ctx, &client.Client, authorizer)
+	setupClient(ctx, log, "resources.GroupsClient", &client.Client, authorizer)
 
 	return &groupsClient{
 		GroupsClient: client,

--- a/pkg/util/azureclient/retry.go
+++ b/pkg/util/azureclient/retry.go
@@ -1,0 +1,125 @@
+package azureclient
+
+import (
+	"encoding/json"
+	"net/http"
+
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
+	"github.com/Azure/go-autorest/autorest"
+	"github.com/Azure/go-autorest/autorest/azure"
+	"github.com/sirupsen/logrus"
+)
+
+type retryKey struct {
+	clientName string
+	code       string
+}
+
+var retryCodes = map[retryKey]struct{}{
+	// Code="InternalExecutionError" Message="An internal execution error
+	// occurred."
+	{clientName: "compute.VirtualMachineScaleSetsClient", code: "InternalExecutionError"}:   {},
+	{clientName: "compute.VirtualMachineScaleSetVMsClient", code: "InternalExecutionError"}: {},
+
+	// Code="InvalidResourceReference"
+	// Message="Resource
+	// /.../providers/Microsoft.Network/loadBalancers/KUBERNETES-INTERNAL
+	// referenced by resource
+	// /.../providers/Microsoft.Compute/virtualMachineScaleSets/ss-compute-1555464513
+	// was not found. Please make sure that the referenced resource exists, and
+	// that both resources are in the same region."
+	{clientName: "compute.VirtualMachineScaleSetVMsClient", code: "InvalidResourceReference"}: {},
+}
+
+type deploymentRetryKey struct {
+	code           string
+	cloudErrorCode string
+}
+
+var deploymentRetryCodes = map[deploymentRetryKey]struct{}{
+	// Code="DeploymentFailed"
+	// Message="At least one resource deployment operation failed. Please list
+	// deployment operations for details. Please see https://aka.ms/arm-debug
+	// for usage details."
+	// Details=
+	//   code="Conflict"
+	//   message="{"error": {"code": "ResourcePurchaseCanceling",
+	//     "message": "The resource 'ss-infra-1554422008' with the id
+	//     'Microsoft.Compute/virtualMachineScaleSets/ss-infra-1554422008' has a
+	//     previous order being canceled. Please try after some time or create
+	//     resource with different name."}}"
+	{code: "Conflict", cloudErrorCode: "ResourcePurchaseCanceling"}: {},
+
+	// Code="DeploymentFailed"
+	// Message="At least one resource deployment operation failed. Please list
+	// deployment operations for details. Please see https://aka.ms/arm-debug
+	// for usage details."
+	// Details=
+	//   code=InternalServerError
+	//   message="{"error": {"code": "ResourceDeploymentFailure",
+	//     "message": "Encountered internal server error. Diagnostic
+	//     information: timestamp '20190412T193259Z', subscription id '...',
+	//     tracking id '...', request correlation id '...'."}}"
+	{code: "InternalServerError", cloudErrorCode: "ResourceDeploymentFailure"}: {},
+}
+
+type retrySender struct {
+	autorest.Sender
+	log        *logrus.Entry
+	clientName string
+}
+
+func (rs *retrySender) Do(req *http.Request) (resp *http.Response, err error) {
+	retry, retries := 0, 3
+	for {
+		retry++
+
+		resp, err = rs.Sender.Do(req)
+		if err == nil {
+			return
+		}
+
+		if retry <= retries && isRetryableError(rs.clientName, err) {
+			rs.log.Warnf("%s: retry %d", err, retry)
+			continue
+		}
+
+		return
+	}
+}
+
+func isRetryableError(clientName string, err error) bool {
+	re, ok := err.(*azure.RequestError)
+	if !ok || re.ServiceError == nil {
+		return false
+	}
+
+	if _, found := retryCodes[retryKey{clientName: clientName, code: re.ServiceError.Code}]; found {
+		return true
+	}
+
+	if re.ServiceError.Code == "DeploymentFailed" {
+		for _, detail := range re.ServiceError.Details {
+			code, ok := detail["code"].(string)
+			if !ok {
+				continue
+			}
+
+			message, ok := detail["message"].(string)
+			if !ok {
+				continue
+			}
+
+			var ce compute.CloudError
+			if json.Unmarshal([]byte(message), &ce) == nil {
+				if ce.Error != nil && ce.Error.Code != nil {
+					if _, found := deploymentRetryCodes[deploymentRetryKey{code: code, cloudErrorCode: *ce.Error.Code}]; found {
+						return true
+					}
+				}
+			}
+		}
+	}
+
+	return false
+}

--- a/pkg/util/azureclient/storage.go
+++ b/pkg/util/azureclient/storage.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2018-02-01/storage"
 	"github.com/Azure/go-autorest/autorest"
+	"github.com/sirupsen/logrus"
 )
 
 // AccountsClient is a minimal interface for azure AccountsClient
@@ -26,9 +27,9 @@ type accountsClient struct {
 var _ AccountsClient = &accountsClient{}
 
 // NewAccountsClient returns a new AccountsClient
-func NewAccountsClient(ctx context.Context, subscriptionID string, authorizer autorest.Authorizer) AccountsClient {
+func NewAccountsClient(ctx context.Context, log *logrus.Entry, subscriptionID string, authorizer autorest.Authorizer) AccountsClient {
 	client := storage.NewAccountsClient(subscriptionID)
-	setupClient(ctx, &client.Client, authorizer)
+	setupClient(ctx, log, "storage.AccountsClient", &client.Client, authorizer)
 
 	return &accountsClient{
 		AccountsClient: client,

--- a/pkg/util/configblob/container.go
+++ b/pkg/util/configblob/container.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 
 	"github.com/Azure/azure-sdk-for-go/services/storage/mgmt/2018-02-01/storage"
+	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/openshift-azure/pkg/util/azureclient"
 	azureclientstorage "github.com/openshift/openshift-azure/pkg/util/azureclient/storage"
@@ -14,13 +15,13 @@ import (
 // GetService is a helper function called by code running outside of the plugin.
 // It returns the blob storage interface to the storage account containing the
 // config blob, etcd backups, etc.
-func GetService(ctx context.Context, cpc *cloudprovider.Config) (azureclientstorage.BlobStorageClient, error) {
+func GetService(ctx context.Context, log *logrus.Entry, cpc *cloudprovider.Config) (azureclientstorage.BlobStorageClient, error) {
 	authorizer, err := azureclient.NewAuthorizer(cpc.AadClientID, cpc.AadClientSecret, cpc.TenantID, "")
 	if err != nil {
 		return nil, err
 	}
 
-	acctsCli := azureclient.NewAccountsClient(ctx, cpc.SubscriptionID, authorizer)
+	acctsCli := azureclient.NewAccountsClient(ctx, log, cpc.SubscriptionID, authorizer)
 
 	accts, err := acctsCli.ListByResourceGroup(ctx, cpc.ResourceGroup)
 	if err != nil {

--- a/test/clients/azure/client.go
+++ b/test/clients/azure/client.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 
 	"github.com/onsi/ginkgo/config"
+	"github.com/sirupsen/logrus"
 
 	"github.com/openshift/openshift-azure/pkg/fakerp/shared"
 	"github.com/openshift/openshift-azure/pkg/util/azureclient"
@@ -53,7 +54,7 @@ type Client struct {
 // Setting the storage client is optional and should only be used selectively by
 // tests that need access to the config storage blob because configblob.GetService
 // makes api calls to Azure in order to setup the blob client.
-func NewClientFromEnvironment(setStorageClient bool) (*Client, error) {
+func NewClientFromEnvironment(ctx context.Context, log *logrus.Entry, setStorageClient bool) (*Client, error) {
 	authorizer, err := azureclient.NewAuthorizerFromEnvironment("")
 	if err != nil {
 		return nil, err
@@ -70,7 +71,7 @@ func NewClientFromEnvironment(setStorageClient bool) (*Client, error) {
 
 	var storageClient storage.BlobStorageClient
 	if setStorageClient {
-		storageClient, err = configblob.GetService(context.Background(), cfg)
+		storageClient, err = configblob.GetService(ctx, log, cfg)
 		if err != nil {
 			return nil, err
 		}
@@ -94,21 +95,19 @@ func NewClientFromEnvironment(setStorageClient bool) (*Client, error) {
 
 	rpcAdmin := adminapi.NewClient(rpURL, subscriptionID)
 
-	ctx := context.Background()
-
 	return &Client{
-		Accounts:                         azureclient.NewAccountsClient(ctx, subscriptionID, authorizer),
-		ActivityLogs:                     azureclient.NewActivityLogsClient(ctx, subscriptionID, authorizer),
-		Applications:                     azureclient.NewApplicationsClient(ctx, subscriptionID, authorizer),
+		Accounts:                         azureclient.NewAccountsClient(ctx, log, subscriptionID, authorizer),
+		ActivityLogs:                     azureclient.NewActivityLogsClient(ctx, log, subscriptionID, authorizer),
+		Applications:                     azureclient.NewApplicationsClient(ctx, log, subscriptionID, authorizer),
 		BlobStorage:                      storageClient,
 		OpenShiftManagedClusters:         rpc,
 		OpenShiftManagedClustersAdmin:    rpcAdmin,
-		VirtualMachineScaleSets:          azureclient.NewVirtualMachineScaleSetsClient(ctx, subscriptionID, authorizer),
-		VirtualMachineScaleSetExtensions: azureclient.NewVirtualMachineScaleSetExtensionsClient(ctx, subscriptionID, authorizer),
-		VirtualMachineScaleSetVMs:        azureclient.NewVirtualMachineScaleSetVMsClient(ctx, subscriptionID, authorizer),
-		Resources:                        azureclient.NewResourcesClient(ctx, subscriptionID, authorizer),
-		VirtualNetworks:                  azureclient.NewVirtualNetworkClient(ctx, subscriptionID, authorizer),
-		VirtualNetworksPeerings:          azureclient.NewVirtualNetworksPeeringsClient(ctx, subscriptionID, authorizer),
-		Groups:                           azureclient.NewGroupsClient(ctx, subscriptionID, authorizer),
+		VirtualMachineScaleSets:          azureclient.NewVirtualMachineScaleSetsClient(ctx, log, subscriptionID, authorizer),
+		VirtualMachineScaleSetExtensions: azureclient.NewVirtualMachineScaleSetExtensionsClient(ctx, log, subscriptionID, authorizer),
+		VirtualMachineScaleSetVMs:        azureclient.NewVirtualMachineScaleSetVMsClient(ctx, log, subscriptionID, authorizer),
+		Resources:                        azureclient.NewResourcesClient(ctx, log, subscriptionID, authorizer),
+		VirtualNetworks:                  azureclient.NewVirtualNetworkClient(ctx, log, subscriptionID, authorizer),
+		VirtualNetworksPeerings:          azureclient.NewVirtualNetworksPeeringsClient(ctx, log, subscriptionID, authorizer),
+		Groups:                           azureclient.NewGroupsClient(ctx, log, subscriptionID, authorizer),
 	}, nil
 }

--- a/test/e2e/specs/fakerp/admin.go
+++ b/test/e2e/specs/fakerp/admin.go
@@ -17,6 +17,7 @@ import (
 	"github.com/openshift/openshift-azure/pkg/util/jsonpath"
 	"github.com/openshift/openshift-azure/test/clients/azure"
 	"github.com/openshift/openshift-azure/test/sanity"
+	"github.com/openshift/openshift-azure/test/util/log"
 )
 
 var _ = Describe("Openshift on Azure admin e2e tests [Fake][EveryPR]", func() {
@@ -57,7 +58,7 @@ var _ = Describe("Openshift on Azure admin e2e tests [Fake][EveryPR]", func() {
 
 	It("should ensure no unnecessary VM rotations occured", func() {
 		Expect(os.Getenv("RESOURCEGROUP")).ToNot(BeEmpty())
-		azurecli, err := azure.NewClientFromEnvironment(true)
+		azurecli, err := azure.NewClientFromEnvironment(context.Background(), log.GetTestLogger(), true)
 		Expect(err).ToNot(HaveOccurred())
 
 		ubs := updateblob.NewBlobService(azurecli.BlobStorage)
@@ -91,7 +92,7 @@ var _ = Describe("Openshift on Azure admin e2e tests [Fake][EveryPR]", func() {
 
 	It("should be possible for an SRE to fetch the RP plugin version", func() {
 		Expect(os.Getenv("RESOURCEGROUP")).ToNot(BeEmpty())
-		azurecli, err := azure.NewClientFromEnvironment(true)
+		azurecli, err := azure.NewClientFromEnvironment(context.Background(), log.GetTestLogger(), true)
 		Expect(err).ToNot(HaveOccurred())
 
 		By("Using the OSA admin client to fetch the RP plugin version")

--- a/test/e2e/specs/fakerp/clusterstatus.go
+++ b/test/e2e/specs/fakerp/clusterstatus.go
@@ -12,6 +12,7 @@ import (
 	v1 "k8s.io/api/core/v1"
 
 	"github.com/openshift/openshift-azure/test/clients/azure"
+	"github.com/openshift/openshift-azure/test/util/log"
 )
 
 var _ = Describe("Control Plane Pods Status E2E tests [Fake][EveryPR]", func() {
@@ -21,7 +22,7 @@ var _ = Describe("Control Plane Pods Status E2E tests [Fake][EveryPR]", func() {
 
 	BeforeEach(func() {
 		var err error
-		cli, err = azure.NewClientFromEnvironment(false)
+		cli, err = azure.NewClientFromEnvironment(context.Background(), log.GetTestLogger(), false)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/test/e2e/specs/fakerp/command.go
+++ b/test/e2e/specs/fakerp/command.go
@@ -15,6 +15,7 @@ import (
 	"github.com/openshift/openshift-azure/pkg/util/resourceid"
 	"github.com/openshift/openshift-azure/test/clients/azure"
 	"github.com/openshift/openshift-azure/test/sanity"
+	"github.com/openshift/openshift-azure/test/util/log"
 )
 
 var _ = Describe("Command tests [Command][Fake][LongRunning]", func() {
@@ -24,7 +25,7 @@ var _ = Describe("Command tests [Command][Fake][LongRunning]", func() {
 
 	BeforeEach(func() {
 		var err error
-		azurecli, err = azure.NewClientFromEnvironment(false)
+		azurecli, err = azure.NewClientFromEnvironment(context.Background(), log.GetTestLogger(), false)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(azurecli).NotTo(BeNil())
 	})

--- a/test/e2e/specs/fakerp/etcdrecovery.go
+++ b/test/e2e/specs/fakerp/etcdrecovery.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/openshift-azure/pkg/util/random"
 	"github.com/openshift/openshift-azure/test/clients/azure"
 	"github.com/openshift/openshift-azure/test/sanity"
+	"github.com/openshift/openshift-azure/test/util/log"
 )
 
 var _ = Describe("Etcd Recovery E2E tests [EtcdRecovery][Fake][LongRunning]", func() {
@@ -30,7 +31,7 @@ var _ = Describe("Etcd Recovery E2E tests [EtcdRecovery][Fake][LongRunning]", fu
 
 	BeforeEach(func() {
 		var err error
-		azurecli, err = azure.NewClientFromEnvironment(false)
+		azurecli, err = azure.NewClientFromEnvironment(context.Background(), log.GetTestLogger(), false)
 		Expect(err).ToNot(HaveOccurred())
 
 		backup, err = random.LowerCaseAlphanumericString(5)

--- a/test/e2e/specs/fakerp/forceupdate.go
+++ b/test/e2e/specs/fakerp/forceupdate.go
@@ -10,6 +10,7 @@ import (
 	"github.com/openshift/openshift-azure/pkg/cluster/updateblob"
 	"github.com/openshift/openshift-azure/test/clients/azure"
 	"github.com/openshift/openshift-azure/test/sanity"
+	"github.com/openshift/openshift-azure/test/util/log"
 )
 
 var _ = Describe("Force Update E2E tests [ForceUpdate][Fake][LongRunning]", func() {
@@ -19,7 +20,7 @@ var _ = Describe("Force Update E2E tests [ForceUpdate][Fake][LongRunning]", func
 
 	BeforeEach(func() {
 		var err error
-		azurecli, err = azure.NewClientFromEnvironment(true)
+		azurecli, err = azure.NewClientFromEnvironment(context.Background(), log.GetTestLogger(), true)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/test/e2e/specs/fakerp/keyrotation.go
+++ b/test/e2e/specs/fakerp/keyrotation.go
@@ -9,6 +9,7 @@ import (
 
 	"github.com/openshift/openshift-azure/test/clients/azure"
 	"github.com/openshift/openshift-azure/test/sanity"
+	"github.com/openshift/openshift-azure/test/util/log"
 )
 
 var _ = Describe("Key Rotation E2E tests [KeyRotation][Fake][LongRunning]", func() {
@@ -18,7 +19,7 @@ var _ = Describe("Key Rotation E2E tests [KeyRotation][Fake][LongRunning]", func
 
 	BeforeEach(func() {
 		var err error
-		azurecli, err = azure.NewClientFromEnvironment(false)
+		azurecli, err = azure.NewClientFromEnvironment(context.Background(), log.GetTestLogger(), false)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(azurecli).NotTo(BeNil())
 	})

--- a/test/e2e/specs/fakerp/loglevel.go
+++ b/test/e2e/specs/fakerp/loglevel.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/openshift/openshift-azure/test/clients/azure"
 	"github.com/openshift/openshift-azure/test/sanity"
+	"github.com/openshift/openshift-azure/test/util/log"
 )
 
 var _ = Describe("Change OpenShift Component Log Level E2E tests [ChangeLogLevel][Fake][LongRunning]", func() {
@@ -21,7 +22,7 @@ var _ = Describe("Change OpenShift Component Log Level E2E tests [ChangeLogLevel
 
 	BeforeEach(func() {
 		var err error
-		azurecli, err = azure.NewClientFromEnvironment(true)
+		azurecli, err = azure.NewClientFromEnvironment(context.Background(), log.GetTestLogger(), true)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/test/e2e/specs/fakerp/prometheus.go
+++ b/test/e2e/specs/fakerp/prometheus.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/openshift/openshift-azure/test/clients/azure"
 	"github.com/openshift/openshift-azure/test/sanity"
+	"github.com/openshift/openshift-azure/test/util/log"
 )
 
 type target struct {
@@ -40,7 +41,7 @@ var _ = Describe("Prometheus E2E tests [Fake][EveryPR]", func() {
 
 	BeforeEach(func() {
 		var err error
-		azurecli, err = azure.NewClientFromEnvironment(false)
+		azurecli, err = azure.NewClientFromEnvironment(context.Background(), log.GetTestLogger(), false)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/test/e2e/specs/fakerp/reimagevm.go
+++ b/test/e2e/specs/fakerp/reimagevm.go
@@ -16,6 +16,7 @@ import (
 	"github.com/openshift/openshift-azure/pkg/util/resourceid"
 	"github.com/openshift/openshift-azure/test/clients/azure"
 	"github.com/openshift/openshift-azure/test/sanity"
+	"github.com/openshift/openshift-azure/test/util/log"
 )
 
 var _ = Describe("Reimage VM E2E tests [ReimageVM][Fake][LongRunning]", func() {
@@ -25,7 +26,7 @@ var _ = Describe("Reimage VM E2E tests [ReimageVM][Fake][LongRunning]", func() {
 
 	BeforeEach(func() {
 		var err error
-		azurecli, err = azure.NewClientFromEnvironment(false)
+		azurecli, err = azure.NewClientFromEnvironment(context.Background(), log.GetTestLogger(), false)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(azurecli).NotTo(BeNil())
 	})

--- a/test/e2e/specs/fakerp/setcontainerimage.go
+++ b/test/e2e/specs/fakerp/setcontainerimage.go
@@ -16,6 +16,7 @@ import (
 	pluginapi "github.com/openshift/openshift-azure/pkg/api/plugin"
 	"github.com/openshift/openshift-azure/test/clients/azure"
 	"github.com/openshift/openshift-azure/test/sanity"
+	"github.com/openshift/openshift-azure/test/util/log"
 )
 
 var _ = Describe("Change a single image to latest E2E tests [ChangeImage][Fake][LongRunning]", func() {
@@ -26,7 +27,7 @@ var _ = Describe("Change a single image to latest E2E tests [ChangeImage][Fake][
 
 	BeforeEach(func() {
 		var err error
-		azurecli, err = azure.NewClientFromEnvironment(false)
+		azurecli, err = azure.NewClientFromEnvironment(context.Background(), log.GetTestLogger(), false)
 		Expect(err).NotTo(HaveOccurred())
 	})
 

--- a/test/e2e/specs/realrp/realrp.go
+++ b/test/e2e/specs/realrp/realrp.go
@@ -28,7 +28,7 @@ var _ = Describe("Resource provider e2e tests [Default][Real]", func() {
 	// NOTE: Ensure this is always the first test in the [Default][Real] spec!
 	It("should deploy a cluster using the production RP", func() {
 		var err error
-		cli, err = azure.NewClientFromEnvironment(false)
+		cli, err = azure.NewClientFromEnvironment(ctx, log.GetTestLogger(), false)
 		Expect(err).ToNot(HaveOccurred())
 
 		cfg, err = client.NewConfig(log.GetTestLogger())

--- a/test/e2e/specs/realrp/vnetpeering.go
+++ b/test/e2e/specs/realrp/vnetpeering.go
@@ -13,6 +13,7 @@ import (
 	v20190430 "github.com/openshift/openshift-azure/pkg/api/2019-04-30"
 	"github.com/openshift/openshift-azure/pkg/fakerp/client"
 	"github.com/openshift/openshift-azure/test/clients/azure"
+	"github.com/openshift/openshift-azure/test/util/log"
 	tlog "github.com/openshift/openshift-azure/test/util/log"
 )
 
@@ -25,7 +26,7 @@ var _ = Describe("Peer Vnet tests [Vnet][Real][LongRunning]", func() {
 
 	BeforeEach(func() {
 		var err error
-		cli, err = azure.NewClientFromEnvironment(false)
+		cli, err = azure.NewClientFromEnvironment(context.Background(), log.GetTestLogger(), false)
 		Expect(err).NotTo(HaveOccurred())
 
 		cfg, err = client.NewConfig(tlog.GetTestLogger())

--- a/test/e2e/specs/scaleupdown.go
+++ b/test/e2e/specs/scaleupdown.go
@@ -22,6 +22,7 @@ import (
 	"github.com/openshift/openshift-azure/pkg/util/ready"
 	"github.com/openshift/openshift-azure/test/clients/azure"
 	"github.com/openshift/openshift-azure/test/sanity"
+	"github.com/openshift/openshift-azure/test/util/log"
 )
 
 var _ = Describe("Scale Up/Down E2E tests [ScaleUpDown][Fake][LongRunning]", func() {
@@ -35,7 +36,7 @@ var _ = Describe("Scale Up/Down E2E tests [ScaleUpDown][Fake][LongRunning]", fun
 
 	BeforeEach(func() {
 		var err error
-		azurecli, err = azure.NewClientFromEnvironment(true)
+		azurecli, err = azure.NewClientFromEnvironment(context.Background(), log.GetTestLogger(), true)
 		Expect(err).NotTo(HaveOccurred())
 		Expect(azurecli).NotTo(BeNil())
 

--- a/test/e2e/standard/sanitychecker.go
+++ b/test/e2e/standard/sanitychecker.go
@@ -56,7 +56,7 @@ func NewSanityChecker(ctx context.Context, log *logrus.Entry, cs *internalapi.Op
 		return nil, err
 	}
 
-	kvc := azureclient.NewKeyVaultClient(ctx, vaultauthorizer)
+	kvc := azureclient.NewKeyVaultClient(ctx, log, vaultauthorizer)
 
 	err = enrich.CertificatesFromVault(ctx, kvc, cs)
 	if err != nil {


### PR DESCRIPTION
This work adds retry logic which works depending on the type of error emitted by the function to be retried. 

- [x] Add retry logic and tests
- [x] Refactor fakerp and clients to use retry logic
- [x] Add other error codes from #1122 
```release-note
NONE
```

closes #1122 
