### PR TITLE
Set Makefile SHELL to bash

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,3 +1,4 @@
+SHELL := /bin/bash
 GITCOMMIT=$(shell git describe --tags HEAD)$(shell [[ $$(git status --porcelain) = "" ]] || echo -dirty)
 LDFLAGS="-X main.gitCommit=$(GITCOMMIT)"
 


### PR DESCRIPTION
Our Makefile uses the bash-specific [[ test construct, but GNU make defaults to using `/bin/sh` if a shell is not specified.[*] Hence, let's specify it.

[*]: https://www.gnu.org/software/make/manual/html_node/Choosing-the-Shell.html#index-shell_002c-choosing-the

This is a permanent fix for the problem previous patched in #1513 (and I see also #1098). It got reverted, I think by accident, in #1507.

Without this fix, I continue to get `/bin/sh: 1: [[: not found` errors.

```release-note
NONE
```
