### PR TITLE
Allows make vmimage-validate to validate published marketplace vmimages

### DIFF
--- a/cmd/vmimage/vmimage.go
+++ b/cmd/vmimage/vmimage.go
@@ -29,10 +29,12 @@ var (
 	location                   = flag.String("location", "eastus", "location")
 	buildResourceGroup         = flag.String("buildResourceGroup", "vmimage-"+timestamp, "build resource group")
 	preserveBuildResourceGroup = flag.Bool("preserveBuildResourceGroup", false, "preserve build resource group after build")
-	image                      = flag.String("image", "rhel7-3.11-"+timestamp, "image name")
+	image                      = flag.String("image", "", "image name")
 	imageResourceGroup         = flag.String("imageResourceGroup", "images", "image resource group")
 	imageStorageAccount        = flag.String("imageStorageAccount", "openshiftimages", "image storage account")
 	imageContainer             = flag.String("imageContainer", "images", "image container")
+	imageSku                   = flag.String("imageSku", "", "image SKU")
+	imageVersion               = flag.String("imageVersion", "", "image version")
 	clientKey                  = flag.String("clientKey", "secrets/client-key.pem", "cdn client key")
 	clientCert                 = flag.String("clientCert", "secrets/client-cert.pem", "cdn client cert")
 	validate                   = flag.Bool("validate", false, "If set, will create VM with provided image and will try to update it")
@@ -98,14 +100,17 @@ func run(ctx context.Context, log *logrus.Entry) error {
 		ImageResourceGroup:         *imageResourceGroup,
 		ImageStorageAccount:        *imageStorageAccount,
 		ImageContainer:             *imageContainer,
+		ImageSku:                   *imageSku,
+		ImageVersion:               *imageVersion,
 		SSHKey:                     sshkey,
 		ClientKey:                  clientKey,
 		ClientCert:                 clientCert,
 		Validate:                   *validate,
 	}
 
-	if *logLevel == "Debug" {
-		log.Printf("using image %s/%s/%s/%s", builder.ImageResourceGroup, builder.ImageStorageAccount, builder.ImageContainer, builder.Image)
+	err = builder.ValidateFields()
+	if err != nil {
+		return err
 	}
 
 	err = builder.Run(ctx)

--- a/pkg/vmimage/resources.go
+++ b/pkg/vmimage/resources.go
@@ -138,33 +138,15 @@ func nic(subscriptionID, resourceGroup, location string) *network.Interface {
 	}
 }
 
-func vm(subscriptionID, resourceGroup, location, sshPublicKey, image, imageResourceGroup string, verify bool) *compute.VirtualMachine {
-	var imageReference compute.ImageReference
-	if !verify {
-		imageReference = compute.ImageReference{
-			Publisher: to.StringPtr("RedHat"),
-			Offer:     to.StringPtr("RHEL"),
-			Sku:       to.StringPtr("7-RAW"),
-			Version:   to.StringPtr("latest"),
-		}
-	} else {
-		imageReference = compute.ImageReference{
-			ID: to.StringPtr(resourceid.ResourceID(
-				subscriptionID,
-				imageResourceGroup,
-				"Microsoft.Compute/images",
-				image,
-			)),
-		}
-	}
-
+func vm(subscriptionID, resourceGroup, location, sshPublicKey string, plan *compute.Plan, imageReference *compute.ImageReference) *compute.VirtualMachine {
 	return &compute.VirtualMachine{
+		Plan: plan,
 		VirtualMachineProperties: &compute.VirtualMachineProperties{
 			HardwareProfile: &compute.HardwareProfile{
 				VMSize: compute.VirtualMachineSizeTypesStandardD2sV3,
 			},
 			StorageProfile: &compute.StorageProfile{
-				ImageReference: &imageReference,
+				ImageReference: imageReference,
 				OsDisk: &compute.OSDisk{
 					CreateOption: compute.DiskCreateOptionTypesFromImage,
 					ManagedDisk: &compute.ManagedDiskParameters{

--- a/pkg/vmimage/vmimage_test.go
+++ b/pkg/vmimage/vmimage_test.go
@@ -1,8 +1,13 @@
 package vmimage
 
 import (
+	"strings"
 	"testing"
 
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
+	"github.com/Azure/go-autorest/autorest/to"
+
+	"github.com/openshift/openshift-azure/pkg/util/cmp"
 	"github.com/openshift/openshift-azure/test/util/tls"
 )
 
@@ -15,5 +20,134 @@ func TestGenerateTemplate(t *testing.T) {
 	_, err := builder.generateTemplate()
 	if err != nil {
 		t.Error(err)
+	}
+}
+
+func TestValidateFields(t *testing.T) {
+	tests := []struct {
+		name             string
+		builder          *Builder
+		expectedContains string
+	}{
+		{
+			name: "has custom image reference",
+			builder: &Builder{
+				Image:               "rhel7-3.11-197001010000",
+				ImageResourceGroup:  "images",
+				ImageStorageAccount: "foo",
+				ImageContainer:      "images",
+			},
+		},
+		{
+			name: "has marketplace image reference",
+			builder: &Builder{
+				ImageSku:     "osa_111",
+				ImageVersion: "latest",
+			},
+		},
+		{
+			name: "has marketplace and custom image reference",
+			builder: &Builder{
+				Image:               "rhel7-3.11-197001010000",
+				ImageResourceGroup:  "images",
+				ImageStorageAccount: "foo",
+				ImageContainer:      "images",
+				ImageSku:            "osa_111",
+				ImageVersion:        "latest",
+			},
+			expectedContains: "confilicting fields",
+		},
+		{
+			name: "has incomplete marketplace image reference",
+			builder: &Builder{
+				ImageSku: "osa_111",
+			},
+			expectedContains: "missing fields",
+		},
+		{
+			name: "has incomplete custom image reference",
+			builder: &Builder{
+				ImageResourceGroup:  "images",
+				ImageStorageAccount: "foo",
+				ImageContainer:      "images",
+			},
+			expectedContains: "missing fields",
+		},
+	}
+
+	for _, test := range tests {
+		err := test.builder.ValidateFields()
+
+		if err != nil && test.expectedContains == "" {
+			t.Errorf("%s: unexpected error %#v", test.name, err.Error())
+		}
+
+		if err == nil && test.expectedContains != "" {
+			t.Errorf("%s: expected error to contain %#v, got none", test.name, test.expectedContains)
+		}
+
+		if err != nil && !strings.Contains(err.Error(), test.expectedContains) {
+			t.Errorf("%s: expected error to contain %#v, got error: %#v", test.name, test.expectedContains, err.Error())
+		}
+	}
+}
+
+func TestVMImageReference(t *testing.T) {
+	tests := []struct {
+		name     string
+		builder  *Builder
+		expected compute.ImageReference
+	}{
+		{
+			name: "vm image to create a vm that we are going to use to build a new vm image",
+			builder: &Builder{
+				Image:               "rhel7-3.11-197001010000",
+				ImageResourceGroup:  "images",
+				ImageStorageAccount: "foo",
+				ImageContainer:      "images",
+			},
+			expected: compute.ImageReference{
+				Publisher: to.StringPtr("RedHat"),
+				Offer:     to.StringPtr("RHEL"),
+				Sku:       to.StringPtr("7-RAW"),
+				Version:   to.StringPtr("latest"),
+			},
+		},
+		{
+			name: "custom vm image to validation",
+			builder: &Builder{
+				Image:               "rhel7-3.11-197001010000",
+				ImageResourceGroup:  "images",
+				ImageStorageAccount: "foo",
+				ImageContainer:      "images",
+				Validate:            true,
+			},
+			expected: compute.ImageReference{
+				ID: to.StringPtr("/subscriptions//resourceGroups/images/providers/Microsoft.Compute/images/rhel7-3.11-197001010000"),
+			},
+		},
+		{
+			name: "marketplace vm image to validation",
+			builder: &Builder{
+				ImageSku:     "osa_111",
+				ImageVersion: "latest",
+				Validate:     true,
+			},
+			expected: compute.ImageReference{
+				Publisher: to.StringPtr("redhat"),
+				Offer:     to.StringPtr("osa"),
+				Sku:       to.StringPtr("osa_111"),
+				Version:   to.StringPtr("latest"),
+			},
+		},
+	}
+
+	for _, test := range tests {
+		vmRef := test.builder.vmImageReference()
+
+		diff := cmp.Diff(*vmRef, test.expected)
+		if diff != "" {
+			t.Errorf("%s: unexpected vm image reference: %s", test.name, diff)
+		}
 	}
 }


### PR DESCRIPTION
We can now run `IMAGE_VERSION=latest IMAGE_SKU=osa_311 make vmimage-validate` to validate the latest published marketplace vmimage or `IMAGE_VERSION=311.129.20190810 IMAGE_SKU=osa_311 make vmimage-validate` to validate a specific version.

Jira ref: AZURE-326

```release-note
NONE
```
