### PR TITLE
Re-add default router profile to real rp sample manifest

### DIFF
--- a/test/manifests/realrp/create.yaml
+++ b/test/manifests/realrp/create.yaml
@@ -33,3 +33,5 @@ properties:
     vmSize: Standard_D4s_v3
     subnetCidr: 10.0.0.0/24
     osType: Linux
+  routerProfiles:
+  - name: default


### PR DESCRIPTION
@ehashman's defaulting work got merged but hasn't made it to all earlier versions
of the plugin deployed on the RP. Therefore #1738 was hastily merged.

We can only take this out after all supported versions in production
contain the defaulting code.

sample error artifacts: https://storage.googleapis.com/origin-ci-test/logs/periodic-ci-azure-e2e-prod-vnet/61/build-log.txt

/cc @ehashman @thekad @makdaam @gburges 

```release-note
NONE
```
