### PR TITLE
wait for SCC annotation at project creation to avoid "no providers available to validate pod request" flake

### DIFF
--- a/test/clients/openshift/project.go
+++ b/test/clients/openshift/project.go
@@ -56,6 +56,18 @@ func (cli *Client) CreateProject(namespace string) error {
 		return fmt.Errorf("failed to wait for default service account: %v", err)
 	}
 
+	err = wait.PollImmediate(time.Second, time.Minute, func() (bool, error) {
+		project, err := cli.ProjectV1.Projects().Get(namespace, metav1.GetOptions{})
+		if err != nil {
+			return false, err
+		}
+		_, found := project.Annotations["openshift.io/sa.scc.uid-range"]
+		return found, nil
+	})
+	if err != nil {
+		return fmt.Errorf("failed to wait for scc: %v", err)
+	}
+
 	return nil
 }
 


### PR DESCRIPTION
```release-note
NONE
```

fixes #1436 

the log I saw which led me to this was `namespace_scc_allocation_controller.go:335] error syncing namespace, it will be retried: Operation cannot be fulfilled on namespaces "e2e-test-37of0": the object has been modified; please apply your changes to the latest version and try again`

@mjudeikis 