### PR TITLE
adding EndUser and ScaleUpDown to EveryPR

### DIFF
--- a/test/e2e/specs/customer_admin.go
+++ b/test/e2e/specs/customer_admin.go
@@ -22,7 +22,7 @@ import (
 	"github.com/openshift/openshift-azure/test/sanity"
 )
 
-var _ = Describe("Openshift on Azure customer-admin e2e tests [CustomerAdmin][Fake]", func() {
+var _ = Describe("Openshift on Azure customer-admin e2e tests [CustomerAdmin][Fake][EveryPR]", func() {
 	It("should not read nodes", func() {
 		_, err := sanity.Checker.Client.CustomerAdmin.CoreV1.Nodes().Get("master-000000", metav1.GetOptions{})
 		Expect(kerrors.IsForbidden(err)).To(Equal(true))

--- a/test/e2e/specs/end_user.go
+++ b/test/e2e/specs/end_user.go
@@ -9,7 +9,7 @@ import (
 	"github.com/openshift/openshift-azure/test/sanity"
 )
 
-var _ = Describe("Openshift on Azure end user e2e tests [EndUser][Fake]", func() {
+var _ = Describe("Openshift on Azure end user e2e tests [EndUser][Fake][EveryPR]", func() {
 	It("should create and validate test apps [EndUser][Fake][Apps]", func() {
 		ctx := context.Background()
 		By("creating test app")

--- a/test/e2e/specs/osba_app.go
+++ b/test/e2e/specs/osba_app.go
@@ -80,7 +80,7 @@ func createOSBAApp(ctx context.Context) (err error) {
 	return
 }
 
-var _ = Describe("Openshift on Azure end user e2e tests [CostumerAdmin][Fake]", func() {
+var _ = Describe("Openshift on Azure end user e2e tests [CustomerAdmin][Fake][EveryPR]", func() {
 	It("should create and validate an OpenShift Broker App [CustomerAdmin][Fake][OSBA]", func() {
 		var errs []error
 		ctx := context.Background()

--- a/test/e2e/specs/scaleupdown.go
+++ b/test/e2e/specs/scaleupdown.go
@@ -25,7 +25,7 @@ import (
 	"github.com/openshift/openshift-azure/test/util/log"
 )
 
-var _ = Describe("Scale Up/Down E2E tests [ScaleUpDown][Fake][LongRunning]", func() {
+var _ = Describe("Scale Up/Down E2E tests [ScaleUpDown][Fake][EveryPR][LongRunning]", func() {
 	const (
 		sampleDeployment = "hello-openshift"
 	)


### PR DESCRIPTION
```release-note
NONE
```
Same as #1565 Reopening as a new PR due to github caching old tests as "required".