### PR TITLE
Update allowed cluster names to match ARM validation

### DIFF
--- a/pkg/api/validate/types.go
+++ b/pkg/api/validate/types.go
@@ -12,7 +12,7 @@ import (
 )
 
 var (
-	rxClusterName = regexp.MustCompile(`(?i)^([a-z0-9]|[a-z0-9][-a-z0-9]{0,61}[a-z0-9])$`)
+	rxClusterName = regexp.MustCompile(`^[-\w\._\(\)]+$`)
 
 	rxLocation = regexp.MustCompile(`(?i)^[a-z0-9]+$`)
 

--- a/pkg/api/validate/types_test.go
+++ b/pkg/api/validate/types_test.go
@@ -59,14 +59,9 @@ func TestValidatePluginVersion(t *testing.T) {
 func TestIsValidClusterName(t *testing.T) {
 	invalidClusterNames := []string{
 		"",
-		"-",
-		"my.cluster",
+		"✨️",
 		"has spaces",
 		"random#characters?",
-		"cluster-",
-		"-cluster",
-		"aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa",
-		"verylongtoolongnameitslongerthan63characterswhoopsthiswontworkatall",
 	}
 	for _, invalidClusterName := range invalidClusterNames {
 		if isValidClusterName(invalidClusterName) {
@@ -74,9 +69,15 @@ func TestIsValidClusterName(t *testing.T) {
 		}
 	}
 	validClusterNames := []string{
+		"-",
 		"k",
 		"k0",
+		"ARO3.11",
+		"cluster-",
+		"_cluster",
 		"0cluster",
+		"(cluster)",
+		"my.cluster",
 		"1234567890",
 		"osa-testing",
 		"ExampleCluster111",

--- a/pkg/api/validate/validators_test.go
+++ b/pkg/api/validate/validators_test.go
@@ -157,8 +157,8 @@ func TestValidate(t *testing.T) {
 			expectedErrs: []error{errors.New(`invalid name ""`)},
 		},
 		"invalid name": {
-			f:            func(oc *api.OpenShiftManagedCluster) { oc.Name = "cluster.name" },
-			expectedErrs: []error{errors.New(`invalid name "cluster.name"`)},
+			f:            func(oc *api.OpenShiftManagedCluster) { oc.Name = "cluster name" },
+			expectedErrs: []error{errors.New(`invalid name "cluster name"`)},
 		},
 		"openshift config invalid api fqdn": {
 			f: func(oc *api.OpenShiftManagedCluster) {


### PR DESCRIPTION
```release-note
Update cluster name validation to match ARM RG regex
```

Fixes #1753.