### PR TITLE
Add some default settings for AgentPoolProfiles

### DIFF
--- a/pkg/api/2018-09-30-preview/default.go
+++ b/pkg/api/2018-09-30-preview/default.go
@@ -20,14 +20,19 @@ func setDefaults(oc *OpenShiftManagedCluster) {
 	if len(oc.Properties.AgentPoolProfiles) == 0 {
 		oc.Properties.AgentPoolProfiles = []AgentPoolProfile{
 			{
-				Name:  to.StringPtr("infra"),
-				Count: to.Int64Ptr(3),
-				Role:  (*AgentPoolProfileRole)(to.StringPtr("infra")),
+				Name: to.StringPtr("infra"),
+				Role: (*AgentPoolProfileRole)(to.StringPtr("infra")),
 			},
 		}
 	}
 
 	for i := range oc.Properties.AgentPoolProfiles {
+		if oc.Properties.AgentPoolProfiles[i].Name != nil &&
+			*oc.Properties.AgentPoolProfiles[i].Name == "infra" &&
+			oc.Properties.AgentPoolProfiles[i].Count == nil {
+			oc.Properties.AgentPoolProfiles[i].Count = to.Int64Ptr(3)
+		}
+
 		if oc.Properties.AgentPoolProfiles[i].OSType == nil {
 			oc.Properties.AgentPoolProfiles[i].OSType = (*OSType)(to.StringPtr("Linux"))
 		}

--- a/pkg/api/2018-09-30-preview/default.go
+++ b/pkg/api/2018-09-30-preview/default.go
@@ -17,6 +17,22 @@ func setDefaults(oc *OpenShiftManagedCluster) {
 		oc.Properties.MasterPoolProfile.Count = to.Int64Ptr(3)
 	}
 
+	if len(oc.Properties.AgentPoolProfiles) == 0 {
+		oc.Properties.AgentPoolProfiles = []AgentPoolProfile{
+			{
+				Name:  to.StringPtr("infra"),
+				Count: to.Int64Ptr(3),
+				Role:  (*AgentPoolProfileRole)(to.StringPtr("infra")),
+			},
+		}
+	}
+
+	for i := range oc.Properties.AgentPoolProfiles {
+		if oc.Properties.AgentPoolProfiles[i].OSType == nil {
+			oc.Properties.AgentPoolProfiles[i].OSType = (*OSType)(to.StringPtr("Linux"))
+		}
+	}
+
 	if len(oc.Properties.RouterProfiles) == 0 {
 		oc.Properties.RouterProfiles = []RouterProfile{
 			{

--- a/pkg/api/2018-09-30-preview/default_test.go
+++ b/pkg/api/2018-09-30-preview/default_test.go
@@ -25,6 +25,14 @@ func sampleManagedCluster() *OpenShiftManagedCluster {
 					OSType:     (*OSType)(to.StringPtr("Windows")),
 					Role:       (*AgentPoolProfileRole)(to.StringPtr("infra")),
 				},
+				{
+					Name:       to.StringPtr("compute"),
+					Count:      to.Int64Ptr(4),
+					VMSize:     (*VMSize)(to.StringPtr("Standard_D2s_v3")),
+					SubnetCIDR: to.StringPtr("10.0.0.0/24"),
+					OSType:     (*OSType)(to.StringPtr("Windows")),
+					Role:       (*AgentPoolProfileRole)(to.StringPtr("compute")),
+				},
 			},
 			RouterProfiles: []RouterProfile{
 				{
@@ -77,6 +85,15 @@ func TestDefaults(t *testing.T) {
 					VMSize:     (*VMSize)(to.StringPtr("Standard_D2s_v3")),
 					SubnetCIDR: to.StringPtr("10.0.0.0/24"),
 				}
+			},
+		},
+		{
+			name: "sets AgentPoolProfile.Count to 3 on infra when empty",
+			changeInput: func(oc *OpenShiftManagedCluster) {
+				oc.Properties.AgentPoolProfiles[0].Count = nil
+			},
+			expectedChange: func(oc *OpenShiftManagedCluster) {
+				oc.Properties.AgentPoolProfiles[0].Count = to.Int64Ptr(3)
 			},
 		},
 		{

--- a/pkg/api/2018-09-30-preview/default_test.go
+++ b/pkg/api/2018-09-30-preview/default_test.go
@@ -16,6 +16,16 @@ func sampleManagedCluster() *OpenShiftManagedCluster {
 				VMSize:     (*VMSize)(to.StringPtr("Standard_D2s_v3")),
 				SubnetCIDR: to.StringPtr("10.0.0.0/24"),
 			},
+			AgentPoolProfiles: []AgentPoolProfile{
+				{
+					Name:       to.StringPtr("infra"),
+					Count:      to.Int64Ptr(4),
+					VMSize:     (*VMSize)(to.StringPtr("Standard_D2s_v3")),
+					SubnetCIDR: to.StringPtr("10.0.0.0/24"),
+					OSType:     (*OSType)(to.StringPtr("Windows")),
+					Role:       (*AgentPoolProfileRole)(to.StringPtr("infra")),
+				},
+			},
 			RouterProfiles: []RouterProfile{
 				{
 					Name:            to.StringPtr("Properties.RouterProfiles[0].Name"),
@@ -41,6 +51,14 @@ func TestDefaults(t *testing.T) {
 				oc.Properties.MasterPoolProfile = &MasterPoolProfile{
 					Count: to.Int64Ptr(3),
 				}
+				oc.Properties.AgentPoolProfiles = []AgentPoolProfile{
+					{
+						Name:   to.StringPtr("infra"),
+						Count:  to.Int64Ptr(3),
+						OSType: (*OSType)(to.StringPtr("Linux")),
+						Role:   (*AgentPoolProfileRole)(to.StringPtr("infra")),
+					},
+				}
 				oc.Properties.RouterProfiles = []RouterProfile{
 					{
 						Name: to.StringPtr("default"),
@@ -51,10 +69,7 @@ func TestDefaults(t *testing.T) {
 		{
 			name: "sets MasterPoolProfile.Count to 3 when empty",
 			changeInput: func(oc *OpenShiftManagedCluster) {
-				oc.Properties.MasterPoolProfile = &MasterPoolProfile{
-					VMSize:     (*VMSize)(to.StringPtr("Standard_D2s_v3")),
-					SubnetCIDR: to.StringPtr("10.0.0.0/24"),
-				}
+				oc.Properties.MasterPoolProfile.Count = nil
 			},
 			expectedChange: func(oc *OpenShiftManagedCluster) {
 				oc.Properties.MasterPoolProfile = &MasterPoolProfile{
@@ -62,6 +77,15 @@ func TestDefaults(t *testing.T) {
 					VMSize:     (*VMSize)(to.StringPtr("Standard_D2s_v3")),
 					SubnetCIDR: to.StringPtr("10.0.0.0/24"),
 				}
+			},
+		},
+		{
+			name: "sets AgentPoolProfile.OSType to Linux when empty",
+			changeInput: func(oc *OpenShiftManagedCluster) {
+				oc.Properties.AgentPoolProfiles[0].OSType = nil
+			},
+			expectedChange: func(oc *OpenShiftManagedCluster) {
+				oc.Properties.AgentPoolProfiles[0].OSType = (*OSType)(to.StringPtr("Linux"))
 			},
 		},
 		{

--- a/pkg/api/2019-04-30/default.go
+++ b/pkg/api/2019-04-30/default.go
@@ -20,14 +20,19 @@ func setDefaults(oc *OpenShiftManagedCluster) {
 	if len(oc.Properties.AgentPoolProfiles) == 0 {
 		oc.Properties.AgentPoolProfiles = []AgentPoolProfile{
 			{
-				Name:  to.StringPtr("infra"),
-				Count: to.Int64Ptr(3),
-				Role:  (*AgentPoolProfileRole)(to.StringPtr("infra")),
+				Name: to.StringPtr("infra"),
+				Role: (*AgentPoolProfileRole)(to.StringPtr("infra")),
 			},
 		}
 	}
 
 	for i := range oc.Properties.AgentPoolProfiles {
+		if oc.Properties.AgentPoolProfiles[i].Name != nil &&
+			*oc.Properties.AgentPoolProfiles[i].Name == "infra" &&
+			oc.Properties.AgentPoolProfiles[i].Count == nil {
+			oc.Properties.AgentPoolProfiles[i].Count = to.Int64Ptr(3)
+		}
+
 		if oc.Properties.AgentPoolProfiles[i].OSType == nil {
 			oc.Properties.AgentPoolProfiles[i].OSType = (*OSType)(to.StringPtr("Linux"))
 		}

--- a/pkg/api/2019-04-30/default.go
+++ b/pkg/api/2019-04-30/default.go
@@ -17,6 +17,22 @@ func setDefaults(oc *OpenShiftManagedCluster) {
 		oc.Properties.MasterPoolProfile.Count = to.Int64Ptr(3)
 	}
 
+	if len(oc.Properties.AgentPoolProfiles) == 0 {
+		oc.Properties.AgentPoolProfiles = []AgentPoolProfile{
+			{
+				Name:  to.StringPtr("infra"),
+				Count: to.Int64Ptr(3),
+				Role:  (*AgentPoolProfileRole)(to.StringPtr("infra")),
+			},
+		}
+	}
+
+	for i := range oc.Properties.AgentPoolProfiles {
+		if oc.Properties.AgentPoolProfiles[i].OSType == nil {
+			oc.Properties.AgentPoolProfiles[i].OSType = (*OSType)(to.StringPtr("Linux"))
+		}
+	}
+
 	if len(oc.Properties.RouterProfiles) == 0 {
 		oc.Properties.RouterProfiles = []RouterProfile{
 			{

--- a/pkg/api/2019-04-30/default_test.go
+++ b/pkg/api/2019-04-30/default_test.go
@@ -25,6 +25,14 @@ func sampleManagedCluster() *OpenShiftManagedCluster {
 					OSType:     (*OSType)(to.StringPtr("Windows")),
 					Role:       (*AgentPoolProfileRole)(to.StringPtr("infra")),
 				},
+				{
+					Name:       to.StringPtr("compute"),
+					Count:      to.Int64Ptr(4),
+					VMSize:     (*VMSize)(to.StringPtr("Standard_D2s_v3")),
+					SubnetCIDR: to.StringPtr("10.0.0.0/24"),
+					OSType:     (*OSType)(to.StringPtr("Windows")),
+					Role:       (*AgentPoolProfileRole)(to.StringPtr("compute")),
+				},
 			},
 			RouterProfiles: []RouterProfile{
 				{
@@ -77,6 +85,15 @@ func TestDefaults(t *testing.T) {
 					VMSize:     (*VMSize)(to.StringPtr("Standard_D2s_v3")),
 					SubnetCIDR: to.StringPtr("10.0.0.0/24"),
 				}
+			},
+		},
+		{
+			name: "sets AgentPoolProfile.Count to 3 on infra when empty",
+			changeInput: func(oc *OpenShiftManagedCluster) {
+				oc.Properties.AgentPoolProfiles[0].Count = nil
+			},
+			expectedChange: func(oc *OpenShiftManagedCluster) {
+				oc.Properties.AgentPoolProfiles[0].Count = to.Int64Ptr(3)
 			},
 		},
 		{

--- a/pkg/api/2019-04-30/default_test.go
+++ b/pkg/api/2019-04-30/default_test.go
@@ -16,6 +16,16 @@ func sampleManagedCluster() *OpenShiftManagedCluster {
 				VMSize:     (*VMSize)(to.StringPtr("Standard_D2s_v3")),
 				SubnetCIDR: to.StringPtr("10.0.0.0/24"),
 			},
+			AgentPoolProfiles: []AgentPoolProfile{
+				{
+					Name:       to.StringPtr("infra"),
+					Count:      to.Int64Ptr(4),
+					VMSize:     (*VMSize)(to.StringPtr("Standard_D2s_v3")),
+					SubnetCIDR: to.StringPtr("10.0.0.0/24"),
+					OSType:     (*OSType)(to.StringPtr("Windows")),
+					Role:       (*AgentPoolProfileRole)(to.StringPtr("infra")),
+				},
+			},
 			RouterProfiles: []RouterProfile{
 				{
 					Name:            to.StringPtr("Properties.RouterProfiles[0].Name"),
@@ -41,6 +51,14 @@ func TestDefaults(t *testing.T) {
 				oc.Properties.MasterPoolProfile = &MasterPoolProfile{
 					Count: to.Int64Ptr(3),
 				}
+				oc.Properties.AgentPoolProfiles = []AgentPoolProfile{
+					{
+						Name:   to.StringPtr("infra"),
+						Count:  to.Int64Ptr(3),
+						OSType: (*OSType)(to.StringPtr("Linux")),
+						Role:   (*AgentPoolProfileRole)(to.StringPtr("infra")),
+					},
+				}
 				oc.Properties.RouterProfiles = []RouterProfile{
 					{
 						Name: to.StringPtr("default"),
@@ -51,10 +69,7 @@ func TestDefaults(t *testing.T) {
 		{
 			name: "sets MasterPoolProfile.Count to 3 when empty",
 			changeInput: func(oc *OpenShiftManagedCluster) {
-				oc.Properties.MasterPoolProfile = &MasterPoolProfile{
-					VMSize:     (*VMSize)(to.StringPtr("Standard_D2s_v3")),
-					SubnetCIDR: to.StringPtr("10.0.0.0/24"),
-				}
+				oc.Properties.MasterPoolProfile.Count = nil
 			},
 			expectedChange: func(oc *OpenShiftManagedCluster) {
 				oc.Properties.MasterPoolProfile = &MasterPoolProfile{
@@ -62,6 +77,15 @@ func TestDefaults(t *testing.T) {
 					VMSize:     (*VMSize)(to.StringPtr("Standard_D2s_v3")),
 					SubnetCIDR: to.StringPtr("10.0.0.0/24"),
 				}
+			},
+		},
+		{
+			name: "sets AgentPoolProfile.OSType to Linux when empty",
+			changeInput: func(oc *OpenShiftManagedCluster) {
+				oc.Properties.AgentPoolProfiles[0].OSType = nil
+			},
+			expectedChange: func(oc *OpenShiftManagedCluster) {
+				oc.Properties.AgentPoolProfiles[0].OSType = (*OSType)(to.StringPtr("Linux"))
 			},
 		},
 		{


### PR DESCRIPTION
```release-note
Add a default AgentPoolProfile with name and role "infra" when not specified in new cluster configs
Set default Count to 3 for the "infra" AgentPoolProfile
Set default OSType to Linux in AgentPoolProfiles
```

Addresses #336.