### PR TITLE
Update secrets in-place within make secrets

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,10 +7,10 @@ AZURE_IMAGE ?= quay.io/openshift-on-azure/azure:$(GITCOMMIT)
 
 all: azure
 
+# you must login to the ci cluster before running the secrets target
 secrets:
-	@rm -rf secrets
-	@mkdir secrets
-	@oc extract -n azure secret/cluster-secrets-azure --to=secrets >/dev/null
+	@mkdir -p secrets
+	@oc extract -n azure secret/cluster-secrets-azure --confirm=true --to=secrets >/dev/null
 
 clean:
 	rm -f coverage.out azure releasenotes


### PR DESCRIPTION
make secrets currently deletes the secrets directory, recreates it and then pulls the secrets from CI.
This PR changes that a bit to:
- do not delete an existing secrets directory because the developer might have other secret files in there
- use mkdir -p to create the directory if it does not exist
- use the --confirm=true flag to oc extract to overwrite existing files
- add a comment above the secrets target stating that logging into the CI cluster is a prerequisite for the secrets target

```release-note
NONE
```

fyi @mjudeikis @jim-minter 
