### PR TITLE
fakerp: create clients in one place and use envconfig more

### DIFF
--- a/pkg/fakerp/client/config.go
+++ b/pkg/fakerp/client/config.go
@@ -26,6 +26,9 @@ type Config struct {
 	Regions       string `envconfig:"AZURE_REGIONS" required:"true"`
 	ResourceGroup string `envconfig:"RESOURCEGROUP" required:"true"`
 
+	DNSDomain        string `envconfig:"DNS_DOMAIN" required:"true"`
+	DNSResourceGroup string `envconfig:"DNS_RESOURCEGROUP" required:"true"`
+
 	ResourceGroupTTL string `envconfig:"RESOURCEGROUP_TTL"`
 	Manifest         string `envconfig:"MANIFEST"`
 	NoWait           bool   `envconfig:"NO_WAIT"`

--- a/pkg/fakerp/clients.go
+++ b/pkg/fakerp/clients.go
@@ -1,0 +1,47 @@
+package fakerp
+
+import (
+	"context"
+
+	"github.com/sirupsen/logrus"
+
+	"github.com/openshift/openshift-azure/pkg/api"
+	internalapi "github.com/openshift/openshift-azure/pkg/api"
+	"github.com/openshift/openshift-azure/pkg/fakerp/client"
+	"github.com/openshift/openshift-azure/pkg/util/azureclient"
+	"github.com/openshift/openshift-azure/pkg/util/azureclient/resources"
+)
+
+type clients struct {
+	aadMgr      *aadManager
+	dnsMgr      *dnsManager
+	vaultMgr    *vaultManager
+	groupClient resources.GroupsClient
+}
+
+func newClients(ctx context.Context, log *logrus.Entry, cs *api.OpenShiftManagedCluster, testConfig api.TestConfig, conf *client.Config) (*clients, error) {
+	var err error
+	c := &clients{}
+	c.aadMgr, err = newAADManager(ctx, log, cs, testConfig)
+	if err != nil {
+		return nil, err
+	}
+	c.dnsMgr, err = newDNSManager(ctx, log, cs.Properties.AzProfile.SubscriptionID, conf.DNSResourceGroup, conf.DNSDomain)
+	if err != nil {
+		return nil, err
+	}
+	c.vaultMgr, err = newVaultManager(ctx, log, cs.Properties.AzProfile.SubscriptionID, cs.Properties.AzProfile.TenantID)
+	if err != nil {
+		return nil, err
+	}
+	authorizer, err := azureclient.GetAuthorizerFromContext(ctx, internalapi.ContextKeyClientAuthorizer)
+	if err != nil {
+		return nil, err
+	}
+	c.groupClient = resources.NewGroupsClient(ctx, log, cs.Properties.AzProfile.SubscriptionID, authorizer)
+	if err != nil {
+		return nil, err
+	}
+
+	return c, nil
+}

--- a/pkg/fakerp/vault.go
+++ b/pkg/fakerp/vault.go
@@ -6,7 +6,6 @@ import (
 	"crypto/x509/pkix"
 	"net"
 	"net/url"
-	"os"
 	"strings"
 	"time"
 
@@ -37,7 +36,7 @@ type vaultManager struct {
 	kvc keyvault.KeyVaultClient
 }
 
-func newVaultManager(ctx context.Context, log *logrus.Entry, subscriptionID string) (*vaultManager, error) {
+func newVaultManager(ctx context.Context, log *logrus.Entry, subscriptionID, tenantID string) (*vaultManager, error) {
 	authorizer, err := azureclient.GetAuthorizerFromContext(ctx, api.ContextKeyClientAuthorizer)
 	if err != nil {
 		return nil, err
@@ -54,8 +53,8 @@ func newVaultManager(ctx context.Context, log *logrus.Entry, subscriptionID stri
 	}
 
 	return &vaultManager{
-		vc:  vaultmgmt.NewVaultMgmtClient(ctx, log, os.Getenv("AZURE_SUBSCRIPTION_ID"), authorizer),
-		spc: graphrbac.NewServicePrincipalsClient(ctx, log, os.Getenv("AZURE_TENANT_ID"), graphauthorizer),
+		vc:  vaultmgmt.NewVaultMgmtClient(ctx, log, subscriptionID, authorizer),
+		spc: graphrbac.NewServicePrincipalsClient(ctx, log, tenantID, graphauthorizer),
 		kvc: keyvault.NewKeyVaultClient(ctx, log, vaultauthorizer),
 	}, nil
 }


### PR DESCRIPTION
Tidy up the fakerp client creation and use of environment variables.

closes #1227

```release-note
NONE
```
