### PR TITLE
Fix the e2e prod script to avoid double creates and fakerp-esque deletes

### DIFF
--- a/hack/tests/e2e-prod.sh
+++ b/hack/tests/e2e-prod.sh
@@ -12,7 +12,6 @@ cleanup() {
     if [[ -n "$NO_DELETE" ]]; then
         return
     fi
-    make delete
     az group delete -g "$RESOURCEGROUP" --yes --no-wait
 }
 trap cleanup EXIT
@@ -21,7 +20,5 @@ trap cleanup EXIT
 
 export RUNNING_UNDER_TEST=false
 export TEST_IN_PRODUCTION=true
-
-make create
 
 hack/e2e.sh

--- a/test/sanity/sanity.go
+++ b/test/sanity/sanity.go
@@ -16,21 +16,23 @@ import (
 var Checker *standard.SanityChecker
 
 func init() {
-	b, err := ioutil.ReadFile("../../_data/containerservice.yaml") // running via `go test`
-	if os.IsNotExist(err) {
-		b, err = ioutil.ReadFile("_data/containerservice.yaml") // running via compiled test binary
-	}
-	if err != nil {
-		panic(err)
-	}
+	if os.Getenv("TEST_IN_PRODUCTION") != "true" {
+		b, err := ioutil.ReadFile("../../_data/containerservice.yaml") // running via `go test`
+		if os.IsNotExist(err) {
+			b, err = ioutil.ReadFile("_data/containerservice.yaml") // running via compiled test binary
+		}
+		if err != nil {
+			panic(err)
+		}
 
-	var cs *api.OpenShiftManagedCluster
-	if err := yaml.Unmarshal(b, &cs); err != nil {
-		panic(err)
-	}
+		var cs *api.OpenShiftManagedCluster
+		if err := yaml.Unmarshal(b, &cs); err != nil {
+			panic(err)
+		}
 
-	Checker, err = standard.NewSanityChecker(context.Background(), testlogger.GetTestLogger(), cs)
-	if err != nil {
-		panic(err)
+		Checker, err = standard.NewSanityChecker(context.Background(), testlogger.GetTestLogger(), cs)
+		if err != nil {
+			panic(err)
+		}
 	}
 }


### PR DESCRIPTION
- it doesnt need to call `make delete` because tests run against prod without access to kubeconfigs etc
- it doesnt need to call `make create` because the tests against the real rp already create a resource group and cluster as prereqs
- do not run the sanity package init logic if we are running a test against production TEST_IN_PRODUCTION=true

/cc @jim-minter @mjudeikis

```release-note
NONE
```

closes #1622 
