### PR TITLE
make IsMatchingSyscallError() more flexible

### DIFF
--- a/pkg/util/errors/errors.go
+++ b/pkg/util/errors/errors.go
@@ -26,11 +26,11 @@ var (
 )
 
 func unwrapNetHTTPError(err error) (bool, error) {
-	if !strings.HasPrefix(err.Error(), netHTTPErrorPrefix) {
+	if !strings.Contains(err.Error(), netHTTPErrorPrefix) {
 		return false, err
 	}
 	for sysMsg, errno := range str2Syscall {
-		if strings.Contains(err.Error()[netHTTPErrorPrefixLen:], sysMsg) {
+		if strings.Contains(err.Error(), sysMsg) {
 			return true, errno
 		}
 	}


### PR DESCRIPTION
IsMatchingSyscallError() is currently not parsing a fully formatted url.Error. This PR makes this possible.


```release-note
NONE
```

closes #1400
