### PR TITLE
removed [EveryPR] from Prometheus test, fixed admin.go test

### DIFF
--- a/test/e2e/specs/fakerp/admin.go
+++ b/test/e2e/specs/fakerp/admin.go
@@ -99,7 +99,7 @@ var _ = Describe("Openshift on Azure admin e2e tests [Fake][EveryPR]", func() {
 		result, err := azurecli.OpenShiftManagedClustersAdmin.GetPluginVersion(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
 		Expect(err).NotTo(HaveOccurred())
 		Expect(result).NotTo(BeNil())
-		Expect(result.PluginVersion).NotTo(BeEmpty())
+		Expect(*result.PluginVersion).NotTo(BeEmpty())
 		Expect(strings.HasPrefix(*result.PluginVersion, "v")).To(BeTrue())
 	})
 })

--- a/test/e2e/specs/fakerp/prometheus.go
+++ b/test/e2e/specs/fakerp/prometheus.go
@@ -34,7 +34,7 @@ type targetsResponse struct {
 	} `json:"data"`
 }
 
-var _ = Describe("Prometheus E2E tests [Fake][EveryPR]", func() {
+var _ = Describe("Prometheus E2E tests [Fake]", func() {
 	var (
 		azurecli *azure.Client
 	)


### PR DESCRIPTION
```release-note
NONE
```
admin.go tested if a string pointer is not empty, changed to string.
Prometheus tests can't be run right after cluster startup. Cleaning up [EveryPR] tag for now.