### PR TITLE
Make sure the allowed admin config update pass through

### DIFF
--- a/pkg/api/plugin/convertertointernal.go
+++ b/pkg/api/plugin/convertertointernal.go
@@ -17,27 +17,16 @@ func ToInternal(in *Config, old *api.Config, setVersionFields bool) (*api.Config
 		c = old.DeepCopy()
 	}
 
-	if c.SecurityPatchPackages == nil {
-		c.SecurityPatchPackages = in.SecurityPatchPackages
-	}
-
 	// setting c.PluginVersion = in.PluginVersion is done up-front by the plugin
 	// code.  It could be done here as well (gated by setVersionFields) but
 	// would/should be a no-op.  To simplify the logic, we don't do it.
 
-	if c.ComponentLogLevel.APIServer == nil {
-		c.ComponentLogLevel.APIServer = &in.ComponentLogLevel.APIServer
-	}
-	if c.ComponentLogLevel.ControllerManager == nil {
-		c.ComponentLogLevel.ControllerManager = &in.ComponentLogLevel.ControllerManager
-	}
-	if c.ComponentLogLevel.Node == nil {
-		c.ComponentLogLevel.Node = &in.ComponentLogLevel.Node
-	}
+	c.ComponentLogLevel.APIServer = &in.ComponentLogLevel.APIServer
+	c.ComponentLogLevel.ControllerManager = &in.ComponentLogLevel.ControllerManager
+	c.ComponentLogLevel.Node = &in.ComponentLogLevel.Node
 
-	if c.SSHSourceAddressPrefixes == nil {
-		c.SSHSourceAddressPrefixes = in.SSHSourceAddressPrefixes
-	}
+	c.SecurityPatchPackages = in.SecurityPatchPackages
+	c.SSHSourceAddressPrefixes = in.SSHSourceAddressPrefixes
 
 	if setVersionFields {
 		inVersion, found := in.Versions[c.PluginVersion]

--- a/pkg/api/validate/admin.go
+++ b/pkg/api/validate/admin.go
@@ -78,6 +78,7 @@ func (v *AdminAPIValidator) validateUpdateContainerService(cs, oldCs *api.OpenSh
 
 	old.Config.Images = cs.Config.Images
 	old.Config.SecurityPatchPackages = cs.Config.SecurityPatchPackages
+	old.Config.SSHSourceAddressPrefixes = cs.Config.SSHSourceAddressPrefixes
 
 	if !reflect.DeepEqual(cs, old) {
 		errs = append(errs, fmt.Errorf("invalid change %s", cmp.Diff(cs, old)))

--- a/pkg/plugin/integration_test.go
+++ b/pkg/plugin/integration_test.go
@@ -520,6 +520,13 @@ func TestHowAdminConfigChangesCausesRotations(t *testing.T) {
 			expectRotation: map[rotationType]bool{rotationMaster: true, rotationInfra: true, rotationSync: false, rotationCompute: true},
 			change:         func(cs *api.OpenShiftManagedCluster) { cs.Config.SecurityPatchPackages = []string{"patch-rpm"} },
 		},
+		{
+			name:           "change SSHSourceAddressPrefixes",
+			expectRotation: map[rotationType]bool{rotationMaster: false, rotationInfra: false, rotationSync: false, rotationCompute: false},
+			change: func(cs *api.OpenShiftManagedCluster) {
+				cs.Config.SSHSourceAddressPrefixes = []string{"101.165.48.112/24"}
+			},
+		},
 	}
 
 	log := logrus.NewEntry(logrus.StandardLogger())


### PR DESCRIPTION
closes #1873

```release-note
allow the following to be set using the admin API:
- SSHSourceAddressPrefixes
- SecurityPatchPackages
- ComponentLogLevel
```

/cc @jim-minter @ehashman 
