### PR TITLE
Add default router profile to real rp sample manifest

### DIFF
--- a/test/manifests/realrp/create.yaml
+++ b/test/manifests/realrp/create.yaml
@@ -33,3 +33,5 @@ properties:
     vmSize: Standard_D4s_v3
     subnetCidr: 10.0.0.0/24
     osType: Linux
+  routerProfiles:
+    - name: default


### PR DESCRIPTION
This is needed when running tests against the real rp. Otherwise the cluster creation fails validation:

```
charles@titan:~/Documents/go/src/github.com/openshift/openshift-azure$ FOCUS='\[Vnet\]\[Real\]' hack/tests/e2e-create-prod.sh
./hack/create.sh charles-terraform
INFO[2019-05-09T13:48:17+02:00] using region westeurope                      
INFO[2019-05-09T13:48:17+02:00] ensuring resource group charles-terraform    
INFO[2019-05-09T13:48:19+02:00] creating/updating cluster                    
FATA[2019-05-09T13:54:24+02:00] Code="TemplateValidationError" Message="OpenShift Managed Cluster validation failed with error: [invalid properties.routerProfiles[\"default\"]]" 
exit status 1
kill: usage: kill [-s sigspec | -n signum | -sigspec] pid | jobspec ... or kill -l [sigspec]
Makefile:25: recipe for target 'create' failed

```

```release-note
NONE
```

/cc @jim-minter @mjudeikis @Makdaam 