### PR TITLE
Fix VirtualNetworkPeeringState check in real rp vnet test

### DIFF
--- a/test/e2e/specs/realrp/vnetpeering.go
+++ b/test/e2e/specs/realrp/vnetpeering.go
@@ -98,7 +98,7 @@ var _ = Describe("Peer Vnet tests [Vnet][Real][LongRunning]", func() {
 		Expect(err).ToNot(HaveOccurred())
 		Expect(len(*vnetPeer.VirtualNetworkPeerings)).To(Equal(1))
 		for _, vnetPeering := range *vnetPeer.VirtualNetworkPeerings {
-			Expect(vnetPeering.PeeringState).To(Equal("Connected"))
+			Expect(vnetPeering.PeeringState).To(Equal(network.VirtualNetworkPeeringState("Connected")))
 			Expect(*vnetPeering.Name).To(Equal("OSACustomerVNetPeer"))
 		}
 	})


### PR DESCRIPTION
This fixes the VirtualNetworkPeeringState check in the vnet peering e2e test against the real rp.

sample error: https://storage.googleapis.com/origin-ci-test/logs/periodic-ci-azure-e2e-prod-vnet/20/build-log.txt

```release-note
NONE
```

/cc @mjudeikis @Makdaam @jim-minter 
