### PR TITLE
ETCD Backup before update

### DIFF
--- a/pkg/api/plugin.go
+++ b/pkg/api/plugin.go
@@ -20,6 +20,7 @@ const (
 	PluginStepInitializeUpdateBlob                PluginStep = "InitializeUpdateBlob"
 	PluginStepResetUpdateBlob                     PluginStep = "ResetUpdateBlob"
 	PluginStepEtcdListBackups                     PluginStep = "EtcdListBackups"
+	PluginStepEtcdBackup                          PluginStep = "EtcdBackup"
 	PluginStepClientCreation                      PluginStep = "ClientCreation"
 	PluginStepEnrichCertificatesFromVault         PluginStep = "EnrichCertificatesFromVault"
 	PluginStepEnrichStorageAccountKeys            PluginStep = "EnrichStorageAccountKeys"

--- a/pkg/api/validate/types.go
+++ b/pkg/api/validate/types.go
@@ -152,6 +152,15 @@ func isValidIPV4CIDR(cidr string) bool {
 
 func IsValidBlobName(c string) bool {
 	// https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata
+	if len(c) < 1 || len(c) > 1024 {
+		return false
+	}
+	if strings.HasSuffix(c, ".") || strings.HasSuffix(c, "/") {
+		return false
+	}
+	if strings.Contains(c, "./") || strings.Contains(c, "/.") {
+		return false
+	}
 	u, err := url.Parse(fmt.Sprintf("http://example.com/%s", c))
 	if err != nil {
 		return false

--- a/pkg/api/validate/types.go
+++ b/pkg/api/validate/types.go
@@ -1,7 +1,9 @@
 package validate
 
 import (
+	"fmt"
 	"net"
+	"net/url"
 	"regexp"
 	"strconv"
 	"strings"
@@ -34,8 +36,6 @@ var (
 
 	// This regexp is to guard against InvalidDomainNameLabel for hostname validation
 	rxCloudDomainLabel = regexp.MustCompile(`^[a-z][a-z0-9-]{1,61}[a-z0-9]\.`)
-
-	rxBlobContainerName = regexp.MustCompile(`^[a-z0-9-]{3,63}$`)
 
 	// This regexp is to check image version format
 	rxImageVersion = regexp.MustCompile(`^[0-9]{3}.[0-9]{1,4}.[0-9]{8}$`)
@@ -150,16 +150,15 @@ func isValidIPV4CIDR(cidr string) bool {
 	return true
 }
 
-func IsValidBlobContainerName(c string) bool {
+func IsValidBlobName(c string) bool {
 	// https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata
-	if !rxBlobContainerName.MatchString(c) {
+	u, err := url.Parse(fmt.Sprintf("http://example.com/%s", c))
+	if err != nil {
 		return false
 	}
-
-	if strings.Trim(c, "-") != c || strings.Contains(c, "--") {
+	if u.EscapedPath() != "/"+c {
 		return false
 	}
-
 	return true
 }
 

--- a/pkg/api/validate/types_test.go
+++ b/pkg/api/validate/types_test.go
@@ -1,8 +1,10 @@
 package validate
 
 import (
+	"fmt"
 	"net"
 	"testing"
+	"time"
 )
 
 func TestValidateImageVersion(t *testing.T) {
@@ -287,14 +289,11 @@ func TestIsValidAgentPoolHostname(t *testing.T) {
 	}
 }
 
-func TestIsValidBlobContainerName(t *testing.T) {
+func TestIsValidBlobName(t *testing.T) {
 	for _, tt := range []struct {
 		name  string
 		valid bool
 	}{
-		{
-			name: "12",
-		},
 		{
 			name:  "123",
 			valid: true,
@@ -308,29 +307,30 @@ func TestIsValidBlobContainerName(t *testing.T) {
 			valid: true,
 		},
 		{
-			name:  "123456789012345678901234567890123456789012345678901234567890123",
+			name:  "Good",
 			valid: true,
 		},
 		{
-			name: "1234567890123456789012345678901234567890123456789012345678901234",
+			name: "\\bad\\",
 		},
 		{
-			name: "bad!",
+			name: "1%",
 		},
 		{
-			name: "Bad",
+			name: "\bad",
 		},
 		{
-			name: "-bad",
+			name: "foo/c{/}.jpg",
 		},
 		{
-			name: "bad-",
+			name: "ba da",
 		},
 		{
-			name: "bad--bad",
+			name:  fmt.Sprintf("backup%s", time.Now().UTC().Format("2006-01-02T15-04-05")),
+			valid: true,
 		},
 	} {
-		valid := IsValidBlobContainerName(tt.name)
+		valid := IsValidBlobName(tt.name)
 		if valid != tt.valid {
 			t.Errorf("%s: wanted valid %v, got %v", tt.name, tt.valid, valid)
 		}

--- a/pkg/api/validate/types_test.go
+++ b/pkg/api/validate/types_test.go
@@ -311,6 +311,21 @@ func TestIsValidBlobName(t *testing.T) {
 			valid: true,
 		},
 		{
+			name: "bad.",
+		},
+		{
+			name: "bad/",
+		},
+		{
+			name: "",
+		},
+		{
+			name: "ba./d",
+		},
+		{
+			name: "b/.ad",
+		},
+		{
 			name: "\\bad\\",
 		},
 		{

--- a/pkg/cluster/kubeclient/backup.go
+++ b/pkg/cluster/kubeclient/backup.go
@@ -22,7 +22,7 @@ func (u *Kubeclientset) BackupCluster(ctx context.Context, backupName string) er
 
 	job := &batchv1.Job{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      backupName,
+			Name:      "etcd-backup",
 			Namespace: cronjob.Namespace,
 		},
 		Spec: cronjob.Spec.JobTemplate.Spec,

--- a/pkg/entrypoint/etcdbackup/etcdbackup.go
+++ b/pkg/entrypoint/etcdbackup/etcdbackup.go
@@ -10,6 +10,7 @@ import (
 	"github.com/coreos/etcd/pkg/transport"
 	"github.com/sirupsen/logrus"
 
+	"github.com/openshift/openshift-azure/pkg/api/validate"
 	"github.com/openshift/openshift-azure/pkg/cluster"
 	"github.com/openshift/openshift-azure/pkg/etcdbackup"
 	"github.com/openshift/openshift-azure/pkg/util/cloudprovider"
@@ -69,6 +70,10 @@ func start(cfg *cmdConfig) error {
 		if len(cfg.blobName) > 0 {
 			path = cfg.blobName
 		}
+		if !validate.IsValidBlobName(path) {
+			return fmt.Errorf("bad backup blob name %s", path)
+		}
+
 		log.Infof("backing up etcd to %s", path)
 		err = b.SaveSnapshot(ctx, path)
 		if err != nil {

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -184,7 +184,8 @@ func (p *plugin) RecoverEtcdCluster(ctx context.Context, cs *api.OpenShiftManage
 	}
 
 	p.log.Info("running CreateOrUpdate")
-	if err := p.CreateOrUpdate(ctx, cs, true, deployFn); err != nil {
+	// note: do not backupEtcd as we are recovering from a backup - doesn't make sense
+	if err := p.createOrUpdateExt(ctx, cs, updateTypeNormal, deployFn, false); err != nil {
 		return err
 	}
 	return nil
@@ -198,17 +199,25 @@ const (
 
 func (p *plugin) CreateOrUpdate(ctx context.Context, cs *api.OpenShiftManagedCluster, isUpdate bool, deployFn api.DeployFn) *api.PluginError {
 	if isUpdate {
-		return p.createOrUpdateExt(ctx, cs, updateTypeNormal, deployFn)
+		return p.createOrUpdateExt(ctx, cs, updateTypeNormal, deployFn, true)
 	}
-	return p.createOrUpdateExt(ctx, cs, updateTypeCreate, deployFn)
+	return p.createOrUpdateExt(ctx, cs, updateTypeCreate, deployFn, false)
 }
 
-func (p *plugin) createOrUpdateExt(ctx context.Context, cs *api.OpenShiftManagedCluster, updateType int, deployFn api.DeployFn) *api.PluginError {
+func (p *plugin) createOrUpdateExt(ctx context.Context, cs *api.OpenShiftManagedCluster, updateType int, deployFn api.DeployFn, backupEtcd bool) *api.PluginError {
 	suffix := fmt.Sprintf("%d", p.now().Unix())
 
 	isUpdate := true
 	if updateType == updateTypeCreate {
 		isUpdate = false
+	}
+
+	if backupEtcd && isUpdate {
+		path := fmt.Sprintf("pre-update-%s", time.Now().UTC().Format("2006-01-02T15-04-05"))
+		err := p.BackupEtcdCluster(ctx, cs, path)
+		if err != nil {
+			return &api.PluginError{Err: err, Step: api.PluginStepEtcdBackup}
+		}
 	}
 
 	p.log.Info("creating clients")
@@ -351,7 +360,7 @@ func (p *plugin) RotateClusterSecrets(ctx context.Context, cs *api.OpenShiftMana
 	}
 
 	p.log.Info("running CreateOrUpdate")
-	if err := p.createOrUpdateExt(ctx, cs, updateTypeNormal, deployFn); err != nil {
+	if err := p.createOrUpdateExt(ctx, cs, updateTypeNormal, deployFn, false); err != nil {
 		return err
 	}
 	return nil
@@ -375,7 +384,7 @@ func (p *plugin) RotateClusterCertificates(ctx context.Context, cs *api.OpenShif
 	}
 
 	p.log.Info("running CreateOrUpdate")
-	if err := p.createOrUpdateExt(ctx, cs, updateTypeMasterFast, deployFn); err != nil {
+	if err := p.createOrUpdateExt(ctx, cs, updateTypeMasterFast, deployFn, false); err != nil {
 		return err
 	}
 	return nil
@@ -403,7 +412,7 @@ func (p *plugin) RotateClusterCertificatesAndSecrets(ctx context.Context, cs *ap
 	}
 
 	p.log.Info("running CreateOrUpdate")
-	if err := p.createOrUpdateExt(ctx, cs, updateTypeMasterFast, deployFn); err != nil {
+	if err := p.createOrUpdateExt(ctx, cs, updateTypeMasterFast, deployFn, false); err != nil {
 		return err
 	}
 	return nil

--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -494,7 +494,7 @@ func (p *plugin) Reimage(ctx context.Context, cs *api.OpenShiftManagedCluster, h
 }
 
 func (p *plugin) BackupEtcdCluster(ctx context.Context, cs *api.OpenShiftManagedCluster, backupName string) error {
-	if !validate.IsValidBlobContainerName(backupName) { // no valid blob name is an invalid kubernetes name
+	if !validate.IsValidBlobName(backupName) {
 		return fmt.Errorf("invalid backup name %q", backupName)
 	}
 

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -77,6 +77,7 @@ func TestCreateOrUpdate(t *testing.T) {
 			clusterUpgrader := mock_cluster.NewMockUpgrader(gmc)
 			if tt.isUpdate {
 				var c *gomock.Call
+				clusterUpgrader.EXPECT().BackupCluster(nil, gomock.Any())
 				expectUpdate(cs, clusterUpgrader, &c)
 			} else {
 				c := clusterUpgrader.EXPECT().CreateOrUpdateConfigStorageAccount(nil).Return(nil)
@@ -238,6 +239,7 @@ func TestForceUpdate(t *testing.T) {
 	clusterUpgrader := mock_cluster.NewMockUpgrader(gmc)
 
 	c := clusterUpgrader.EXPECT().ResetUpdateBlob().Return(nil)
+	c = clusterUpgrader.EXPECT().BackupCluster(nil, gomock.Any()).After(c)
 	expectUpdate(cs, clusterUpgrader, &c)
 
 	p := &plugin{


### PR DESCRIPTION
```release-note
ETCD backups are now run prior to updating
```
Jira-263

@ehashman can you check the blobname validate. we currently create backup blobs with a "T" between the date and time.. I'd like to be consistent with how we do this
