### PR TITLE
Default MasterProfilePool count to 3

### DIFF
--- a/pkg/api/2018-09-30-preview/default.go
+++ b/pkg/api/2018-09-30-preview/default.go
@@ -9,6 +9,12 @@ func setDefaults(oc *OpenShiftManagedCluster) {
 		oc.Properties = &Properties{}
 	}
 
+	if oc.Properties.MasterPoolProfile != nil {
+		if oc.Properties.MasterPoolProfile.Count == nil {
+			oc.Properties.MasterPoolProfile.Count = to.Int64Ptr(3)
+		}
+	}
+
 	if len(oc.Properties.RouterProfiles) == 0 {
 		oc.Properties.RouterProfiles = []RouterProfile{
 			{

--- a/pkg/api/2018-09-30-preview/default.go
+++ b/pkg/api/2018-09-30-preview/default.go
@@ -9,10 +9,12 @@ func setDefaults(oc *OpenShiftManagedCluster) {
 		oc.Properties = &Properties{}
 	}
 
-	if oc.Properties.MasterPoolProfile != nil {
-		if oc.Properties.MasterPoolProfile.Count == nil {
-			oc.Properties.MasterPoolProfile.Count = to.Int64Ptr(3)
-		}
+	if oc.Properties.MasterPoolProfile == nil {
+		oc.Properties.MasterPoolProfile = &MasterPoolProfile{}
+	}
+
+	if oc.Properties.MasterPoolProfile.Count == nil {
+		oc.Properties.MasterPoolProfile.Count = to.Int64Ptr(3)
 	}
 
 	if len(oc.Properties.RouterProfiles) == 0 {

--- a/pkg/api/2018-09-30-preview/default_test.go
+++ b/pkg/api/2018-09-30-preview/default_test.go
@@ -11,6 +11,11 @@ import (
 func sampleManagedCluster() *OpenShiftManagedCluster {
 	return &OpenShiftManagedCluster{
 		Properties: &Properties{
+			MasterPoolProfile: &MasterPoolProfile{
+				Count:      to.Int64Ptr(3),
+				VMSize:     (*VMSize)(to.StringPtr("Standard_D2s_v3")),
+				SubnetCIDR: to.StringPtr("10.0.0.0/24"),
+			},
 			RouterProfiles: []RouterProfile{
 				{
 					Name:            to.StringPtr("Properties.RouterProfiles[0].Name"),
@@ -28,11 +33,14 @@ func TestDefaults(t *testing.T) {
 		expectedChange func(*OpenShiftManagedCluster)
 	}{
 		{
-			name: "sets default RouterProfile",
+			name: "sets all defaults",
 			changeInput: func(oc *OpenShiftManagedCluster) {
 				oc.Properties = nil
 			},
 			expectedChange: func(oc *OpenShiftManagedCluster) {
+				oc.Properties.MasterPoolProfile = &MasterPoolProfile{
+					Count: to.Int64Ptr(3),
+				}
 				oc.Properties.RouterProfiles = []RouterProfile{
 					{
 						Name: to.StringPtr("default"),
@@ -41,7 +49,7 @@ func TestDefaults(t *testing.T) {
 			},
 		},
 		{
-			name: "sets MasterPoolProfile.Count to 3",
+			name: "sets MasterPoolProfile.Count to 3 when empty",
 			changeInput: func(oc *OpenShiftManagedCluster) {
 				oc.Properties.MasterPoolProfile = &MasterPoolProfile{
 					VMSize:     (*VMSize)(to.StringPtr("Standard_D2s_v3")),

--- a/pkg/api/2019-04-30/default.go
+++ b/pkg/api/2019-04-30/default.go
@@ -9,6 +9,12 @@ func setDefaults(oc *OpenShiftManagedCluster) {
 		oc.Properties = &Properties{}
 	}
 
+	if oc.Properties.MasterPoolProfile != nil {
+		if oc.Properties.MasterPoolProfile.Count == nil {
+			oc.Properties.MasterPoolProfile.Count = to.Int64Ptr(3)
+		}
+	}
+
 	if len(oc.Properties.RouterProfiles) == 0 {
 		oc.Properties.RouterProfiles = []RouterProfile{
 			{

--- a/pkg/api/2019-04-30/default.go
+++ b/pkg/api/2019-04-30/default.go
@@ -9,10 +9,12 @@ func setDefaults(oc *OpenShiftManagedCluster) {
 		oc.Properties = &Properties{}
 	}
 
-	if oc.Properties.MasterPoolProfile != nil {
-		if oc.Properties.MasterPoolProfile.Count == nil {
-			oc.Properties.MasterPoolProfile.Count = to.Int64Ptr(3)
-		}
+	if oc.Properties.MasterPoolProfile == nil {
+		oc.Properties.MasterPoolProfile = &MasterPoolProfile{}
+	}
+
+	if oc.Properties.MasterPoolProfile.Count == nil {
+		oc.Properties.MasterPoolProfile.Count = to.Int64Ptr(3)
 	}
 
 	if len(oc.Properties.RouterProfiles) == 0 {

--- a/pkg/api/2019-04-30/default_test.go
+++ b/pkg/api/2019-04-30/default_test.go
@@ -11,6 +11,11 @@ import (
 func sampleManagedCluster() *OpenShiftManagedCluster {
 	return &OpenShiftManagedCluster{
 		Properties: &Properties{
+			MasterPoolProfile: &MasterPoolProfile{
+				Count:      to.Int64Ptr(3),
+				VMSize:     (*VMSize)(to.StringPtr("Standard_D2s_v3")),
+				SubnetCIDR: to.StringPtr("10.0.0.0/24"),
+			},
 			RouterProfiles: []RouterProfile{
 				{
 					Name:            to.StringPtr("Properties.RouterProfiles[0].Name"),
@@ -28,11 +33,14 @@ func TestDefaults(t *testing.T) {
 		expectedChange func(*OpenShiftManagedCluster)
 	}{
 		{
-			name: "sets default RouterProfile",
+			name: "sets all defaults",
 			changeInput: func(oc *OpenShiftManagedCluster) {
 				oc.Properties = nil
 			},
 			expectedChange: func(oc *OpenShiftManagedCluster) {
+				oc.Properties.MasterPoolProfile = &MasterPoolProfile{
+					Count: to.Int64Ptr(3),
+				}
 				oc.Properties.RouterProfiles = []RouterProfile{
 					{
 						Name: to.StringPtr("default"),
@@ -41,7 +49,7 @@ func TestDefaults(t *testing.T) {
 			},
 		},
 		{
-			name: "sets MasterPoolProfile.Count to 3",
+			name: "sets MasterPoolProfile.Count to 3 when empty",
 			changeInput: func(oc *OpenShiftManagedCluster) {
 				oc.Properties.MasterPoolProfile = &MasterPoolProfile{
 					VMSize:     (*VMSize)(to.StringPtr("Standard_D2s_v3")),


### PR DESCRIPTION
```release-note
Default MasterProfilePool count to 3 when not specified in new cluster configs
```

Addresses #336.

Note that the changes to each API version are identical.