### PR TITLE
Use shell-agnostic command for checking git tree

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,6 @@
 TAG=$(shell git describe --tags HEAD)
-GITCOMMIT=$(TAG)$(shell [[ $$(git status --porcelain) = "" ]] && echo -clean || echo -dirty)
+GITSTATUS=$(shell git status --porcelain)
+GITCOMMIT=$(TAG)$(shell [ "$(GITSTATUS)" = "" ] && echo -clean || echo -dirty)
 LDFLAGS="-X main.gitCommit=$(GITCOMMIT)"
 
 AZURE_IMAGE ?= quay.io/openshift-on-azure/azure:$(TAG)


### PR DESCRIPTION
```release-note
NONE
```

When running ./hack/test/e2e-upgrade.sh I got an error:

```
+ make monitoring
go generate ./...
bindata.go
...
bindata.go
/bin/sh: 1: [[: not found
```

make will apparently use /bin/sh here, where [[ is not supported,
rather than /bin/bash. This change fixes this error.
