### PR TITLE
fixing etcdbackup test

### DIFF
--- a/test/e2e/specs/fakerp/etcdbackuprecovery.go
+++ b/test/e2e/specs/fakerp/etcdbackuprecovery.go
@@ -28,9 +28,9 @@ var _ = Describe("Etcd Recovery E2E tests [EtcdBackupRecovery][Fake][LongRunning
 	)
 
 	BeforeEach(func() {
-		backup, err := random.LowerCaseAlphanumericString(5)
+		randomTag, err := random.LowerCaseAlphanumericString(5)
 		Expect(err).ToNot(HaveOccurred())
-		backup = "e2e-test-" + backup
+		backup = "e2e-test-" + randomTag
 		namespace, err = random.LowerCaseAlphanumericString(5)
 		Expect(err).ToNot(HaveOccurred())
 		namespace = "e2e-test-" + namespace


### PR DESCRIPTION
making sure the backup variable is initialized before each run.
If the name of the backup is empty, fakeRP returns 404.

Fixes #1672 

```release-note
NONE
```
