### PR TITLE
Reject vault names that contain MS reserved words

### DIFF
--- a/pkg/util/random/random.go
+++ b/pkg/util/random/random.go
@@ -73,11 +73,15 @@ func StorageAccountName(prefix string) (string, error) {
 
 // VaultURL returns a random string suitable for use as an Azure key vault URL
 func VaultURL(prefix string) (string, error) {
-	fqdn, err := FQDN("vault.azure.net", 24-len(prefix))
-	if err != nil {
-		return "", err
+	for {
+		fqdn, err := FQDN("vault.azure.net", 24-len(prefix))
+		if err != nil {
+			return "", err
+		}
+		if !isMicrosoftReserved(fqdn) {
+			return "https://" + prefix + fqdn, nil
+		}
 	}
-	return "https://" + prefix + fqdn, nil
 }
 
 // FQDN returns a random fully qualified domain name within a given parent


### PR DESCRIPTION
```release-note
NONE
```

Builds on #1595. Fixes #1662.