### PR TITLE
Add support for etcd ca rotation

### DIFF
--- a/pkg/api/plugin.go
+++ b/pkg/api/plugin.go
@@ -60,6 +60,7 @@ const (
 	PluginStepUpdateWorkerAgentPoolDeleteVM       PluginStep = "UpdateWorkerAgentPoolDeleteVM"
 	PluginStepUpdateSyncPod                       PluginStep = "UpdateSyncPod"
 	PluginStepInvalidateClusterSecrets            PluginStep = "InvalidateClusterSecrets"
+	PluginStepInvalidateClusterCertificates       PluginStep = "InvalidateClusterCertificates"
 	PluginStepRegenerateClusterSecrets            PluginStep = "RegenerateClusterSecrets"
 )
 
@@ -135,6 +136,12 @@ type GenevaActions interface {
 
 	// RotateClusterSecrets rotates the secrets in a cluster's config blob and then updates the cluster
 	RotateClusterSecrets(ctx context.Context, cs *OpenShiftManagedCluster, deployer DeployFn) *PluginError
+
+	// RotateClusterCertificates rotates the certificates in a cluster's config blob and then updates the cluster
+	RotateClusterCertificates(ctx context.Context, cs *OpenShiftManagedCluster, deployer DeployFn) *PluginError
+
+	// RotateClusterCertificatesAndSecrets rotates the certificates and secrets in a cluster's config blob and then updates the cluster
+	RotateClusterCertificatesAndSecrets(ctx context.Context, cs *OpenShiftManagedCluster, deployer DeployFn) *PluginError
 
 	// GetControlPlanePods fetches a consolidated list of the control plane pods in the cluster
 	GetControlPlanePods(ctx context.Context, oc *OpenShiftManagedCluster) ([]byte, error)

--- a/pkg/cluster/types.go
+++ b/pkg/cluster/types.go
@@ -46,6 +46,7 @@ type Upgrader interface {
 	SortedAgentPoolProfilesForRole(role api.AgentPoolProfileRole) []api.AgentPoolProfile
 	WaitForNodesInAgentPoolProfile(ctx context.Context, app *api.AgentPoolProfile, suffix string) error
 	UpdateMasterAgentPool(ctx context.Context, app *api.AgentPoolProfile) *api.PluginError
+	UpdateMasterAgentPoolTogether(ctx context.Context, app *api.AgentPoolProfile) *api.PluginError
 	UpdateWorkerAgentPool(ctx context.Context, app *api.AgentPoolProfile, suffix string) *api.PluginError
 	CreateOrUpdateSyncPod(ctx context.Context) error
 	EtcdListBackups(ctx context.Context) ([]azstorage.Blob, error)

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -19,6 +19,7 @@ import (
 type Interface interface {
 	Generate(template *pluginapi.Config, setVersionFields bool) error
 	InvalidateSecrets() error
+	InvalidateCertificates() error
 }
 
 func New(cs *api.OpenShiftManagedCluster) (Interface, error) {

--- a/pkg/config/v4/generate.go
+++ b/pkg/config/v4/generate.go
@@ -433,6 +433,11 @@ func (g *simpleGenerator) Generate(template *pluginapi.Config, setVersionFields 
 	return
 }
 
+// InvalidateCertificates removes some certificates from an OpenShiftManagedCluster.Config
+func (g *simpleGenerator) InvalidateCertificates() (err error) {
+	return nil
+}
+
 // InvalidateSecrets removes some secrets from an OpenShiftManagedCluster.Config
 func (g *simpleGenerator) InvalidateSecrets() (err error) {
 	g.cs.Config.SSHKey = nil

--- a/pkg/config/v5/generate.go
+++ b/pkg/config/v5/generate.go
@@ -433,6 +433,11 @@ func (g *simpleGenerator) Generate(template *pluginapi.Config, setVersionFields 
 	return
 }
 
+// InvalidateCertificates removes some certificates from an OpenShiftManagedCluster.Config
+func (g *simpleGenerator) InvalidateCertificates() (err error) {
+	return nil
+}
+
 // InvalidateSecrets removes some secrets from an OpenShiftManagedCluster.Config
 func (g *simpleGenerator) InvalidateSecrets() (err error) {
 	g.cs.Config.SSHKey = nil

--- a/pkg/config/v6/generate.go
+++ b/pkg/config/v6/generate.go
@@ -433,6 +433,15 @@ func (g *simpleGenerator) Generate(template *pluginapi.Config, setVersionFields 
 	return
 }
 
+// InvalidateCertificates removes some certificates from an OpenShiftManagedCluster.Config
+func (g *simpleGenerator) InvalidateCertificates() (err error) {
+	g.cs.Config.Certificates.EtcdCa = api.CertKeyPair{}
+	g.cs.Config.Certificates.EtcdClient = api.CertKeyPair{}
+	g.cs.Config.Certificates.EtcdServer = api.CertKeyPair{}
+	g.cs.Config.Certificates.EtcdPeer = api.CertKeyPair{}
+	return nil
+}
+
 // InvalidateSecrets removes some secrets from an OpenShiftManagedCluster.Config
 func (g *simpleGenerator) InvalidateSecrets() (err error) {
 	g.cs.Config.SSHKey = nil

--- a/pkg/fakerp/admin_handlers.go
+++ b/pkg/fakerp/admin_handlers.go
@@ -83,6 +83,38 @@ func (s *Server) handleRotateSecrets(w http.ResponseWriter, req *http.Request) {
 		return
 	}
 
+	s.store.Put(cs)
+	err := writeHelpers(s.log, cs)
+	s.adminreply(w, err, nil)
+}
+
+// handleRotateCertificates handles admin requests for the rotation of cluster secrets
+func (s *Server) handleRotateCertificates(w http.ResponseWriter, req *http.Request) {
+	cs := req.Context().Value(contextKeyContainerService).(*api.OpenShiftManagedCluster)
+
+	deployer := GetDeployer(s.log, cs, s.testConfig)
+	pluginErr := s.plugin.RotateClusterCertificates(req.Context(), cs, deployer)
+	if pluginErr != nil {
+		s.badRequest(w, pluginErr.Error())
+		return
+	}
+	s.store.Put(cs)
+	err := writeHelpers(s.log, cs)
+	s.adminreply(w, err, nil)
+}
+
+// handleRotateCertificatesAndSecrets handles admin requests for the rotation of cluster secrets
+func (s *Server) handleRotateCertificatesAndSecrets(w http.ResponseWriter, req *http.Request) {
+	cs := req.Context().Value(contextKeyContainerService).(*api.OpenShiftManagedCluster)
+
+	deployer := GetDeployer(s.log, cs, s.testConfig)
+	pluginErr := s.plugin.RotateClusterCertificatesAndSecrets(req.Context(), cs, deployer)
+	if pluginErr != nil {
+		s.badRequest(w, pluginErr.Error())
+		return
+	}
+
+	s.store.Put(cs)
 	err := writeHelpers(s.log, cs)
 	s.adminreply(w, err, nil)
 }

--- a/pkg/fakerp/routes.go
+++ b/pkg/fakerp/routes.go
@@ -22,6 +22,8 @@ func (s *Server) setupRoutes() {
 	s.router.Get(filepath.Join("/admin", s.basePath, "/listBackups"), s.handleListBackups)
 	s.router.Put(filepath.Join("/admin", s.basePath, "/restore/{backupName}"), s.handleRestore)
 	s.router.Put(filepath.Join("/admin", s.basePath, "/rotate/secrets"), s.handleRotateSecrets)
+	s.router.Put(filepath.Join("/admin", s.basePath, "/rotate/certificates"), s.handleRotateCertificates)
+	s.router.Put(filepath.Join("/admin", s.basePath, "/rotate/certificatesAndSecrets"), s.handleRotateCertificatesAndSecrets)
 	s.router.Get(filepath.Join("/admin", s.basePath, "/status"), s.handleGetControlPlanePods)
 	s.router.Put(filepath.Join("/admin", s.basePath, "/forceUpdate"), s.handleForceUpdate)
 	s.router.Get(filepath.Join("/admin", s.basePath, "/listClusterVMs"), s.handleListClusterVMs)

--- a/pkg/util/azureclient/openshiftmanagedcluster/admin/client.go
+++ b/pkg/util/azureclient/openshiftmanagedcluster/admin/client.go
@@ -132,6 +132,16 @@ func (c *Client) RotateSecrets(ctx context.Context, resourceGroupName, resourceN
 	return
 }
 
+func (c *Client) RotateCertificates(ctx context.Context, resourceGroupName, resourceName string) (err error) {
+	err = c.do(http.MethodPut, resourceGroupName, resourceName, "/rotate/certificates", nil, nil)
+	return
+}
+
+func (c *Client) RotateCertificatesAndSecrets(ctx context.Context, resourceGroupName, resourceName string) (err error) {
+	err = c.do(http.MethodPut, resourceGroupName, resourceName, "/rotate/certificatesAndSecrets", nil, nil)
+	return
+}
+
 func (c *Client) RunCommand(ctx context.Context, resourceGroupName, resourceName, hostname, command string) (err error) {
 	err = c.do(http.MethodPut, resourceGroupName, resourceName, "/runCommand/"+hostname+"/"+command, nil, nil)
 	return

--- a/pkg/util/mocks/mock_cluster/types.go
+++ b/pkg/util/mocks/mock_cluster/types.go
@@ -336,6 +336,20 @@ func (mr *MockUpgraderMockRecorder) UpdateMasterAgentPool(arg0, arg1 interface{}
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMasterAgentPool", reflect.TypeOf((*MockUpgrader)(nil).UpdateMasterAgentPool), arg0, arg1)
 }
 
+// UpdateMasterAgentPoolTogether mocks base method
+func (m *MockUpgrader) UpdateMasterAgentPoolTogether(arg0 context.Context, arg1 *api.AgentPoolProfile) *api.PluginError {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "UpdateMasterAgentPoolTogether", arg0, arg1)
+	ret0, _ := ret[0].(*api.PluginError)
+	return ret0
+}
+
+// UpdateMasterAgentPoolTogether indicates an expected call of UpdateMasterAgentPoolTogether
+func (mr *MockUpgraderMockRecorder) UpdateMasterAgentPoolTogether(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "UpdateMasterAgentPoolTogether", reflect.TypeOf((*MockUpgrader)(nil).UpdateMasterAgentPoolTogether), arg0, arg1)
+}
+
 // UpdateWorkerAgentPool mocks base method
 func (m *MockUpgrader) UpdateWorkerAgentPool(arg0 context.Context, arg1 *api.AgentPoolProfile, arg2 string) *api.PluginError {
 	m.ctrl.T.Helper()

--- a/pkg/util/mocks/mock_config/config.go
+++ b/pkg/util/mocks/mock_config/config.go
@@ -62,3 +62,17 @@ func (mr *MockInterfaceMockRecorder) InvalidateSecrets() *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InvalidateSecrets", reflect.TypeOf((*MockInterface)(nil).InvalidateSecrets))
 }
+
+// InvalidateCertificates mocks base method
+func (m *MockInterface) InvalidateCertificates() error {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "InvalidateCertificates")
+	ret0, _ := ret[0].(error)
+	return ret0
+}
+
+// InvalidateCertificates indicates an expected call of InvalidateCertificates
+func (mr *MockInterfaceMockRecorder) InvalidateCertificates() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "InvalidateCertificates", reflect.TypeOf((*MockInterface)(nil).InvalidateCertificates))
+}

--- a/test/e2e/specs/fakerp/carotation.go
+++ b/test/e2e/specs/fakerp/carotation.go
@@ -1,0 +1,44 @@
+package fakerp
+
+import (
+	"context"
+	"os"
+
+	. "github.com/onsi/ginkgo"
+	. "github.com/onsi/gomega"
+
+	"github.com/openshift/openshift-azure/test/clients/azure"
+	"github.com/openshift/openshift-azure/test/sanity"
+)
+
+var _ = Describe("Ca Rotation E2E tests [CaRotation][Fake][LongRunning]", func() {
+	It("should be possible to maintain a healthy cluster after rotating all certificates", func() {
+		By("Reading the cluster state")
+		before, err := azure.RPClient.OpenShiftManagedClustersAdmin.Get(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(before).NotTo(BeNil())
+
+		By("Executing Certificate rotation on the cluster.")
+		err = azure.RPClient.OpenShiftManagedClustersAdmin.RotateCertificates(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
+		Expect(err).NotTo(HaveOccurred())
+
+		By("Reading the cluster state after the update")
+		after, err := azure.RPClient.OpenShiftManagedClustersAdmin.Get(context.Background(), os.Getenv("RESOURCEGROUP"), os.Getenv("RESOURCEGROUP"))
+		Expect(err).NotTo(HaveOccurred())
+		Expect(after).NotTo(BeNil())
+
+		By("Verifying that the correct ca certificates have been updated")
+		Expect(before.Config.Certificates.ServiceSigningCa.Cert).To(Equal(after.Config.Certificates.ServiceSigningCa.Cert))
+		Expect(before.Config.Certificates.ServiceCatalogCa.Cert).To(Equal(after.Config.Certificates.ServiceCatalogCa.Cert))
+		Expect(before.Config.Certificates.FrontProxyCa.Cert).To(Equal(after.Config.Certificates.FrontProxyCa.Cert))
+		Expect(before.Config.Certificates.EtcdCa.Cert).NotTo(Equal(after.Config.Certificates.EtcdCa.Cert))
+		Expect(before.Config.Certificates.EtcdClient.Cert).NotTo(Equal(after.Config.Certificates.EtcdClient.Cert))
+		Expect(before.Config.Certificates.EtcdPeer.Cert).NotTo(Equal(after.Config.Certificates.EtcdPeer.Cert))
+		Expect(before.Config.Certificates.EtcdServer.Cert).NotTo(Equal(after.Config.Certificates.EtcdServer.Cert))
+		Expect(before.Config.Certificates.Ca.Cert).To(Equal(after.Config.Certificates.Ca.Cert))
+
+		By("Validating the cluster")
+		errs := sanity.Checker.ValidateCluster(context.Background())
+		Expect(errs).To(BeEmpty())
+	})
+})


### PR DESCRIPTION
Jira AZURE-198

```release-note
Microsoft: Add geneva actions for rotating certificates and certificatesAndSecrets.
```
The current implementation just rotates etcd certificates and support for the other certs will be added soon.
