### PR TITLE
Pin go-bindata in validate-generated.sh

### DIFF
--- a/hack/verify/validate-generated.sh
+++ b/hack/verify/validate-generated.sh
@@ -19,6 +19,7 @@ mkdir -p "${T}/src/github.com/openshift/openshift-azure"
 
 cp -a "${DIR}/../.." "${T}/src/github.com/openshift/openshift-azure"
 
+(GOPATH="${T}" go get -d "github.com/go-bindata/go-bindata/go-bindata" && cd "${T}/src/github.com/go-bindata/go-bindata" && git checkout -q 41975c0)
 (cd "${T}/src/github.com/openshift/openshift-azure" && GOPATH="${T}" go generate ./...)
 
 


### PR DESCRIPTION
This fixes the `validate-generated.sh` script which has caused `make verify` to fail locally for me, @Makdaam and maybe other members of the team.

This pins the version of go-bindata used to generate code in the temp directory created from the script to `41975c0`.

```release-note
NONE
```

/cc @Makdaam @mjudeikis
