### PR TITLE
added [EveryPR] to Prometheus test, [LongRunning] to admin e2e test

### DIFF
--- a/test/e2e/specs/fakerp/admin.go
+++ b/test/e2e/specs/fakerp/admin.go
@@ -19,7 +19,7 @@ import (
 	"github.com/openshift/openshift-azure/test/sanity"
 )
 
-var _ = Describe("Openshift on Azure admin e2e tests [Fake]", func() {
+var _ = Describe("Openshift on Azure admin e2e tests [Fake][EveryPR]", func() {
 	It("should run the correct image", func() {
 		// e2e check should ensure that no reg-aws images are running on box
 		pods, err := sanity.Checker.Client.Admin.CoreV1.Pods("").List(metav1.ListOptions{})

--- a/test/e2e/specs/fakerp/prometheus.go
+++ b/test/e2e/specs/fakerp/prometheus.go
@@ -33,7 +33,7 @@ type targetsResponse struct {
 	} `json:"data"`
 }
 
-var _ = Describe("Prometheus E2E tests [Prometheus][EveryPR]", func() {
+var _ = Describe("Prometheus E2E tests [Fake][EveryPR]", func() {
 	var (
 		azurecli *azure.Client
 	)
@@ -89,8 +89,12 @@ var _ = Describe("Prometheus E2E tests [Prometheus][EveryPR]", func() {
 		}
 
 		Expect(healthyTargets).To(Equal(map[string]int{
-			"alertmanager-main": 3,
-			"apiserver":         masters,
+			"alertmanager-main":           3,
+			"apiserver":                   masters,
+			"canary":                      2,
+			"etcd-metrics":                3,
+			"router-stats":                3,
+			"cluster-monitoring-operator": 1,
 			// TODO: enable once https://github.com/openshift/cluster-monitoring-operator/pull/230 is backported
 			// "kube-controllers": masters,
 			"kube-state-metrics":  2,


### PR DESCRIPTION
```release-note
NONE
```
Looks like were e2e tests which were not run in some time because they lacked labels. This is a first step in making sure that a test is either run on every PR, or is part of a periodic run.