### PR TITLE
move to use dedicated aad sync application

### DIFF
--- a/hack/tests/ci-prepare.sh
+++ b/hack/tests/ci-prepare.sh
@@ -83,7 +83,9 @@ make secrets
 . ./secrets/secret
 export AZURE_CLIENT_ID="$AZURE_CI_CLIENT_ID"
 export AZURE_CLIENT_SECRET="$AZURE_CI_CLIENT_SECRET"
+export AZURE_AAD_CLIENT_ID="$AZURE_AAD_CI_CLIENT_ID"
+export AZURE_AAD_CLIENT_SECRET="$AZURE_AAD_CI_CLIENT_SECRET"
 
-az login --service-principal -u ${AZURE_CLIENT_ID} -p ${AZURE_CLIENT_SECRET} --tenant ${AZURE_TENANT_ID} >/dev/null
+az login --service-principal -u ${AZURE_CLIENT_ID} -p ${AZURE_CLIENT_SECRET} --tenant ${AZURE_TENANT_ID} --allow-no-subscriptions  >/dev/null
 
 reset_xtrace

--- a/pkg/fakerp/client/config.go
+++ b/pkg/fakerp/client/config.go
@@ -42,9 +42,5 @@ func NewConfig(log *logrus.Entry) (*Config, error) {
 		return nil, fmt.Errorf("must set AZURE_REGIONS to a comma separated list")
 	}
 	log.Infof("using region %s", c.Region)
-	if c.AADClientID == "" {
-		c.AADClientID = c.ClientID
-		c.AADClientSecret = c.ClientSecret
-	}
 	return &c, nil
 }

--- a/pkg/fakerp/fakerp.go
+++ b/pkg/fakerp/fakerp.go
@@ -132,6 +132,17 @@ func createOrUpdateWrapper(ctx context.Context, p api.Plugin, log *logrus.Entry,
 		return nil, err
 	}
 
+	am, err := newAADManager(ctx, log, cs, testConfig)
+	if err != nil {
+		return nil, err
+	}
+
+	log.Info("setting up service principals")
+	err = am.ensureApps(ctx)
+	if err != nil {
+		return nil, err
+	}
+
 	var errs []error
 	if isAdmin {
 		errs = p.ValidateAdmin(ctx, cs, oldCs)
@@ -156,17 +167,6 @@ func createOrUpdateWrapper(ctx context.Context, p api.Plugin, log *logrus.Entry,
 		}
 		cs.Properties.ClusterVersion = ""
 		cs.Config.PluginVersion = "latest"
-	}
-
-	am, err := newAADManager(ctx, log, cs, testConfig)
-	if err != nil {
-		return nil, err
-	}
-
-	log.Info("setting up service principals")
-	err = am.ensureApps(ctx)
-	if err != nil {
-		return nil, err
 	}
 
 	dm, err := newDNSManager(ctx, log, os.Getenv("AZURE_SUBSCRIPTION_ID"), os.Getenv("DNS_RESOURCEGROUP"), os.Getenv("DNS_DOMAIN"))


### PR DESCRIPTION
```release-note
NONE
```

Stop re-using main secret for AAD sync and start using shared `aro-aad-shared` secret for this. This would limit the blast radius if the secret is leaked. 