### PR TITLE
add secrets to vmimage

### DIFF
--- a/hack/vmimage.sh
+++ b/hack/vmimage.sh
@@ -17,6 +17,8 @@ cleanup() {
 }
 trap cleanup EXIT
 
+make secrets
+
 TAG=$(git describe --tags HEAD)
 if [[ $(git status --porcelain) = "" ]]; then
   GITCOMMIT="$TAG-clean"


### PR DESCRIPTION
```release-note
NONE
```

solves:
```
./hack/vmimage.sh
time="2019-04-23T06:44:57Z" level=info msg="vmimage starting, git commit v4.0-246-g3027211-clean"
time="2019-04-23T06:44:57Z" level=fatal msg="open secrets/client-key.pem: no such file or directory"
```
