### PR TITLE
Disallow uppercase in cluster names

### DIFF
--- a/pkg/api/validate/types.go
+++ b/pkg/api/validate/types.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	rxClusterName = regexp.MustCompile(`(?i)^([a-z0-9]|[a-z0-9][-a-z0-9]{0,61}[a-z0-9])$`)
+	rxClusterName = regexp.MustCompile(`^([a-z0-9]|[a-z0-9][-a-z0-9]{0,61}[a-z0-9])$`)
 
 	rxLocation = regexp.MustCompile(`(?i)^[a-z0-9]+$`)
 

--- a/pkg/api/validate/types_test.go
+++ b/pkg/api/validate/types_test.go
@@ -65,6 +65,8 @@ func TestIsValidClusterName(t *testing.T) {
 		"random#characters?",
 		"cluster-",
 		"-cluster",
+		"anyUPPERCASE",
+		"ExampleCluster111",
 		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 		"verylongtoolongnameitslongerthan63characterswhoopsthiswontworkatall",
 	}
@@ -79,7 +81,6 @@ func TestIsValidClusterName(t *testing.T) {
 		"0cluster",
 		"1234567890",
 		"osa-testing",
-		"ExampleCluster111",
 		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
 	}
 	for _, validClusterName := range validClusterNames {

--- a/pkg/plugin/integration_test.go
+++ b/pkg/plugin/integration_test.go
@@ -334,7 +334,7 @@ func setupNewCluster(ctx context.Context, log *logrus.Entry, cs *api.OpenShiftMa
 
 func newTestCs() *api.OpenShiftManagedCluster {
 	return &api.OpenShiftManagedCluster{
-		Name:     "integrationTest",
+		Name:     "integration-test",
 		Location: "eastus",
 		Config: api.Config{
 			ConfigStorageAccount:      "config",


### PR DESCRIPTION
```release-note
Cluster names with uppercase letters are not allowed and will fail validation.
```

Fixes #1571.

Behaviour with the patch:

```
ehashman@red-dot:~/go/src/github.com/openshift/openshift-azure$ export RESOURCEGROUP="ehashmanUPPERCASE"
ehashman@red-dot:~/go/src/github.com/openshift/openshift-azure$ ./hack/create.sh $RESOURCEGROUP 
bindata.go
bindata.go
bindata.go
bindata.go
bindata.go
bindata.go
bindata.go
bindata.go
bindata.go
bindata.go
INFO[2019-04-26T14:11:58-04:00] using region eastus                          
INFO[2019-04-26T14:11:58-04:00] ensuring resource group ehashmanUPPERCASE    
INFO[2019-04-26T14:11:59-04:00]/home/ehashman/go/src/github.com/openshift/openshift-azure/cmd/fakerp/main.go:20 main.main() starting the fake resource provider          
INFO[2019-04-26T14:11:59-04:00]/home/ehashman/go/src/github.com/openshift/openshift-azure/pkg/plugin/plugin.go:86 github.com/openshift/openshift-azure/pkg/plugin.(*plugin).ValidatePluginTemplate() validating external plugin api data models   
INFO[2019-04-26T14:11:59-04:00]/home/ehashman/go/src/github.com/openshift/openshift-azure/pkg/fakerp/server.go:82 github.com/openshift/openshift-azure/pkg/fakerp.(*Server).Run() starting server on localhost:8080            
INFO[2019-04-26T14:11:59-04:00] creating/updating cluster                    
DEBU[2019-04-26T14:11:59-04:00]/home/ehashman/go/src/github.com/openshift/openshift-azure/pkg/fakerp/middleware.go:13 github.com/openshift/openshift-azure/pkg/fakerp.(*Server).logger.func1() starting: PUT /subscriptions/225e02bc-43d0-43d1-a01a-17e584a4ef69/resourceGroups/ehashmanUPPERCASE/providers/Microsoft.ContainerService/openShiftManagedClusters/ehashmanUPPERCASE?api-version=2019-04-30 
INFO[2019-04-26T14:11:59-04:00]/home/ehashman/go/src/github.com/openshift/openshift-azure/pkg/fakerp/customer_handlers.go:135 github.com/openshift/openshift-azure/pkg/fakerp.(*Server).handlePut() read request and convert to internal         
INFO[2019-04-26T14:11:59-04:00]/home/ehashman/go/src/github.com/openshift/openshift-azure/pkg/fakerp/fakerp.go:133 github.com/openshift/openshift-azure/pkg/fakerp.createOrUpdate() enrich                                       
INFO[2019-04-26T14:11:59-04:00]/home/ehashman/go/src/github.com/openshift/openshift-azure/pkg/plugin/plugin.go:52 github.com/openshift/openshift-azure/pkg/plugin.(*plugin).Validate() validating internal data models              
DEBU[2019-04-26T14:11:59-04:00]/home/ehashman/go/src/github.com/openshift/openshift-azure/pkg/fakerp/util.go:11 github.com/openshift/openshift-azure/pkg/fakerp.(*Server).badRequest() 400 Bad Request: Failed to apply request: invalid name "ehashmanUPPERCASE" 
DEBU[2019-04-26T14:11:59-04:00]/home/ehashman/go/src/github.com/openshift/openshift-azure/pkg/fakerp/middleware.go:15 github.com/openshift/openshift-azure/pkg/fakerp.(*Server).logger.func1() ending:   PUT /subscriptions/225e02bc-43d0-43d1-a01a-17e584a4ef69/resourceGroups/ehashmanUPPERCASE/providers/Microsoft.ContainerService/openShiftManagedClusters/ehashmanUPPERCASE?api-version=2019-04-30 
FATA[2019-04-26T14:11:59-04:00] containerservice.OpenShiftManagedClustersClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: autorest/azure: error response cannot be parsed: "400 Bad Request: Failed to apply request: invalid name \"ehashmanUPPERCASE\"\n" error: json: cannot unmarshal number into Go value of type azure.RequestError 
exit status 1
signal: terminated
```