### PR TITLE
changing default e2e timeout to 60m

### DIFF
--- a/hack/e2e.sh
+++ b/hack/e2e.sh
@@ -11,7 +11,7 @@ if [[ -n "$FOCUS" ]]; then
 fi
 
 if [[ -z "$TIMEOUT" ]]; then
-    TIMEOUT=20m
+    TIMEOUT=60m
 fi
 
 # start the fake rp server if needed


### PR DESCRIPTION
```release-note
NONE
```
changing the default TIMEOUT for e2e tests instead of overriding it in the openshift/release repository in multiple places.
