### PR TITLE
revert logging validation

### DIFF
--- a/pkg/api/validate/plugin.go
+++ b/pkg/api/validate/plugin.go
@@ -91,9 +91,7 @@ func (v *PluginAPIValidator) Validate(c *pluginapi.Config) (errs []error) {
 }
 
 func validateComponentLogLevel(c *pluginapi.ComponentLogLevel) (errs []error) {
-	// can't set logging level > 7 due to:
-	// https://bugzilla.redhat.com/show_bug.cgi?id=1689366
-	if c.APIServer < 0 || c.APIServer > 7 {
+	if c.APIServer < 0 || c.APIServer > 20 {
 		errs = append(errs, fmt.Errorf("invalid componentLogLevel.apiServer %d", c.APIServer))
 	}
 


### PR DESCRIPTION
```release-note
NONE
```
fix: https://github.com/openshift/openshift-azure/issues/1293
Revert of logging lock/validation
