### PR TITLE
[WIP] fixing context deadline issues with vnet test

### DIFF
--- a/pkg/util/azureclient/resources/groups.go
+++ b/pkg/util/azureclient/resources/groups.go
@@ -2,6 +2,7 @@ package resources
 
 import (
 	"context"
+	"time"
 
 	"github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
 	"github.com/Azure/go-autorest/autorest"
@@ -26,6 +27,7 @@ var _ GroupsClient = &groupsClient{}
 func NewGroupsClient(ctx context.Context, log *logrus.Entry, subscriptionID string, authorizer autorest.Authorizer) GroupsClient {
 	client := resources.NewGroupsClient(subscriptionID)
 	azureclient.SetupClient(ctx, log, "resources.GroupsClient", &client.Client, authorizer)
+	client.PollingDuration = 2 * time.Hour
 
 	return &groupsClient{
 		GroupsClient: client,

--- a/test/e2e/specs/realrp/vnetpeering.go
+++ b/test/e2e/specs/realrp/vnetpeering.go
@@ -33,7 +33,7 @@ var _ = Describe("Peer Vnet tests [Vnet][Real][LongRunning]", func() {
 	})
 
 	AfterEach(func() {
-		ctx, cancelFn := context.WithTimeout(context.Background(), 30*time.Minute)
+		ctx, cancelFn := context.WithTimeout(context.Background(), 2*time.Hour)
 		defer cancelFn()
 		By(fmt.Sprintf("deleting resource group %s", cfg.ResourceGroup))
 		err := azure.RPClient.Groups.Delete(ctx, cfg.ResourceGroup)


### PR DESCRIPTION
still trying to figure out how to pass this value from the test to the azure client

The issue was that PollingDuration is 15min by default if not set. And a blocking Delete() call on a resource group takes more time if there's a whole ARO cluster inside.

```release-note
NONE
```
