### PR TITLE
enabling Sync pod test on EveryPR

### DIFF
--- a/test/e2e/specs/fakerp/sync.go
+++ b/test/e2e/specs/fakerp/sync.go
@@ -12,7 +12,7 @@ import (
 	"github.com/openshift/openshift-azure/test/sanity"
 )
 
-var _ = Describe("sync pod tests [Fake]", func() {
+var _ = Describe("sync pod tests [Fake][EveryPR]", func() {
 	It("should not continuously update objects", func() {
 		pods, err := sanity.Checker.Client.Admin.CoreV1.Pods("kube-system").List(metav1.ListOptions{LabelSelector: "app=sync"})
 		Expect(err).ToNot(HaveOccurred())


### PR DESCRIPTION
```release-note
NONE
```
After #1543 is fixed enables the sync pod test on Every PR.
This will detect changes which cause sync pod to update a resource on every run.