### PR TITLE
Add validation for cluster names and locations

### DIFF
--- a/pkg/api/validate/types.go
+++ b/pkg/api/validate/types.go
@@ -12,6 +12,8 @@ import (
 )
 
 var (
+	rxClusterName = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9-]{0,61}[a-zA-Z0-9]$`)
+
 	rxRfc1123 = regexp.MustCompile(`(?i)^` +
 		`([a-z0-9]|[a-z0-9][-a-z0-9]{0,61}[a-z0-9])` +
 		`(\.([a-z0-9]|[a-z0-9][-a-z0-9]{0,61}[a-z0-9]))*` +
@@ -108,6 +110,10 @@ func init() {
 	if err != nil {
 		panic(err)
 	}
+}
+
+func isValidClusterName(n string) bool {
+	return rxClusterName.MatchString(n)
 }
 
 func isValidHostname(h string) bool {

--- a/pkg/api/validate/types.go
+++ b/pkg/api/validate/types.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	rxClusterName = regexp.MustCompile(`^[a-zA-Z][a-zA-Z0-9-]{0,61}[a-zA-Z0-9]$`)
+	rxClusterName = regexp.MustCompile(`(?i)^([a-z0-9]|[a-z0-9][-a-z0-9]{0,61}[a-z0-9])$`)
 
 	rxRfc1123 = regexp.MustCompile(`(?i)^` +
 		`([a-z0-9]|[a-z0-9][-a-z0-9]{0,61}[a-z0-9])` +

--- a/pkg/api/validate/types.go
+++ b/pkg/api/validate/types.go
@@ -14,6 +14,8 @@ import (
 var (
 	rxClusterName = regexp.MustCompile(`(?i)^([a-z0-9]|[a-z0-9][-a-z0-9]{0,61}[a-z0-9])$`)
 
+	rxLocation = regexp.MustCompile(`(?i)^[a-z0-9]+$`)
+
 	rxRfc1123 = regexp.MustCompile(`(?i)^` +
 		`([a-z0-9]|[a-z0-9][-a-z0-9]{0,61}[a-z0-9])` +
 		`(\.([a-z0-9]|[a-z0-9][-a-z0-9]{0,61}[a-z0-9]))*` +
@@ -114,6 +116,10 @@ func init() {
 
 func isValidClusterName(n string) bool {
 	return rxClusterName.MatchString(n)
+}
+
+func isValidLocation(l string) bool {
+	return rxLocation.MatchString(l)
 }
 
 func isValidHostname(h string) bool {

--- a/pkg/api/validate/types_test.go
+++ b/pkg/api/validate/types_test.go
@@ -56,6 +56,38 @@ func TestValidatePluginVersion(t *testing.T) {
 	}
 }
 
+func TestIsValidClusterName(t *testing.T) {
+	invalidClusterNames := []string{
+		"",
+		"k",
+		"my.cluster",
+		"has spaces",
+		"random#characters?",
+		"1234567890",
+		"0cluster",
+		"cluster-",
+		"-cluster",
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+		"verylongtoolongnameitslongerthan63characterswhoopsthiswontworkatall",
+	}
+	for _, invalidClusterName := range invalidClusterNames {
+		if isValidClusterName(invalidClusterName) {
+			t.Errorf("invalid cluster name passed test: %s", invalidClusterName)
+		}
+	}
+	validClusterNames := []string{
+		"k0",
+		"osa-testing",
+		"ExampleCluster111",
+		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
+	}
+	for _, validClusterName := range validClusterNames {
+		if !isValidClusterName(validClusterName) {
+			t.Errorf("valid cluster name failed to pass test: %s", validClusterName)
+		}
+	}
+}
+
 func TestIsValidCloudAppHostname(t *testing.T) {
 	invalidFqdns := []string{
 		"invalid.random.domain",

--- a/pkg/api/validate/types_test.go
+++ b/pkg/api/validate/types_test.go
@@ -89,6 +89,33 @@ func TestIsValidClusterName(t *testing.T) {
 	}
 }
 
+func TestIsValidLocation(t *testing.T) {
+	invalidLocations := []string{
+		"",
+		"West US 2",
+		"Brazil South",
+		"random#characters?",
+	}
+	for _, invalidLocation := range invalidLocations {
+		if isValidLocation(invalidLocation) {
+			t.Errorf("invalid location passed test: %s", invalidLocation)
+		}
+	}
+	validLocations := []string{
+		"a",
+		"eastus",
+		"EastUS",
+		"westus2",
+		"westeurope",
+		"canadacentral",
+	}
+	for _, validLocation := range validLocations {
+		if !isValidLocation(validLocation) {
+			t.Errorf("valid location failed to pass test: %s", validLocation)
+		}
+	}
+}
+
 func TestIsValidCloudAppHostname(t *testing.T) {
 	invalidFqdns := []string{
 		"invalid.random.domain",

--- a/pkg/api/validate/types_test.go
+++ b/pkg/api/validate/types_test.go
@@ -59,12 +59,10 @@ func TestValidatePluginVersion(t *testing.T) {
 func TestIsValidClusterName(t *testing.T) {
 	invalidClusterNames := []string{
 		"",
-		"k",
+		"-",
 		"my.cluster",
 		"has spaces",
 		"random#characters?",
-		"1234567890",
-		"0cluster",
 		"cluster-",
 		"-cluster",
 		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
@@ -76,7 +74,10 @@ func TestIsValidClusterName(t *testing.T) {
 		}
 	}
 	validClusterNames := []string{
+		"k",
 		"k0",
+		"0cluster",
+		"1234567890",
 		"osa-testing",
 		"ExampleCluster111",
 		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",

--- a/pkg/api/validate/validators.go
+++ b/pkg/api/validate/validators.go
@@ -15,7 +15,7 @@ func validateContainerService(c *api.OpenShiftManagedCluster, externalOnly bool)
 
 	errs = append(errs, validateProperties(&c.Properties, c.Location, externalOnly)...)
 
-	if c.Name == "" {
+	if !isValidClusterName(c.Name) {
 		errs = append(errs, fmt.Errorf("invalid name %q", c.Name))
 	}
 

--- a/pkg/api/validate/validators.go
+++ b/pkg/api/validate/validators.go
@@ -19,7 +19,7 @@ func validateContainerService(c *api.OpenShiftManagedCluster, externalOnly bool)
 		errs = append(errs, fmt.Errorf("invalid name %q", c.Name))
 	}
 
-	if c.Location == "" {
+	if !isValidLocation(c.Location) {
 		errs = append(errs, fmt.Errorf("invalid location %q", c.Location))
 	}
 

--- a/pkg/api/validate/validators_test.go
+++ b/pkg/api/validate/validators_test.go
@@ -144,6 +144,14 @@ func TestValidate(t *testing.T) {
 				errors.New(`invalid location ""`),
 			},
 		},
+		"invalid location": {
+			f: func(oc *api.OpenShiftManagedCluster) { oc.Location = "West US 2" },
+			expectedErrs: []error{
+				errors.New(`invalid properties.fqdn "example.eastus.cloudapp.azure.com"`),
+				errors.New(`invalid properties.routerProfiles["default"].fqdn "router-fqdn.eastus.cloudapp.azure.com"`),
+				errors.New(`invalid location "West US 2"`),
+			},
+		},
 		"empty name": {
 			f:            func(oc *api.OpenShiftManagedCluster) { oc.Name = "" },
 			expectedErrs: []error{errors.New(`invalid name ""`)},

--- a/pkg/api/validate/validators_test.go
+++ b/pkg/api/validate/validators_test.go
@@ -144,9 +144,13 @@ func TestValidate(t *testing.T) {
 				errors.New(`invalid location ""`),
 			},
 		},
-		"name": {
+		"empty name": {
 			f:            func(oc *api.OpenShiftManagedCluster) { oc.Name = "" },
 			expectedErrs: []error{errors.New(`invalid name ""`)},
+		},
+		"invalid name": {
+			f:            func(oc *api.OpenShiftManagedCluster) { oc.Name = "cluster.name" },
+			expectedErrs: []error{errors.New(`invalid name "cluster.name"`)},
 		},
 		"openshift config invalid api fqdn": {
 			f: func(oc *api.OpenShiftManagedCluster) {


### PR DESCRIPTION
```release-note
Validate cluster names to ensure they will comply with the DNS spec.
Validate location names to ensure they match the standard naming scheme.
```
Closes #1116.

This regex is sort of arbitrary; I followed MS' recommendation for domain name label best practices, except that I am allowing capital letters and a length of 2-63 characters. Happy to modify this as necessary.