### PR TITLE
add hostname to output

### DIFF
--- a/hack/tests/ci-operator-prepare.sh
+++ b/hack/tests/ci-operator-prepare.sh
@@ -43,6 +43,7 @@ pullnumber="$(python -c 'import json, os; o=json.loads(os.environ["JOB_SPEC"]); 
 export RESOURCEGROUP="ci-$pullnumber$(basename "$0" .sh)-$(cat /dev/urandom | tr -dc 'a-z' | fold -w 6 | head -n 1)"
 
 echo "RESOURCEGROUP is $RESOURCEGROUP"
+echo "HOSTNAME is $HOSTNAME"
 echo
 
 make secrets


### PR DESCRIPTION
```release-note
NONE
```

After move from CI -operator we dont know which pod name is used to un tests. So we dont know where to check logs in CI cluster. Example: https://openshift-gce-devel.appspot.com/build/origin-ci-test/pr-logs/pull/openshift_openshift-azure/1580/pull-ci-azure-master-upgrade-v3.2/50 (top of the logs)

```
[mjudeiki@redhat release]$ oc get pods -n ci | head -10
NAME                                              READY     STATUS             RESTARTS   AGE
01004e03-67f3-11e9-abd4-0a58ac101b36              0/2       Completed          0          1h
011a57f5-67f3-11e9-abd4-0a58ac101b36              2/2       Running            0          1h
011f6cf7-67f3-11e9-abd4-0a58ac101b36              2/2       Running            0          1h
0125407c-67f3-11e9-abd4-0a58ac101b36              2/2       Running            0          1h
012a0e58-67f3-11e9-abd4-0a58ac101b36              0/2       Completed          0          1h
0136c744-67f3-11e9-abd4-0a58ac101b36              0/2       Completed          0          1h
01412a3d-67f3-11e9-abd4-0a58ac101b36              0/2       Completed          0          1h
03a2d7b1-67e8-11e9-b7a4-0a58ac101a2d              0/2       Completed          0          2h
04c7787f-67f9-11e9-abd4-0a58ac101b36              2/2       Running            0          25m
```

We can read ci namespace pod logs, so this should help to identify pod to check. 