### PR TITLE
Document local testing 

### DIFF
--- a/docs/e2e/requirements.md
+++ b/docs/e2e/requirements.md
@@ -20,7 +20,7 @@ export FOCUS=\[EveryPR\]
 or if you want to tests two focuses
 
 ```bash
- export FOCUS='\[CustomerAdmin\]|\[EndUser\]'
+export FOCUS="\[CustomerAdmin\]|\[EndUser\]"
  ```
 
 **Note:** Even if this document refers to focuses such as `[EveryPR]`, you should always escape them
@@ -28,7 +28,7 @@ before passing them to `FOCUS`.
 
 #### Environment requirements
 
-The following are required for running all e2e tests against the fake RP.  To generate these files you can use `make secrets` at the root of this repository.  See [environment file](../../README.md) to see how to retrieve the environment variables.
+The following are required for running all e2e tests against the fake RP.  To generate these files you can use `make secrets` at the root of this repository.  See [environment file](../../README.md#prerequisites) to see how to retrieve the environment variables.
 
 | Artifact Kind | Name | Notes |
 | --- | --- | --- |

--- a/docs/e2e/requirements.md
+++ b/docs/e2e/requirements.md
@@ -4,22 +4,31 @@ The following are ginkgo test focuses supported by openshift on azure e2e tests
 
 * `[EveryPR]` - These tests should be run on every PR
 * `[LongRunning]` - These tests are long running and should be run periodically
+* `[CustomerAdmin]` - These test run with `make e2e` and focus on Customer Admin capabilities
+* `[EndUser]` - These test run with `make e2e` and focus on End User capabilities
+* `[Apps]` - These test creates and validates a test application in an OpenShift cluster _(this test gets ran with `[EndUser]` focus as well)_
 
 #### Customizing e2e test scope with focuses
 
 You can specify a test focus by setting the `FOCUS` environment variable. For example
 to run all tests tagged with [EveryPR] you would specify the focus as
 
-```
+```bash
 export FOCUS=\[EveryPR\]
 ```
 
-Note: even if this document refers to focuses such as [EveryPR], you should always escape them
+or if you want to tests two focuses
+
+```bash
+ export FOCUS='\[CustomerAdmin\]|\[EndUser\]'
+ ```
+
+**Note:** Even if this document refers to focuses such as `[EveryPR]`, you should always escape them
 before passing them to `FOCUS`.
 
 #### Environment requirements
 
-The following are required for running all e2e tests against the fake RP
+The following are required for running all e2e tests against the fake RP.  To generate these files you can use `make secrets` at the root of this repository.  See [environment file](../../README.md) to see how to retrieve the environment variables.
 
 | Artifact Kind | Name | Notes |
 | --- | --- | --- |

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -32,28 +32,50 @@ Those can be ignored and `/skip`ed. In example:
 ```
 Upstream issue: https://github.com/openshift/ci-operator-prowgen/issues/79 
 
+## Verify 
+
+This repository runs multiple checks to **verify** if it complies with standard go conventions.  The scripts from the target run through a series of checks to ensure the repository remains compliant with standard go practices. This can be ran **locally** with the command `make verify`.  When creating a pull-request, this tests is part of the acceptance criteria. 
+
+```makefile
+verify:
+    ./hack/verify/validate-generated.sh
+    go vet ./...
+    ./hack/verify/validate-code-format.sh
+    ./hack/verify/validate-util.sh
+    ./hack/verify/validate-codecov.sh
+    go run ./hack/validate-imports/validate-imports.go   cmd hack pkg test
+    ./hack/verify/validate-sec.sh
+```
+
 ## Unit test
 
 Packages under `pkg` directory contain their individual unit tests.
 
-To run all unit tests locally, execute: `make unit`
+To run all unit tests **locally**, execute: `make unit`
 
 ```makefile
 unit: generate testinsights
   go test ./... -coverprofile=coverage.out -covermode=atomic -json | ./testinsights
 ```
+_Note: This will **generate** bindata.go files when using this Makefile target as well as testinsights._
 
-or
+or 
+
+at the root of the repository `openshift-azure/` 
 
 ```go 
-go test ./...
+go test ./... -v 
 ```
 
 To run a single package's tests:
-`go test ./pkg/util/tls`
+```go
+go test ./pkg/util/tls
+```
 
 To run a subset of tests in a package:
-`go test -run TestFoo ./pkg/util/tls`
+```go
+go test -run TestFoo ./pkg/util/tls
+```
 
 ## OpenShift E2E tests
 
@@ -62,21 +84,25 @@ The project has its own end-to-end testing test suite. You can find it under:
 
 To run these tests you will need to have OpenShift cluster running.
 
+_Note: To have a OpenShift cluster running refer to the following [documentation](../README.md). To create a cluster use `make create` at the root of this repository with the prerequisites from the documentation above._
+
 The cluster running that you are trying to test **must** have the required files and environment variables described in [e2e requirements](e2e/requirements.md).
 
 To execute e2e tests **locally**, execute:
-`make e2e`   
+`make e2e`
 
 ```Makefile
 e2e:
   FOCUS="\[CustomerAdmin\]|\[EndUser\]" TIMEOUT=60m ./hack/e2e.sh
 ```
-or 
+
+or
 
 ```bash
-export FOCUS='\[CustomerAdmin\]|\[EndUser\]';
+export FOCUS="\[CustomerAdmin\]|\[EndUser\]";
 go test -v -tags e2e ./test/e2e -ginkgo.focus=$FOCUS
 ```
+
 See [e2e requirements](e2e/requirements.md) for more information on the expected inputs to our e2e tests.
 
 See [running e2e](e2e/README.md) for more information on how to run the e2e tests with the container image.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -71,7 +71,7 @@ The project has its own end-to-end testing test suite. You can find it under:
 
 To run these tests you will need to have OpenShift cluster running.
 
-_Note: To have a OpenShift cluster running refer to the following [documentation](../README.md). To create a cluster use `make create` at the root of this repository with the prerequisites from the documentation above._
+_Note: To create a cluster use `make create` at the root of this repository with the prerequisites from the following [documentation](../README#prerequisites)._
 
 The running cluster that you are trying to test **must** have the required files and environment variables described in [e2e requirements](e2e/requirements.md).
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -74,7 +74,7 @@ e2e:
 or 
 
 ```bash
-export FOCUS='\[CustomerAdmin\]|\[EndUser\]'
+export FOCUS='\[CustomerAdmin\]|\[EndUser\]';
 go test -v -tags e2e ./test/e2e -ginkgo.focus=$FOCUS
 ```
 See [e2e requirements](e2e/requirements.md) for more information on the expected inputs to our e2e tests.

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -34,18 +34,7 @@ Upstream issue: https://github.com/openshift/ci-operator-prowgen/issues/79
 
 ## Verify 
 
-This repository runs multiple checks to **verify** if it complies with standard go conventions.  The scripts from the target run through a series of checks to ensure the repository remains compliant with standard go practices. This can be ran **locally** with the command `make verify`.  When creating a pull-request, this tests is part of the acceptance criteria. 
-
-```makefile
-verify:
-    ./hack/verify/validate-generated.sh
-    go vet ./...
-    ./hack/verify/validate-code-format.sh
-    ./hack/verify/validate-util.sh
-    ./hack/verify/validate-codecov.sh
-    go run ./hack/validate-imports/validate-imports.go   cmd hack pkg test
-    ./hack/verify/validate-sec.sh
-```
+This make target runs a series of checks to **verify** if it complies with standard Golang conventions and practices.  This can be run **locally** with the command `make verify`.  When creating a pull-request, this test is part of the acceptance criteria. 
 
 ## Unit test
 
@@ -53,10 +42,6 @@ Packages under `pkg` directory contain their individual unit tests.
 
 To run all unit tests **locally**, execute: `make unit`
 
-```makefile
-unit: generate testinsights
-  go test ./... -coverprofile=coverage.out -covermode=atomic -json | ./testinsights
-```
 _Note: This will **generate** bindata.go files when using this Makefile target as well as testinsights._
 
 or 
@@ -68,11 +53,13 @@ go test ./... -v
 ```
 
 To run a single package's tests:
+
 ```go
 go test ./pkg/util/tls
 ```
 
 To run a subset of tests in a package:
+
 ```go
 go test -run TestFoo ./pkg/util/tls
 ```
@@ -86,15 +73,11 @@ To run these tests you will need to have OpenShift cluster running.
 
 _Note: To have a OpenShift cluster running refer to the following [documentation](../README.md). To create a cluster use `make create` at the root of this repository with the prerequisites from the documentation above._
 
-The cluster running that you are trying to test **must** have the required files and environment variables described in [e2e requirements](e2e/requirements.md).
+The running cluster that you are trying to test **must** have the required files and environment variables described in [e2e requirements](e2e/requirements.md).
 
 To execute e2e tests **locally**, execute:
 `make e2e`
 
-```Makefile
-e2e:
-  FOCUS="\[CustomerAdmin\]|\[EndUser\]" TIMEOUT=60m ./hack/e2e.sh
-```
 
 or
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -35,7 +35,20 @@ Upstream issue: https://github.com/openshift/ci-operator-prowgen/issues/79
 ## Unit test
 
 Packages under `pkg` directory contain their individual unit tests.
-To run all unit tests locally, execute: `make unit` or `go test ./...`
+
+To run all unit tests locally, execute: `make unit`
+
+```makefile
+unit: generate testinsights
+  go test ./... -coverprofile=coverage.out -covermode=atomic -json | ./testinsights
+```
+
+or
+
+```go 
+go test ./...
+```
+
 To run a single package's tests:
 `go test ./pkg/util/tls`
 
@@ -48,11 +61,25 @@ The project has its own end-to-end testing test suite. You can find it under:
 `test/e2e/`. It uses [ginko](https://github.com/onsi/ginkgo) and [gomega](https://github.com/onsi/gomega).
 
 To run these tests you will need to have OpenShift cluster running.
-to execute e2e tests locally, execute: `make e2e` or `go test -tags e2e ./test/e2e`.
+
+The cluster running that you are trying to test **must** have the required files and environment variables described in [e2e requirements](e2e/requirements.md).
+
+To execute e2e tests **locally**, execute:
+`make e2e`   
+
+```Makefile
+e2e:
+  FOCUS="\[CustomerAdmin\]|\[EndUser\]" TIMEOUT=60m ./hack/e2e.sh
+```
+
+or
+```golang
+go test -tags e2e ./test/e2e
+```
 
 See [e2e requirements](e2e/requirements.md) for more information on the expected inputs to our e2e tests.
 
-See [running](e2e/README.md) for more information on how to run the e2e tests with the container image.
+See [running e2e](e2e/README.md) for more information on how to run the e2e tests with the container image.
 
 ## OpenShift Origin Conformance tests
 
@@ -62,7 +89,8 @@ found in [OpenShift Release repository](https://github.com/openshift/release/)
 
 ### Conformance test development
 
-If you want just to run conformance test locally, you can use docker image to do so.
+If you want just to run conformance test **locally**, you can use docker image to do so.
+
 ```
 # run and attach to test the container
 docker run -v $(pwd)/_data:/tmp/_data  -it openshift/origin-tests:v3.11 sh

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -48,19 +48,19 @@ or
 
 at the root of the repository `openshift-azure/` 
 
-```go 
+```bash 
 go test ./... -v 
 ```
 
 To run a single package's tests:
 
-```go
+```bash
 go test ./pkg/util/tls
 ```
 
 To run a subset of tests in a package:
 
-```go
+```bash
 go test -run TestFoo ./pkg/util/tls
 ```
 

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -71,12 +71,12 @@ To execute e2e tests **locally**, execute:
 e2e:
   FOCUS="\[CustomerAdmin\]|\[EndUser\]" TIMEOUT=60m ./hack/e2e.sh
 ```
+or 
 
-or
-```golang
-go test -tags e2e ./test/e2e
+```bash
+export FOCUS='\[CustomerAdmin\]|\[EndUser\]'
+go test -v -tags e2e ./test/e2e -ginkgo.focus=$FOCUS
 ```
-
 See [e2e requirements](e2e/requirements.md) for more information on the expected inputs to our e2e tests.
 
 See [running e2e](e2e/README.md) for more information on how to run the e2e tests with the container image.


### PR DESCRIPTION
```release-note
NONE
```
* Add Makefile targets `verify` to testing document
* Add additional supported FOCUSes to requirements
* Add `make secrets` to requirements for end-to-end testing 
* Format documentation