### PR TITLE
Add labels to sync's service spec

### DIFF
--- a/pkg/cluster/kubeclient/syncpod.go
+++ b/pkg/cluster/kubeclient/syncpod.go
@@ -143,6 +143,9 @@ func (u *Kubeclientset) EnsureSyncPod(ctx context.Context, syncImage string, has
 			ObjectMeta: metav1.ObjectMeta{
 				Name:      "sync",
 				Namespace: "kube-system",
+				Labels: map[string]string{
+					"app": "sync",
+				},
 			},
 			Spec: corev1.ServiceSpec{
 				Ports: []corev1.ServicePort{


### PR DESCRIPTION
This adds labels to the sync's service spec which in turn allows
targeting of the service by the sync's prometheus ServiceMonitor

```release-note
NONE
```
