### PR TITLE
Make some api properties updatable

### DIFF
--- a/pkg/api/validate/api.go
+++ b/pkg/api/validate/api.go
@@ -69,6 +69,7 @@ func (v *APIValidator) validateUpdateContainerService(cs, oldCs *api.OpenShiftMa
 			}
 		}
 	}
+	old.Properties.AuthProfile.IdentityProviders = cs.Properties.AuthProfile.IdentityProviders
 
 	if !reflect.DeepEqual(cs, old) {
 		// TODO: this is a hack because we're using deep.Equal.  To fix properly

--- a/pkg/api/validate/api.go
+++ b/pkg/api/validate/api.go
@@ -53,6 +53,12 @@ func (v *APIValidator) validateUpdateContainerService(cs, oldCs *api.OpenShiftMa
 	old.Properties.ProvisioningState = cs.Properties.ProvisioningState
 
 	for i, app := range old.Properties.AgentPoolProfiles {
+		for _, newApp := range cs.Properties.AgentPoolProfiles {
+			if newApp.Name == app.Name {
+				old.Properties.AgentPoolProfiles[i].VMSize = newApp.VMSize
+			}
+		}
+
 		if app.Role != api.AgentPoolProfileRoleCompute {
 			continue
 		}

--- a/pkg/api/validate/api_test.go
+++ b/pkg/api/validate/api_test.go
@@ -35,12 +35,9 @@ func TestAPIValidateUpdate(t *testing.T) {
 				errors.New(`invalid change [Name: new != openshift]`),
 			},
 		},
-		"secrets hidden": {
+		"change AADIdentityProvider": {
 			f: func(oc *api.OpenShiftManagedCluster) {
 				oc.Properties.AuthProfile.IdentityProviders[0].Provider.(*api.AADIdentityProvider).Secret = "new"
-			},
-			expectedErrs: []error{
-				errors.New(`invalid change [Properties.AuthProfile.IdentityProviders.slice[0].Provider.Secret: <hidden 1> != <hidden 2>]`),
 			},
 		},
 		"provisioningstate is mutable": {

--- a/pkg/api/validate/api_test.go
+++ b/pkg/api/validate/api_test.go
@@ -22,6 +22,11 @@ func TestAPIValidateUpdate(t *testing.T) {
 				oc.Properties.AgentPoolProfiles[2].Count++
 			},
 		},
+		"change compute VMSize": {
+			f: func(oc *api.OpenShiftManagedCluster) {
+				oc.Properties.AgentPoolProfiles[2].VMSize = api.StandardF16sV2
+			},
+		},
 		"invalid change": {
 			f: func(oc *api.OpenShiftManagedCluster) {
 				oc.Name = "new"

--- a/pkg/plugin/integration_test.go
+++ b/pkg/plugin/integration_test.go
@@ -510,6 +510,81 @@ func TestHowAdminConfigChangesCausesRotations(t *testing.T) {
 	}
 }
 
+func TestHowUserConfigChangesCausesRotations(t *testing.T) {
+	tests := []struct {
+		name           string
+		change         func(cs *api.OpenShiftManagedCluster)
+		expectRotation map[rotationType]bool
+	}{
+		{
+			name:           "no changes",
+			expectRotation: map[rotationType]bool{rotationMaster: false, rotationInfra: false, rotationSync: false, rotationCompute: false},
+			change:         func(cs *api.OpenShiftManagedCluster) {},
+		},
+		{
+			// Note: master and infra must be changed together.
+			name:           "change master and infra vm size",
+			expectRotation: map[rotationType]bool{rotationMaster: true, rotationInfra: true, rotationSync: false, rotationCompute: false},
+			change: func(cs *api.OpenShiftManagedCluster) {
+				for i := range cs.Properties.AgentPoolProfiles {
+					if cs.Properties.AgentPoolProfiles[i].Role != api.AgentPoolProfileRoleCompute {
+						cs.Properties.AgentPoolProfiles[i].VMSize = "Standard_D16s_v3"
+					}
+				}
+			},
+		},
+		{
+			// Note: master is rotating here, is this expected?
+			name:           "change compute vm size",
+			expectRotation: map[rotationType]bool{rotationMaster: true, rotationInfra: false, rotationSync: false, rotationCompute: true},
+			change: func(cs *api.OpenShiftManagedCluster) {
+				for i := range cs.Properties.AgentPoolProfiles {
+					if cs.Properties.AgentPoolProfiles[i].Role == api.AgentPoolProfileRoleCompute {
+						cs.Properties.AgentPoolProfiles[i].VMSize = "Standard_F16s_v2"
+					}
+				}
+			},
+		},
+	}
+
+	log := logrus.NewEntry(logrus.StandardLogger())
+	ctx := context.Background()
+	cs := newTestCs()
+	az := newFakeAzureCloud(log)
+	p, _, err := setupNewCluster(ctx, log, cs, az)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			beforeBlob, beforeSyncChecksum, err := getHashes(az, cs)
+			if err != nil {
+				t.Fatal(err)
+			}
+			oldCs := cs.DeepCopy()
+			tt.change(cs)
+
+			errs := p.Validate(ctx, cs, oldCs, false)
+			if errs != nil {
+				t.Fatal(errs)
+			}
+			perr := p.CreateOrUpdate(ctx, cs, true, getFakeDeployer(log, cs, az))
+			if perr != nil {
+				t.Fatal(perr)
+			}
+
+			afterBlob, afterSyncChecksum, err := getHashes(az, cs)
+			if err != nil {
+				t.Fatal(err)
+			}
+			rotations := getRotations(beforeBlob, afterBlob, beforeSyncChecksum, afterSyncChecksum)
+			if !reflect.DeepEqual(tt.expectRotation, rotations) {
+				t.Fatalf("rotation mismatch: expected %v, got %v", tt.expectRotation, rotations)
+			}
+		})
+	}
+}
+
 func TestHowActionsCauseRotations(t *testing.T) {
 	log := logrus.NewEntry(logrus.StandardLogger())
 	ctx := context.Background()

--- a/pkg/plugin/integration_test.go
+++ b/pkg/plugin/integration_test.go
@@ -545,6 +545,13 @@ func TestHowUserConfigChangesCausesRotations(t *testing.T) {
 				}
 			},
 		},
+		{
+			name:           "change AADIdentityProvider",
+			expectRotation: map[rotationType]bool{rotationMaster: true, rotationInfra: false, rotationSync: true, rotationCompute: false},
+			change: func(oc *api.OpenShiftManagedCluster) {
+				oc.Properties.AuthProfile.IdentityProviders[0].Provider.(*api.AADIdentityProvider).Secret = "new"
+			},
+		},
 	}
 
 	log := logrus.NewEntry(logrus.StandardLogger())
@@ -721,7 +728,6 @@ func TestHowActionsCauseRotations(t *testing.T) {
 					t.Errorf("call %s not found in %v", ec, az.ComputeRP.Calls)
 				}
 			}
-
 			nodeCount := getNodeCountFromAz(az)
 			if !reflect.DeepEqual(tt.expectNodes, nodeCount) {
 				t.Fatalf("node mismatch: expected %v, got %v", tt.expectNodes, nodeCount)


### PR DESCRIPTION
```release-note
Properties.AuthProfile.IdentityProviders[x].Provider and Properties.AgentPoolProfiles[x].VMSize can now be changed by the user using CreateOrUpdate.
```
partial #1607 