### PR TITLE
individual artifact gathering on test failures

### DIFF
--- a/test/clients/openshift/dumpinfo.go
+++ b/test/clients/openshift/dumpinfo.go
@@ -12,6 +12,7 @@ import (
 	buildschema "github.com/openshift/client-go/build/clientset/versioned/scheme"
 	"github.com/pkg/errors"
 	"github.com/sirupsen/logrus"
+	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
@@ -19,32 +20,49 @@ var (
 	artifactDir = flag.String("artifact-dir", "", "Directory to place artifacts when a test fails")
 )
 
-func (cli *Client) DumpInfo(namespace string) error {
-	if err := cli.dumpEvents(namespace); err != nil {
+// DumpInfo dumps logs and events from the clusters
+// to sub-directory in ARTIFACTS folder
+func (cli *Client) DumpInfo(namespace, subDir string) error {
+	// namespace = "" is same as --all-namespaces
+	var dir string
+	if os.Getenv("ARTIFACTS") != "" {
+		dir = filepath.Join(os.Getenv("ARTIFACTS"), subDir)
+	} else {
+		dir = filepath.Join(*artifactDir, subDir)
+	}
+	err := os.MkdirAll(dir, 0755)
+	if err != nil {
 		return err
 	}
-	if err := cli.dumpPods(namespace); err != nil {
+
+	if err := cli.dumpEvents(namespace, dir); err != nil {
 		return err
 	}
-	if err := cli.dumpBuilds(namespace); err != nil {
+	if err := cli.dumpPods(namespace, dir); err != nil {
 		return err
+	}
+	if err := cli.dumpBuilds(namespace, dir); err != nil {
+		return err
+	}
+	if namespace != "" {
+		if err := cli.dumpPodsLogs(namespace, dir); err != nil {
+			return err
+		}
 	}
 	return nil
 }
 
-func (cli *Client) dumpBuildLog(name, namespace string, f *os.File) error {
+func (cli *Client) dumpBuildLog(name, namespace, dir string, f *os.File) error {
 	buildLogOptions := buildv1client.BuildLogOptions{
 		Follow: true,
 		NoWait: false,
 	}
-	if *artifactDir != "" {
-		var err error
-		f, err = os.Create(filepath.Join(*artifactDir, fmt.Sprintf("build-%s-%s.log", namespace, name)))
-		if err != nil {
-			logrus.Warn(err)
-		} else {
-			defer f.Close()
-		}
+	var err error
+	f, err = os.Create(filepath.Join(dir, fmt.Sprintf("build-%s.log", name)))
+	if err != nil {
+		logrus.Warn(err)
+	} else {
+		defer f.Close()
 	}
 
 	rd, err := cli.BuildV1.RESTClient().Get().
@@ -66,18 +84,17 @@ func (cli *Client) dumpBuildLog(name, namespace string, f *os.File) error {
 	return nil
 }
 
-func (cli *Client) dumpBuilds(namespace string) error {
-	f := os.Stdout
+func (cli *Client) dumpPodLogs(namespace, dir string) error {
 
-	if *artifactDir != "" {
-		var err error
-		f, err = os.Create(filepath.Join(*artifactDir, fmt.Sprintf("builds-%s.yaml", namespace)))
-		if err != nil {
-			logrus.Warn(err)
-		} else {
-			defer f.Close()
-		}
+	return nil
+}
+
+func (cli *Client) dumpBuilds(namespace, dir string) error {
+	out, err := os.OpenFile(filepath.Join(dir, "builds.yaml"), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
+	if err != nil {
+		return err
 	}
+	defer out.Close()
 
 	list, err := cli.BuildV1.Builds(namespace).List(metav1.ListOptions{})
 	if err != nil {
@@ -90,11 +107,11 @@ func (cli *Client) dumpBuilds(namespace string) error {
 			return err
 		}
 
-		_, err = fmt.Fprintln(f, string(b))
+		_, err = fmt.Fprintln(out, string(b))
 		if err != nil {
 			return err
 		}
-		err = cli.dumpBuildLog(build.Name, build.Namespace, os.Stdout)
+		err = cli.dumpBuildLog(build.Name, build.Namespace, dir, os.Stdout)
 		if err != nil {
 			return err
 		}
@@ -103,32 +120,25 @@ func (cli *Client) dumpBuilds(namespace string) error {
 	return nil
 }
 
-func (cli *Client) dumpEvents(namespace string) error {
-	f := os.Stdout
-
-	if *artifactDir != "" {
-		var err error
-		f, err = os.Create(filepath.Join(*artifactDir, fmt.Sprintf("events-%s.yaml", namespace)))
-		if err != nil {
-			logrus.Warn(err)
-		} else {
-			defer f.Close()
-		}
+func (cli *Client) dumpEvents(namespace, dir string) error {
+	out, err := os.OpenFile(filepath.Join(dir, "events.yaml"), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
+	if err != nil {
+		return err
 	}
+	defer out.Close()
 
 	list, err := cli.CoreV1.Events(namespace).List(metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
 
-	for _, event := range list.Items {
-		b, err := yaml.Marshal(event)
+	for _, item := range list.Items {
+		b, err := yaml.Marshal(item)
 		if err != nil {
 			return err
 		}
 
-		_, err = fmt.Fprintln(f, string(b))
-		if err != nil {
+		if _, err := out.WriteString(string(b)); err != nil {
 			return err
 		}
 	}
@@ -136,35 +146,58 @@ func (cli *Client) dumpEvents(namespace string) error {
 	return nil
 }
 
-func (cli *Client) dumpPods(namespace string) error {
-	f := os.Stdout
-
-	if *artifactDir != "" {
-		var err error
-		f, err = os.Create(filepath.Join(*artifactDir, fmt.Sprintf("pods-%s.yaml", namespace)))
-		if err != nil {
-			logrus.Warn(err)
-		} else {
-			defer f.Close()
-		}
+func (cli *Client) dumpPods(namespace, dir string) error {
+	out, err := os.OpenFile(filepath.Join(dir, "pods.yaml"), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
+	if err != nil {
+		return err
 	}
+	defer out.Close()
 
 	list, err := cli.CoreV1.Pods(namespace).List(metav1.ListOptions{})
 	if err != nil {
 		return err
 	}
 
-	for _, event := range list.Items {
-		b, err := yaml.Marshal(event)
+	for _, item := range list.Items {
+		b, err := yaml.Marshal(item)
 		if err != nil {
 			return err
 		}
 
-		_, err = fmt.Fprintln(f, string(b))
-		if err != nil {
+		if _, err := out.WriteString(string(b)); err != nil {
 			return err
 		}
 	}
 
+	return nil
+}
+
+func (cli *Client) dumpPodsLogs(namespace, dir string) error {
+	pods, err := cli.CoreV1.Pods(namespace).List(metav1.ListOptions{})
+	if err != nil {
+		return err
+	}
+
+	podLogOpt := corev1.PodLogOptions{}
+	for _, pod := range pods.Items {
+		fmt.Printf("log for %s\n", pod.Name)
+		req := cli.CoreV1.Pods(pod.Namespace).GetLogs(pod.Name, &podLogOpt)
+		podLogs, err := req.Stream()
+		if err != nil {
+			return fmt.Errorf("error in opening stream %v", err)
+		}
+		defer podLogs.Close()
+
+		out, err := os.OpenFile(filepath.Join(dir, pod.Name+".log"), os.O_WRONLY|os.O_CREATE|os.O_TRUNC, 0666)
+		if err != nil {
+			return err
+		}
+		defer out.Close()
+
+		_, err = io.Copy(out, podLogs)
+		if err != nil {
+			return fmt.Errorf("error in coping logs %v", err)
+		}
+	}
 	return nil
 }

--- a/test/e2e/specs/osba_app.go
+++ b/test/e2e/specs/osba_app.go
@@ -98,7 +98,7 @@ var _ = Describe("Openshift on Azure end user e2e tests [CustomerAdmin][Fake][Ev
 		By("validating openshift broker app")
 		if err = validateOSBAApp(ctx); err != nil {
 			errs = append(errs, err)
-			if err = sanity.Checker.Client.CustomerAdmin.DumpInfo("osba"); err != nil {
+			if err = sanity.Checker.Client.CustomerAdmin.DumpInfo("osba", "validateOSBAApp"); err != nil {
 				errs = append(errs, err)
 			}
 		}

--- a/test/e2e/standard/cluster.go
+++ b/test/e2e/standard/cluster.go
@@ -264,7 +264,7 @@ func (sc *SanityChecker) checkCanCreateLB(ctx context.Context) error {
 		By(fmt.Sprintf("waiting for %s to be ready (%v)", lb, time.Now()))
 		err = wait.PollImmediate(2*time.Second, 10*time.Minute, ready.CheckServiceIsReady(sc.Client.EndUser.CoreV1.Services(namespace), lb))
 		if err != nil {
-			sc.Client.EndUser.DumpInfo(namespace)
+			sc.Client.EndUser.DumpInfo(namespace, "checkCanCreateLB")
 			return err
 		}
 	}

--- a/test/e2e/standard/sanitychecker.go
+++ b/test/e2e/standard/sanitychecker.go
@@ -85,6 +85,12 @@ func (sc *SanityChecker) CreateTestApp(ctx context.Context) (interface{}, []*Tes
 		sc.Log.Error(err)
 		errs = append(errs, &TestError{Err: err, Bucket: "createStatefulApp"})
 	}
+	if len(errs) > 0 {
+		err := sc.Client.EndUser.DumpInfo(namespace, "createStatefulApp")
+		if err != nil {
+			sc.Log.Warn(err)
+		}
+	}
 	return namespace, errs
 }
 
@@ -133,6 +139,12 @@ func (sc *SanityChecker) ValidateTestApp(ctx context.Context, cookie interface{}
 			errs = append(errs, &TestError{Err: err, Bucket: "validateStatefulApp"})
 		}
 	}
+	if len(errs) > 0 {
+		err := sc.Client.EndUser.DumpInfo(namespace, "validateStatefulApp")
+		if err != nil {
+			sc.Log.Warn(err)
+		}
+	}
 	return
 }
 
@@ -147,48 +159,56 @@ func (sc *SanityChecker) ValidateCluster(ctx context.Context) (errs []*TestError
 	err = sc.checkMonitoringStackHealth(ctx)
 	if err != nil {
 		sc.Log.Error(err)
+		sc.Client.EndUser.DumpInfo("", "checkMonitoringStackHealth")
 		errs = append(errs, &TestError{Err: err, Bucket: "checkMonitoringStackHealth"})
 	}
 	sc.Log.Debugf("validating that pod disruption budgets are immutable")
 	err = sc.checkDisallowsPdbMutations(ctx)
 	if err != nil {
 		sc.Log.Error(err)
+		sc.Client.EndUser.DumpInfo("", "checkDisallowsPdbMutations")
 		errs = append(errs, &TestError{Err: err, Bucket: "checkDisallowsPdbMutations"})
 	}
 	sc.Log.Debugf("validating that an end user cannot access infrastructure components")
 	err = sc.checkCannotAccessInfraResources(ctx)
 	if err != nil {
 		sc.Log.Error(err)
+		sc.Client.EndUser.DumpInfo("", "checkCannotAccessInfraResources")
 		errs = append(errs, &TestError{Err: err, Bucket: "checkCannotAccessInfraResources"})
 	}
 	sc.Log.Debugf("validating that the cluster can pull redhat.io images")
 	err = sc.checkCanDeployRedhatIoImages(ctx)
 	if err != nil {
 		sc.Log.Error(err)
+		sc.Client.EndUser.DumpInfo("", "checkCanDeployRedhatIoImages")
 		errs = append(errs, &TestError{Err: err, Bucket: "checkCanDeployRedhatIoImages"})
 	}
 	sc.Log.Debugf("validating that the cluster can create ELB and ILB")
 	err = sc.checkCanCreateLB(ctx)
 	if err != nil {
 		sc.Log.Error(err)
+		sc.Client.EndUser.DumpInfo("", "checkCanCreateLB")
 		errs = append(errs, &TestError{Err: err, Bucket: "checkCanCreateLB"})
 	}
 	sc.Log.Debugf("validating that cluster services are available")
 	err = sc.checkCanAccessServices(ctx)
 	if err != nil {
 		sc.Log.Error(err)
+		sc.Client.EndUser.DumpInfo("", "checkCanAccessServices")
 		errs = append(errs, &TestError{Err: err, Bucket: "checkCanAccessServices"})
 	}
 	sc.Log.Debugf("validating that the cluster can use azure-file storage")
 	err = sc.checkCanUseAzureFileStorage(ctx)
 	if err != nil {
 		sc.Log.Error(err)
+		sc.Client.EndUser.DumpInfo("", "checkCanUseAzureFile")
 		errs = append(errs, &TestError{Err: err, Bucket: "checkCanUseAzureFile"})
 	}
 	sc.Log.Debugf("validating that Docker builds are not permitted")
 	err = sc.checkCantDoDockerBuild(ctx)
 	if err != nil {
 		sc.Log.Error(err)
+		sc.Client.EndUser.DumpInfo("", "checkCantDoDockerBuild")
 		errs = append(errs, &TestError{Err: err, Bucket: "checkCantDoDockerBuild"})
 	}
 	return

--- a/test/e2e/standard/testapps.go
+++ b/test/e2e/standard/testapps.go
@@ -26,7 +26,7 @@ func (sc *SanityChecker) createStatefulApp(ctx context.Context, namespace string
 	sc.Log.Debugf("instantiating %s template", statefulApp)
 	err := sc.Client.EndUser.InstantiateTemplate(statefulApp, namespace)
 	if err != nil {
-		sc.Client.EndUser.DumpInfo(namespace)
+		sc.Client.EndUser.DumpInfo(namespace, "createStatefulApp")
 		return err
 	}
 	return nil
@@ -36,7 +36,7 @@ func (sc *SanityChecker) createStatelessApp(ctx context.Context, namespace strin
 	sc.Log.Debugf("instantiating %s template", statelessApp)
 	err := sc.Client.EndUser.InstantiateTemplate(statelessApp, namespace)
 	if err != nil {
-		sc.Client.EndUser.DumpInfo(namespace)
+		sc.Client.EndUser.DumpInfo(namespace, "createStatelessApp")
 		return err
 	}
 	return nil


### PR DESCRIPTION
```release-note
NONE
```

Adds basic event and logs gathering for pods for individual tests. This should help to identify cluster state during test failure instead of looking to artefacts at the end of execution where failure mode is already gone