### PR TITLE
Automatic content regeneration script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -57,6 +57,10 @@ monitoring-stop:
 releasenotes:
 	go build -tags releasenotes ./cmd/$@
 
+content:
+	go test -timeout=300s -tags=content -run=TestContent ./pkg/sync/v$(shell ls -d pkg/sync/v* | sed -e 's/.*v//' | sort -n | tail -1)
+	go generate ./pkg/sync/v$(shell ls -d pkg/sync/v* | sed -e 's/.*v//' | sort -n | tail -1)
+
 verify:
 	./hack/verify/validate-generated.sh
 	go vet ./...

--- a/hack/periodic/content-update.sh
+++ b/hack/periodic/content-update.sh
@@ -1,0 +1,21 @@
+#!/bin/bash -e
+
+make content
+
+. hack/tests/ci-operator-prepare.sh
+
+git add pkg/sync/v$(ls -d pkg/sync/v* | sed -e 's/.*v//' | sort -n | tail -1)
+GIT_COMMITTER_NAME=openshift-azure-robot GIT_COMMITTER_EMAIL=aos-azure@redhat.com git commit --no-gpg-sign --author 'openshift-azure-robot <aos-azure@redhat.com>' -m "Content update" || exit 0
+
+git push https://openshift-azure-robot:$GITHUB_TOKEN@github.com/openshift-azure-robot/openshift-azure.git HEAD:content-update -f
+
+git reset HEAD^
+
+curl -u openshift-azure-robot:$GITHUB_TOKEN -H "Content-Type:application/json" -d @- -so /dev/null https://api.github.com/repos/openshift/openshift-azure/pulls <<'EOF'
+{
+    "title": "Content update",
+    "body": "```release-notes\nNONE\n```",
+    "head": "openshift-azure-robot:content-update",
+    "base": "master"
+}
+EOF


### PR DESCRIPTION
```release-note
NONE
```

@jim-minter alternative POC for an automated script. I personally prefer golang one as it gives us more granular control. But at the same time, I can see simplicity here. WDYT?