### PR TITLE
Make the AAD sync test more robust

### DIFF
--- a/test/e2e/specs/customer_admin.go
+++ b/test/e2e/specs/customer_admin.go
@@ -2,6 +2,7 @@ package specs
 
 import (
 	"errors"
+	"strings"
 	"time"
 
 	. "github.com/onsi/ginkgo"
@@ -251,8 +252,13 @@ var _ = Describe("Openshift on Azure customer-admin e2e tests [CustomerAdmin][Fa
 				return err == nil, err
 			})
 			Expect(err).ToNot(HaveOccurred())
-			Expect(g.Users).To(HaveLen(1))
-			Expect(g.Users[0]).To(HavePrefix("testuserdisabled"))
+			found := false
+			for _, user := range g.Users {
+				if strings.HasPrefix(user, "testuserdisabled") {
+					found = true
+				}
+			}
+			Expect(found).To(Equal(true))
 		}
 	})
 	// Placeholder to test that a ded admin cannot delete pods in the default or openshift- namespaces


### PR DESCRIPTION
```release-note
NONE
```
This is needed because the test group has more members now:

```
Openshift on Azure customer-admin e2e tests [CustomerAdmin][Fake][EveryPR]
/home/prow/go/src/github.com/openshift/openshift-azure/test/e2e/specs/customer_admin.go:25
  should sync AAD admin group [It]
  /home/prow/go/src/github.com/openshift/openshift-azure/test/e2e/specs/customer_admin.go:235
   Expected
      <v1.OptionalNames | len:6, cap:8>: [
          "ehashman@rhcuppettgmail.onmicrosoft.com",
          "jgallego@rhcuppettgmail.onmicrosoft.com",
          "jminter@rhcuppettgmail.onmicrosoft.com",
          "ljakubow@rhcuppettgmail.onmicrosoft.com",
          "mjudeikis@rhcuppettgmail.onmicrosoft.com",
          "testuserdisabled@rhcuppettgmail.onmicrosoft.com",
      ]
  to have length 1
```