### PR TITLE
add git status for clarity

### DIFF
--- a/hack/periodic/content-update.sh
+++ b/hack/periodic/content-update.sh
@@ -1,6 +1,7 @@
 #!/bin/bash -e
 
 make content
+git status
 go generate ./...
 
 . hack/tests/ci-operator-prepare.sh


### PR DESCRIPTION
```release-note
NONE
```

Add git status as somehow Ci runs and local runs produce different content. For compare. 