### PR TITLE
Properly clean up cluster NS records from osadev.cloud dns zone

### DIFF
--- a/pkg/fakerp/customer_handlers.go
+++ b/pkg/fakerp/customer_handlers.go
@@ -36,7 +36,7 @@ func (s *Server) handleDelete(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
-	err = dm.deleteOCPDNS(req.Context(), cs)
+	err = dm.deleteDns(req.Context(), cs)
 	if err != nil {
 		s.badRequest(w, fmt.Sprintf("Failed to delete dns records: %v", err))
 		return

--- a/pkg/fakerp/fakerp.go
+++ b/pkg/fakerp/fakerp.go
@@ -175,7 +175,7 @@ func createOrUpdateWrapper(ctx context.Context, p api.Plugin, log *logrus.Entry,
 	}
 
 	log.Info("setting up DNS")
-	err = dm.createOrUpdateOCPDNS(ctx, cs)
+	err = dm.createOrUpdateDns(ctx, cs)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Adds a fix to properly clean up NS records and add more debug logs so we see better what is happening with respect to dns record set updates/deletes.
 
closes #1655 

/cc @Makdaam @mjudeikis 

```release-note
NONE
```
