### PR TITLE
Add --all flag to git add in content-update script

### DIFF
--- a/hack/periodic/content-update.sh
+++ b/hack/periodic/content-update.sh
@@ -6,7 +6,7 @@ go generate ./...
 
 . hack/tests/ci-prepare.sh
 
-git add pkg/sync/v$(ls -d pkg/sync/v* | sed -e 's/.*v//' | sort -n | tail -1)
+git add --all pkg/sync/v$(ls -d pkg/sync/v* | sed -e 's/.*v//' | sort -n | tail -1)
 GIT_COMMITTER_NAME=openshift-azure-robot GIT_COMMITTER_EMAIL=aos-azure@redhat.com git commit --no-gpg-sign --author 'openshift-azure-robot <aos-azure@redhat.com>' -m "Content update" || exit 0
 
 git push https://openshift-azure-robot:$GITHUB_TOKEN@github.com/openshift-azure-robot/openshift-azure.git HEAD:content-update -f


### PR DESCRIPTION
This should fix the content update `make verify` flake which shows up
in the content update job from time to time.

The problem is that an older version of git is used in the ci-base image
(ci-base is used to run hack/periodic/content-update.sh) and the semantics
of `git add` is different in that version to what it is in version 2 with respect 
to deleted paths.

```
warning: You ran 'git add' with neither '-A (--all)' or '--ignore-removal',
whose behaviour will change in Git 2.0 with respect to paths you removed.
Paths like 'pkg/sync/v6/data/Template.template.openshift.io/openshift/eap71-amq-persistent-s2i.yaml' that are
removed from your working tree are ignored with this version of Git.

* 'git add --ignore-removal <pathspec>', which is the current default,
  ignores paths you removed from your working tree.

* 'git add --all <pathspec>' will let you also record the removals.
```

sample content update with `to be deleted` paths: https://storage.googleapis.com/origin-ci-test/logs/periodic-ci-azure-content-update/45/build-log.txt

```release-notes
NONE
```

/cc @mjudeikis @jim-minter @makdaam

```release-note
```
