### PR TITLE
check for role equality in admin update validation

### DIFF
--- a/pkg/api/validate/admin.go
+++ b/pkg/api/validate/admin.go
@@ -60,7 +60,7 @@ func (v *AdminAPIValidator) validateUpdateContainerService(cs, oldCs *api.OpenSh
 		}
 
 		for _, newApp := range cs.Properties.AgentPoolProfiles {
-			if newApp.Count == 3 {
+			if newApp.Role == app.Role && newApp.Count == 3 {
 				old.Properties.AgentPoolProfiles[i].Count = newApp.Count
 			}
 		}


### PR DESCRIPTION
```release-note
check for role equality in admin update validation, otherwise an error occurs when attempting to admin update legacy clusters with only 2 infra nodes'
```
