### PR TITLE
Add default values to external APIs

### DIFF
--- a/pkg/api/2018-09-30-preview/convertertointernal.go
+++ b/pkg/api/2018-09-30-preview/convertertointernal.go
@@ -12,9 +12,13 @@ import (
 // output where the external request is merged on top of.
 func ToInternal(oc *OpenShiftManagedCluster, old *api.OpenShiftManagedCluster) (*api.OpenShiftManagedCluster, error) {
 	cs := &api.OpenShiftManagedCluster{}
-	if old != nil {
+
+	if old == nil {
+		setDefaults(oc)
+	} else {
 		cs = old.DeepCopy()
 	}
+
 	if oc.ID != nil {
 		cs.ID = *oc.ID
 	}

--- a/pkg/api/2018-09-30-preview/default.go
+++ b/pkg/api/2018-09-30-preview/default.go
@@ -5,6 +5,10 @@ import (
 )
 
 func setDefaults(oc *OpenShiftManagedCluster) {
+	if oc.Properties == nil {
+		oc.Properties = &Properties{}
+	}
+
 	if len(oc.Properties.RouterProfiles) == 0 {
 		oc.Properties.RouterProfiles = []RouterProfile{
 			{

--- a/pkg/api/2018-09-30-preview/default.go
+++ b/pkg/api/2018-09-30-preview/default.go
@@ -1,0 +1,15 @@
+package v20180930preview
+
+import (
+	"github.com/Azure/go-autorest/autorest/to"
+)
+
+func setDefaults(oc *OpenShiftManagedCluster) {
+	if len(oc.Properties.RouterProfiles) == 0 {
+		oc.Properties.RouterProfiles = []RouterProfile{
+			{
+				Name: to.StringPtr("default"),
+			},
+		}
+	}
+}

--- a/pkg/api/2018-09-30-preview/default_test.go
+++ b/pkg/api/2018-09-30-preview/default_test.go
@@ -1,0 +1,55 @@
+package v20180930preview
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/go-test/deep"
+)
+
+var sampleManagedCluster = &OpenShiftManagedCluster{
+	Properties: &Properties{
+		RouterProfiles: []RouterProfile{
+			{
+				Name:            to.StringPtr("Properties.RouterProfiles[0].Name"),
+				PublicSubdomain: to.StringPtr("NewPublicSubdomain"),
+			},
+		},
+	},
+}
+
+func TestDefaults(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *OpenShiftManagedCluster
+		expected *OpenShiftManagedCluster
+	}{
+		{
+			name:  "sets default RouterProfile",
+			input: &OpenShiftManagedCluster{},
+			expected: &OpenShiftManagedCluster{
+				Properties: &Properties{
+					RouterProfiles: []RouterProfile{
+						{
+							Name: to.StringPtr("default"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "sets no defaults",
+			input:    sampleManagedCluster,
+			expected: sampleManagedCluster,
+		},
+	}
+
+	for _, test := range tests {
+		setDefaults(test.input)
+
+		if !reflect.DeepEqual(test.input, test.expected) {
+			t.Errorf("%s: unexpected diff %s", test.name, deep.Equal(test.input, test.expected))
+		}
+	}
+}

--- a/pkg/api/2019-04-30/convertertointernal.go
+++ b/pkg/api/2019-04-30/convertertointernal.go
@@ -12,9 +12,13 @@ import (
 // output where the external request is merged on top of.
 func ToInternal(oc *OpenShiftManagedCluster, old *api.OpenShiftManagedCluster) (*api.OpenShiftManagedCluster, error) {
 	cs := &api.OpenShiftManagedCluster{}
-	if old != nil {
+
+	if old == nil {
+		setDefaults(oc)
+	} else {
 		cs = old.DeepCopy()
 	}
+
 	if oc.ID != nil {
 		cs.ID = *oc.ID
 	}

--- a/pkg/api/2019-04-30/default.go
+++ b/pkg/api/2019-04-30/default.go
@@ -5,6 +5,10 @@ import (
 )
 
 func setDefaults(oc *OpenShiftManagedCluster) {
+	if oc.Properties == nil {
+		oc.Properties = &Properties{}
+	}
+
 	if len(oc.Properties.RouterProfiles) == 0 {
 		oc.Properties.RouterProfiles = []RouterProfile{
 			{

--- a/pkg/api/2019-04-30/default.go
+++ b/pkg/api/2019-04-30/default.go
@@ -1,0 +1,15 @@
+package v20190430
+
+import (
+	"github.com/Azure/go-autorest/autorest/to"
+)
+
+func setDefaults(oc *OpenShiftManagedCluster) {
+	if len(oc.Properties.RouterProfiles) == 0 {
+		oc.Properties.RouterProfiles = []RouterProfile{
+			{
+				Name: to.StringPtr("default"),
+			},
+		}
+	}
+}

--- a/pkg/api/2019-04-30/default_test.go
+++ b/pkg/api/2019-04-30/default_test.go
@@ -1,0 +1,55 @@
+package v20190430
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/Azure/go-autorest/autorest/to"
+	"github.com/go-test/deep"
+)
+
+var sampleManagedCluster = &OpenShiftManagedCluster{
+	Properties: &Properties{
+		RouterProfiles: []RouterProfile{
+			{
+				Name:            to.StringPtr("Properties.RouterProfiles[0].Name"),
+				PublicSubdomain: to.StringPtr("NewPublicSubdomain"),
+			},
+		},
+	},
+}
+
+func TestDefaults(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    *OpenShiftManagedCluster
+		expected *OpenShiftManagedCluster
+	}{
+		{
+			name:  "sets default RouterProfile",
+			input: &OpenShiftManagedCluster{},
+			expected: &OpenShiftManagedCluster{
+				Properties: &Properties{
+					RouterProfiles: []RouterProfile{
+						{
+							Name: to.StringPtr("default"),
+						},
+					},
+				},
+			},
+		},
+		{
+			name:     "sets no defaults",
+			input:    sampleManagedCluster,
+			expected: sampleManagedCluster,
+		},
+	}
+
+	for _, test := range tests {
+		setDefaults(test.input)
+
+		if !reflect.DeepEqual(test.input, test.expected) {
+			t.Errorf("%s: unexpected diff %s", test.name, deep.Equal(test.input, test.expected))
+		}
+	}
+}

--- a/pkg/fakerp/fakerp.go
+++ b/pkg/fakerp/fakerp.go
@@ -272,14 +272,6 @@ func enrich(cs *api.OpenShiftManagedCluster) error {
 	// /subscriptions/{subscription}/resourcegroups/{resource_group}/providers/Microsoft.ContainerService/openshiftmanagedClusters/{cluster_name}
 	cs.ID = resourceid.ResourceID(cs.Properties.AzProfile.SubscriptionID, cs.Properties.AzProfile.ResourceGroup, "Microsoft.ContainerService/openshiftmanagedClusters", cs.Name)
 
-	if len(cs.Properties.RouterProfiles) == 0 {
-		cs.Properties.RouterProfiles = []api.RouterProfile{
-			{
-				Name: "default",
-			},
-		}
-	}
-
 	var vaultURL string
 	var err error
 	if cs.Properties.APICertProfile.KeyVaultSecretURL != "" {


### PR DESCRIPTION
```release-note
Set some default values (e.g. RouterProfile) when not specified upon creating a new cluster config
```
Addresses #336.

- [x] Default RouterProfiles.
- [ ] Default masterPoolProfile/count=3
- [ ] Default agentPoolProfiles[name=infra]/count=3
- [ ] Default agentPoolProfiles[*]/osType=Linux
- [x] Unit test defaults
- [ ] Simplify test/manifests/fakerp/create.yaml