### PR TITLE
enable retrying roundtripper in E2E openshift clients

### DIFF
--- a/test/e2e/standard/sanitychecker.go
+++ b/test/e2e/standard/sanitychecker.go
@@ -62,7 +62,7 @@ func NewSanityChecker(ctx context.Context, log *logrus.Entry, cs *internalapi.Op
 	if err != nil {
 		return nil, err
 	}
-	scc.Client, err = openshift.NewClientSet(cs)
+	scc.Client, err = openshift.NewClientSet(log, cs)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This configures the retrying round-tripper on the kubeclient used in e2e tests. In addition, http client used within `sanityChecker.checkCanAccessServices` is configured to use the retrying round-tripper.

Due to the fact that the retrying round-tripper requires a log instance, the `New*Client(cs)` functions in `test/clients/openshift/client.go` have been updated to accept an additional logger e.g. `New*Client(log, cs)`.

```release-note
NONE
```

closes #1438 

/cc @mjudeikis @jim-minter 