### PR TITLE
Disable debug mode in conformance test script

### DIFF
--- a/hack/tests/origin-conformance.sh
+++ b/hack/tests/origin-conformance.sh
@@ -1,4 +1,4 @@
-#!/bin/bash -ex
+#!/bin/bash -e
 
 PATH="$(go env GOPATH)/bin":$PATH
 TEST_SUITE="${TEST_SUITE:-openshift/conformance/parallel/minimal}"


### PR DESCRIPTION
This has caused our secrets to leak in CI. See https://prow.svc.ci.openshift.org/job-history/origin-ci-test/pr-logs/directory/pull-ci-azure-master-e2e-azure-conformance.

We probably should rotate them asap.

```release-notes
NONE
```

/cc @thekad @mjudeikis @jim-minter

```release-note
```
