### PR TITLE
[WIP] PrivateLink plugin side implementation 

### DIFF
--- a/pkg/api/2018-09-30-preview/types_test.go
+++ b/pkg/api/2018-09-30-preview/types_test.go
@@ -202,6 +202,8 @@ func TestAPIParity(t *testing.T) {
 		regexp.MustCompile(`^\.Properties\.WorkerServicePrincipalProfile`),
 		regexp.MustCompile(`^\.Properties\.AzProfile`),
 		regexp.MustCompile(`^\.Properties\.MonitorProfile`),
+		regexp.MustCompile(`^\.Properties\.NetworkProfile.DefaultCIDR`),
+		regexp.MustCompile(`^\.Properties\.NetworkProfile.ManagementCIDR`),
 		regexp.MustCompile(`^\.Properties\.APICertProfile\.`),
 		regexp.MustCompile(`\.RouterCertProfile\.`),
 		regexp.MustCompile(`^\.Config`),

--- a/pkg/api/2019-04-30/types_test.go
+++ b/pkg/api/2019-04-30/types_test.go
@@ -202,6 +202,8 @@ func TestAPIParity(t *testing.T) {
 		regexp.MustCompile(`^\.Properties\.WorkerServicePrincipalProfile`),
 		regexp.MustCompile(`^\.Properties\.AzProfile`),
 		regexp.MustCompile(`^\.Properties\.MonitorProfile`),
+		regexp.MustCompile(`^\.Properties\.NetworkProfile.DefaultCIDR`),
+		regexp.MustCompile(`^\.Properties\.NetworkProfile.ManagementCIDR`),
 		regexp.MustCompile(`^\.Properties\.APICertProfile\.`),
 		regexp.MustCompile(`\.RouterCertProfile\.`),
 		regexp.MustCompile(`^\.Config`),

--- a/pkg/api/2019-09-30-preview/converterfrominternal.go
+++ b/pkg/api/2019-09-30-preview/converterfrominternal.go
@@ -37,9 +37,11 @@ func FromInternal(cs *api.OpenShiftManagedCluster) *OpenShiftManagedCluster {
 	}
 
 	oc.Properties.NetworkProfile = &NetworkProfile{
-		VnetID:     &cs.Properties.NetworkProfile.VnetID,
-		VnetCIDR:   &cs.Properties.NetworkProfile.VnetCIDR,
-		PeerVnetID: cs.Properties.NetworkProfile.PeerVnetID,
+		VnetID:         &cs.Properties.NetworkProfile.VnetID,
+		VnetCIDR:       &cs.Properties.NetworkProfile.VnetCIDR,
+		DefaultCIDR:    &cs.Properties.NetworkProfile.DefaultCIDR,
+		ManagementCIDR: &cs.Properties.NetworkProfile.ManagementCIDR,
+		PeerVnetID:     cs.Properties.NetworkProfile.PeerVnetID,
 	}
 	oc.Properties.MonitorProfile = &MonitorProfile{
 		WorkspaceResourceID: &cs.Properties.MonitorProfile.WorkspaceResourceID,

--- a/pkg/api/2019-09-30-preview/convertertointernal.go
+++ b/pkg/api/2019-09-30-preview/convertertointernal.go
@@ -98,6 +98,12 @@ func mergeProperties(oc *OpenShiftManagedCluster, cs *api.OpenShiftManagedCluste
 		if oc.Properties.NetworkProfile.VnetCIDR != nil {
 			cs.Properties.NetworkProfile.VnetCIDR = *oc.Properties.NetworkProfile.VnetCIDR
 		}
+		if oc.Properties.NetworkProfile.ManagementCIDR != nil {
+			cs.Properties.NetworkProfile.ManagementCIDR = *oc.Properties.NetworkProfile.ManagementCIDR
+		}
+		if oc.Properties.NetworkProfile.DefaultCIDR != nil {
+			cs.Properties.NetworkProfile.DefaultCIDR = *oc.Properties.NetworkProfile.DefaultCIDR
+		}
 		cs.Properties.NetworkProfile.PeerVnetID = oc.Properties.NetworkProfile.PeerVnetID
 	}
 

--- a/pkg/api/2019-09-30-preview/default.go
+++ b/pkg/api/2019-09-30-preview/default.go
@@ -45,4 +45,18 @@ func setDefaults(oc *OpenShiftManagedCluster) {
 			},
 		}
 	}
+
+	if oc.Properties.NetworkProfile == nil {
+		oc.Properties.NetworkProfile = &NetworkProfile{}
+	}
+
+	if oc.Properties.NetworkProfile.VnetCIDR == nil {
+		oc.Properties.NetworkProfile.VnetCIDR = to.StringPtr("10.0.0.0/8")
+	}
+	if oc.Properties.NetworkProfile.DefaultCIDR == nil {
+		oc.Properties.NetworkProfile.DefaultCIDR = to.StringPtr("10.0.0.0/24")
+	}
+	if oc.Properties.NetworkProfile.ManagementCIDR == nil {
+		oc.Properties.NetworkProfile.ManagementCIDR = to.StringPtr("10.0.2.0/24")
+	}
 }

--- a/pkg/api/2019-09-30-preview/default_test.go
+++ b/pkg/api/2019-09-30-preview/default_test.go
@@ -41,6 +41,11 @@ func sampleManagedCluster() *OpenShiftManagedCluster {
 					PublicSubdomain: to.StringPtr("NewPublicSubdomain"),
 				},
 			},
+			NetworkProfile: &NetworkProfile{
+				DefaultCIDR:    to.StringPtr("10.0.0.0/24"),
+				ManagementCIDR: to.StringPtr("10.0.2.0/24"),
+				VnetCIDR:       to.StringPtr("10.0.0.0/8"),
+			},
 		},
 	}
 }
@@ -73,6 +78,11 @@ func TestDefaults(t *testing.T) {
 						Name: to.StringPtr("default"),
 					},
 				}
+				oc.Properties.NetworkProfile = &NetworkProfile{
+					DefaultCIDR:    to.StringPtr("10.0.0.0/24"),
+					ManagementCIDR: to.StringPtr("10.0.2.0/24"),
+					VnetCIDR:       to.StringPtr("10.0.0.0/8"),
+				}
 			},
 		},
 		{
@@ -104,6 +114,18 @@ func TestDefaults(t *testing.T) {
 			},
 			expectedChange: func(oc *OpenShiftManagedCluster) {
 				oc.Properties.AgentPoolProfiles[0].OSType = (*OSType)(to.StringPtr("Linux"))
+			},
+		},
+		{
+			name: "sets NetorkProfile when empty",
+			changeInput: func(oc *OpenShiftManagedCluster) {
+				oc.Properties.NetworkProfile = nil
+			},
+		},
+		{
+			name: "sets NetorkProfile.ManagementCIDR when empty",
+			changeInput: func(oc *OpenShiftManagedCluster) {
+				oc.Properties.NetworkProfile.ManagementCIDR = nil
 			},
 		},
 		{

--- a/pkg/api/2019-09-30-preview/types.go
+++ b/pkg/api/2019-09-30-preview/types.go
@@ -98,6 +98,12 @@ type NetworkProfile struct {
 	// VnetCIDR (in): the CIDR with which the OSA cluster's Vnet is configured
 	VnetCIDR *string `json:"vnetCidr,omitempty"`
 
+	// DefaultCIDR (in): the CIDR used to configure default subnet
+	DefaultCIDR *string `json:"defaultCidr,omitempty"`
+
+	// ManagementCIDR (in): the CIDR used to configure management subnet
+	ManagementCIDR *string `json:"managementCidr,omitempty"`
+
 	// VnetID (out): the ID of the Vnet created for the OSA cluster
 	VnetID *string `json:"vnetId,omitempty"`
 

--- a/pkg/api/2019-09-30-preview/types_test.go
+++ b/pkg/api/2019-09-30-preview/types_test.go
@@ -29,6 +29,8 @@ var marshalled = []byte(`{
 		"fqdn": "Properties.FQDN",
 		"networkProfile": {
 			"vnetCidr": "Properties.NetworkProfile.VnetCIDR",
+			"defaultCidr": "Properties.NetworkProfile.DefaultCIDR",
+			"managementCidr": "Properties.NetworkProfile.ManagementCIDR",
 			"vnetId": "Properties.NetworkProfile.VnetID",
 			"peerVnetId": "Properties.NetworkProfile.PeerVnetID"
 		},

--- a/pkg/api/admin/converterfrominternal.go
+++ b/pkg/api/admin/converterfrominternal.go
@@ -37,9 +37,11 @@ func FromInternal(cs *api.OpenShiftManagedCluster) *OpenShiftManagedCluster {
 	}
 
 	oc.Properties.NetworkProfile = &NetworkProfile{
-		VnetID:     &cs.Properties.NetworkProfile.VnetID,
-		VnetCIDR:   &cs.Properties.NetworkProfile.VnetCIDR,
-		PeerVnetID: cs.Properties.NetworkProfile.PeerVnetID,
+		VnetID:         &cs.Properties.NetworkProfile.VnetID,
+		VnetCIDR:       &cs.Properties.NetworkProfile.VnetCIDR,
+		ManagementCIDR: &cs.Properties.NetworkProfile.ManagementCIDR,
+		DefaultCIDR:    &cs.Properties.NetworkProfile.DefaultCIDR,
+		PeerVnetID:     cs.Properties.NetworkProfile.PeerVnetID,
 	}
 	oc.Properties.MonitorProfile = &MonitorProfile{
 		WorkspaceResourceID: &cs.Properties.MonitorProfile.WorkspaceResourceID,

--- a/pkg/api/admin/convertertointernal.go
+++ b/pkg/api/admin/convertertointernal.go
@@ -97,6 +97,12 @@ func mergePropertiesAdmin(oc *OpenShiftManagedCluster, cs *api.OpenShiftManagedC
 		if oc.Properties.NetworkProfile.VnetCIDR != nil {
 			cs.Properties.NetworkProfile.VnetCIDR = *oc.Properties.NetworkProfile.VnetCIDR
 		}
+		if oc.Properties.NetworkProfile.DefaultCIDR != nil {
+			cs.Properties.NetworkProfile.DefaultCIDR = *oc.Properties.NetworkProfile.DefaultCIDR
+		}
+		if oc.Properties.NetworkProfile.ManagementCIDR != nil {
+			cs.Properties.NetworkProfile.ManagementCIDR = *oc.Properties.NetworkProfile.ManagementCIDR
+		}
 		cs.Properties.NetworkProfile.PeerVnetID = oc.Properties.NetworkProfile.PeerVnetID
 	}
 

--- a/pkg/api/admin/convertertointernal_test.go
+++ b/pkg/api/admin/convertertointernal_test.go
@@ -270,6 +270,20 @@ func TestToInternal(t *testing.T) {
 			},
 		},
 		{
+			name: "networkProfile update",
+			input: &OpenShiftManagedCluster{
+				Properties: &Properties{
+					NetworkProfile: &NetworkProfile{
+						DefaultCIDR: to.StringPtr("10.0.0.0/16"),
+					},
+				},
+			},
+			base: internalManagedCluster(),
+			expectedChange: func(expectedCs *api.OpenShiftManagedCluster) {
+				expectedCs.Properties.NetworkProfile.DefaultCIDR = "10.0.0.0/16"
+			},
+		},
+		{
 			name: "loglevel update",
 			input: &OpenShiftManagedCluster{
 				Config: &Config{

--- a/pkg/api/admin/default.go
+++ b/pkg/api/admin/default.go
@@ -1,0 +1,19 @@
+package admin
+
+import (
+	"github.com/openshift/openshift-azure/pkg/api"
+)
+
+func setDefaults(cs *api.OpenShiftManagedCluster) {
+	// upgrade v7 to v8+ requires additional network fields to be added.
+	// TODO: Remove when v7 is gone
+	if len(cs.Properties.NetworkProfile.VnetCIDR) == 0 {
+		cs.Properties.NetworkProfile.VnetCIDR = "10.0.0.0/8"
+	}
+	if len(cs.Properties.NetworkProfile.DefaultCIDR) == 0 {
+		cs.Properties.NetworkProfile.DefaultCIDR = "10.0.0.0/24"
+	}
+	if len(cs.Properties.NetworkProfile.ManagementCIDR) == 0 {
+		cs.Properties.NetworkProfile.ManagementCIDR = "10.0.2.0/24"
+	}
+}

--- a/pkg/api/admin/types.go
+++ b/pkg/api/admin/types.go
@@ -94,6 +94,12 @@ type NetworkProfile struct {
 	// VnetCIDR (in): the CIDR with which the OSA cluster's Vnet is configured
 	VnetCIDR *string `json:"vnetCidr,omitempty"`
 
+	// DefaultCIDR (in): the CIDR used to configure default subnet
+	DefaultCIDR *string `json:"defaultCidr,omitempty"`
+
+	// ManagementCIDR (in): the CIDR used to configure management subnet
+	ManagementCIDR *string `json:"managementCidr,omitempty"`
+
 	// VnetID (out): the ID of the Vnet created for the OSA cluster
 	VnetID *string `json:"vnetId,omitempty"`
 

--- a/pkg/api/admin/types_test.go
+++ b/pkg/api/admin/types_test.go
@@ -32,6 +32,8 @@ var marshalled = []byte(`{
 		"fqdn": "Properties.FQDN",
 		"networkProfile": {
 			"vnetCidr": "Properties.NetworkProfile.VnetCIDR",
+			"defaultCidr": "Properties.NetworkProfile.DefaultCIDR",
+			"managementCidr": "Properties.NetworkProfile.ManagementCIDR",
 			"vnetId": "Properties.NetworkProfile.VnetID",
 			"peerVnetId": "Properties.NetworkProfile.PeerVnetID"
 		},

--- a/pkg/api/mock.go
+++ b/pkg/api/mock.go
@@ -52,9 +52,11 @@ func GetInternalMockCluster() *OpenShiftManagedCluster {
 				},
 			},
 			NetworkProfile: NetworkProfile{
-				VnetID:     "Properties.NetworkProfile.VnetID",
-				VnetCIDR:   "Properties.NetworkProfile.VnetCIDR",
-				PeerVnetID: to.StringPtr("Properties.NetworkProfile.PeerVnetID"),
+				VnetID:         "Properties.NetworkProfile.VnetID",
+				VnetCIDR:       "Properties.NetworkProfile.VnetCIDR",
+				ManagementCIDR: "Properties.NetworkProfile.ManagementCIDR",
+				DefaultCIDR:    "Properties.NetworkProfile.DefaultCIDR",
+				PeerVnetID:     to.StringPtr("Properties.NetworkProfile.PeerVnetID"),
 			},
 			MonitorProfile: MonitorProfile{
 				WorkspaceResourceID: "Properties.MonitorProfile.WorkspaceResourceID",

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -106,8 +106,11 @@ type NetworkProfile struct {
 	// VnetCIDR (in): the CIDR with which the OSA cluster's Vnet is configured
 	VnetCIDR string `json:"vnetCidr,omitempty"`
 
+	// DefaultCIDR (in): the CIDR used to configure default subnet
+	DefaultCIDR string `json:"defaultCidr,omitempty"`
+
 	// ManagementCIDR (in): the CIDR used to configure management subnet
-	ManagementCIDR string `json:"managementCIDR,omitempty"`
+	ManagementCIDR string `json:"managementCidr,omitempty"`
 
 	// VnetID (out): the ID of the Vnet created for the OSA cluster
 	VnetID string `json:"vnetId,omitempty"`

--- a/pkg/api/types.go
+++ b/pkg/api/types.go
@@ -106,6 +106,9 @@ type NetworkProfile struct {
 	// VnetCIDR (in): the CIDR with which the OSA cluster's Vnet is configured
 	VnetCIDR string `json:"vnetCidr,omitempty"`
 
+	// ManagementCIDR (in): the CIDR used to configure management subnet
+	ManagementCIDR string `json:"managementCIDR,omitempty"`
+
 	// VnetID (out): the ID of the Vnet created for the OSA cluster
 	VnetID string `json:"vnetId,omitempty"`
 

--- a/pkg/api/types_test.go
+++ b/pkg/api/types_test.go
@@ -25,6 +25,8 @@ var marshalled = []byte(`{
 		"fqdn": "Properties.FQDN",
 		"networkProfile": {
 			"vnetCidr": "Properties.NetworkProfile.VnetCIDR",
+			"defaultCidr": "Properties.NetworkProfile.DefaultCIDR",
+			"managementCidr": "Properties.NetworkProfile.ManagementCIDR",
 			"vnetId": "Properties.NetworkProfile.VnetID",
 			"peerVnetId": "Properties.NetworkProfile.PeerVnetID"
 		},

--- a/pkg/api/validate/admin.go
+++ b/pkg/api/validate/admin.go
@@ -65,6 +65,10 @@ func (v *AdminAPIValidator) validateUpdateContainerService(cs, oldCs *api.OpenSh
 		}
 	}
 
+	// networkProfile is mutatable field in v8+ to accommodate
+	// PLS, expressRoute, private-clusters
+	old.Properties.NetworkProfile = cs.Properties.NetworkProfile
+
 	// validating ProvisioningState and ClusterVersion is the RP's responsibility
 	old.Properties.ProvisioningState = cs.Properties.ProvisioningState
 	old.Properties.ClusterVersion = cs.Properties.ClusterVersion

--- a/pkg/api/validate/types.go
+++ b/pkg/api/validate/types.go
@@ -150,6 +150,7 @@ func isValidIPV4CIDR(cidr string) bool {
 	return true
 }
 
+// IsValidBlobName validates azure blob name
 func IsValidBlobName(c string) bool {
 	// https://docs.microsoft.com/en-us/rest/api/storageservices/naming-and-referencing-containers--blobs--and-metadata
 	if len(c) < 1 || len(c) > 1024 {
@@ -169,6 +170,10 @@ func IsValidBlobName(c string) bool {
 		return false
 	}
 	return true
+}
+
+func cidrIntersect(cidr1, cidr2 *net.IPNet) bool {
+	return cidr1.Contains(cidr2.IP) || cidr2.Contains(cidr1.IP)
 }
 
 func vnetContainsSubnet(vnet, subnet *net.IPNet) bool {

--- a/pkg/arm/v8/arm.go
+++ b/pkg/arm/v8/arm.go
@@ -41,6 +41,7 @@ func (g *simpleGenerator) Generate(ctx context.Context, backupBlob string, isUpd
 			g.vnet(),
 			g.ipAPIServer(),
 			g.lbAPIServer(),
+			g.ilbAPIServer(),
 			g.storageAccount(g.cs.Config.RegistryStorageAccount, map[string]*string{
 				"type": to.StringPtr("registry"),
 			}),
@@ -80,6 +81,12 @@ func (g *simpleGenerator) Generate(ctx context.Context, backupBlob string, isUpd
 	}
 
 	arm.FixupDepends(g.cs.Properties.AzProfile.SubscriptionID, g.cs.Properties.AzProfile.ResourceGroup, azuretemplate)
+
+	// HACK: Current SDK version is v24. Private link support comes into the version v28+.
+	// To use PLS/PE we need to set configurables on vnet and create PLS itself
+	// search for PrivateEndpointNetworkPolicies in https://raw.githubusercontent.com/Azure/azure-sdk-for-go/master/services/network/mgmt/2019-04-01/network/models.go
+	// To have these configs in our we need to modify the object after we generate them
+	arm.FixupSDKMismatch(g.cs.Properties.AzProfile.SubscriptionID, g.cs.Properties.AzProfile.ResourceGroup, azuretemplate)
 
 	return azuretemplate, nil
 }

--- a/pkg/arm/v8/resources.go
+++ b/pkg/arm/v8/resources.go
@@ -29,10 +29,13 @@ var (
 const (
 	vnetName                                      = "vnet"
 	vnetSubnetName                                = "default"
+	vnetmManagementSubnetName                     = "management"
 	ipAPIServerName                               = "ip-apiserver"
 	ipOutboundName                                = "ip-outbound"
 	lbAPIServerName                               = "lb-apiserver"
+	ilbAPIServerName                              = "ilb-apiserver"
 	lbAPIServerFrontendConfigurationName          = "frontend"
+	ilbAPIServerFrontendConfigurationName         = "ilb-frontend"
 	lbAPIServerBackendPoolName                    = "backend"
 	lbAPIServerLoadBalancingRuleName              = "port-443"
 	lbAPIServerProbeName                          = "port-443"
@@ -65,6 +68,12 @@ func (g *simpleGenerator) vnet() *network.VirtualNetwork {
 						AddressPrefix: to.StringPtr(g.cs.Properties.AgentPoolProfiles[0].SubnetCIDR),
 					},
 					Name: to.StringPtr(vnetSubnetName),
+				},
+				{
+					SubnetPropertiesFormat: &network.SubnetPropertiesFormat{
+						AddressPrefix: to.StringPtr("10.0.1.0/24"),
+					},
+					Name: to.StringPtr(vnetmManagementSubnetName),
 				},
 			},
 		},
@@ -188,6 +197,96 @@ func (g *simpleGenerator) lbAPIServer() *network.LoadBalancer {
 			OutboundRules:   &[]network.OutboundRule{},
 		},
 		Name:     to.StringPtr(lbAPIServerName),
+		Type:     to.StringPtr("Microsoft.Network/loadBalancers"),
+		Location: to.StringPtr(g.cs.Location),
+	}
+
+	return lb
+}
+
+func (g *simpleGenerator) ilbAPIServer() *network.LoadBalancer {
+	lb := &network.LoadBalancer{
+		Sku: &network.LoadBalancerSku{
+			Name: network.LoadBalancerSkuNameStandard,
+		},
+		LoadBalancerPropertiesFormat: &network.LoadBalancerPropertiesFormat{
+			FrontendIPConfigurations: &[]network.FrontendIPConfiguration{
+				{
+					FrontendIPConfigurationPropertiesFormat: &network.FrontendIPConfigurationPropertiesFormat{
+						PrivateIPAllocationMethod: network.Static,
+						// https://docs.microsoft.com/en-us/azure/virtual-network/virtual-networks-faq#are-there-any-restrictions-on-using-ip-addresses-within-these-subnets
+						PrivateIPAddress: to.StringPtr("10.0.1.4"),
+						Subnet: &network.Subnet{
+							ID: to.StringPtr(resourceid.ResourceID(
+								g.cs.Properties.AzProfile.SubscriptionID,
+								g.cs.Properties.AzProfile.ResourceGroup,
+								"Microsoft.Network/virtualNetworks",
+								vnetName,
+							) + "/subnets/" + vnetmManagementSubnetName),
+						},
+					},
+					Name: to.StringPtr(ilbAPIServerFrontendConfigurationName),
+				},
+			},
+			BackendAddressPools: &[]network.BackendAddressPool{
+				{
+					Name: to.StringPtr(lbAPIServerBackendPoolName),
+				},
+			},
+			LoadBalancingRules: &[]network.LoadBalancingRule{
+				{
+					LoadBalancingRulePropertiesFormat: &network.LoadBalancingRulePropertiesFormat{
+						FrontendIPConfiguration: &network.SubResource{
+							ID: to.StringPtr(resourceid.ResourceID(
+								g.cs.Properties.AzProfile.SubscriptionID,
+								g.cs.Properties.AzProfile.ResourceGroup,
+								"Microsoft.Network/loadBalancers",
+								ilbAPIServerName,
+							) + "/frontendIPConfigurations/" + ilbAPIServerFrontendConfigurationName),
+						},
+						BackendAddressPool: &network.SubResource{
+							ID: to.StringPtr(resourceid.ResourceID(
+								g.cs.Properties.AzProfile.SubscriptionID,
+								g.cs.Properties.AzProfile.ResourceGroup,
+								"Microsoft.Network/loadBalancers",
+								ilbAPIServerName,
+							) + "/backendAddressPools/" + lbAPIServerBackendPoolName),
+						},
+						Probe: &network.SubResource{
+							ID: to.StringPtr(resourceid.ResourceID(
+								g.cs.Properties.AzProfile.SubscriptionID,
+								g.cs.Properties.AzProfile.ResourceGroup,
+								"Microsoft.Network/loadBalancers",
+								ilbAPIServerName,
+							) + "/probes/" + lbAPIServerProbeName),
+						},
+						Protocol:             network.TransportProtocolTCP,
+						LoadDistribution:     network.Default,
+						FrontendPort:         to.Int32Ptr(443),
+						BackendPort:          to.Int32Ptr(443),
+						IdleTimeoutInMinutes: to.Int32Ptr(15),
+						EnableFloatingIP:     to.BoolPtr(false),
+					},
+					Name: to.StringPtr(lbAPIServerLoadBalancingRuleName),
+				},
+			},
+			Probes: &[]network.Probe{
+				{
+					ProbePropertiesFormat: &network.ProbePropertiesFormat{
+						Protocol:          network.ProbeProtocolHTTPS,
+						Port:              to.Int32Ptr(443),
+						IntervalInSeconds: to.Int32Ptr(5),
+						NumberOfProbes:    to.Int32Ptr(2),
+						RequestPath:       to.StringPtr("/healthz"),
+					},
+					Name: to.StringPtr(lbAPIServerProbeName),
+				},
+			},
+			InboundNatRules: &[]network.InboundNatRule{},
+			InboundNatPools: &[]network.InboundNatPool{},
+			OutboundRules:   &[]network.OutboundRule{},
+		},
+		Name:     to.StringPtr(ilbAPIServerName),
 		Type:     to.StringPtr("Microsoft.Network/loadBalancers"),
 		Location: to.StringPtr(g.cs.Location),
 	}
@@ -496,6 +595,14 @@ func vmss(cs *api.OpenShiftManagedCluster, app *api.AgentPoolProfile, backupBlob
 					cs.Properties.AzProfile.ResourceGroup,
 					"Microsoft.Network/loadBalancers",
 					lbAPIServerName,
+				) + "/backendAddressPools/" + lbAPIServerBackendPoolName),
+			},
+			{
+				ID: to.StringPtr(resourceid.ResourceID(
+					cs.Properties.AzProfile.SubscriptionID,
+					cs.Properties.AzProfile.ResourceGroup,
+					"Microsoft.Network/loadBalancers",
+					ilbAPIServerName,
 				) + "/backendAddressPools/" + lbAPIServerBackendPoolName),
 			},
 		}

--- a/pkg/fakerp/customer_handlers.go
+++ b/pkg/fakerp/customer_handlers.go
@@ -65,12 +65,14 @@ func (s *Server) handlePut(w http.ResponseWriter, req *http.Request) {
 	var cs *internalapi.OpenShiftManagedCluster
 	var err error
 	if isAdmin {
+		s.log.Info("admin request")
 		cs, err = s.readAdminRequest(req.Body, oldCs)
 		if err == nil {
 			cs.Properties.ProvisioningState = internalapi.AdminUpdating
 			s.store.Put(cs)
 		}
 	} else {
+		s.log.Info("customer request")
 		cs, err = s.read20190430Request(req.Body, oldCs)
 		if err == nil {
 			cs.Properties.ProvisioningState = internalapi.Updating

--- a/pkg/plugin/integration_test.go
+++ b/pkg/plugin/integration_test.go
@@ -421,7 +421,11 @@ func newTestCs() *api.OpenShiftManagedCluster {
 				{Role: api.AgentPoolProfileRoleCompute, Count: 1, Name: "compute", VMSize: "Standard_D2s_v3", SubnetCIDR: "10.0.0.0/24", OSType: "Linux"},
 				{Role: api.AgentPoolProfileRoleInfra, Count: 2, Name: "infra", VMSize: "Standard_D2s_v3", SubnetCIDR: "10.0.0.0/24", OSType: "Linux"},
 			},
-			NetworkProfile: api.NetworkProfile{VnetCIDR: "10.0.0.0/8"},
+			NetworkProfile: api.NetworkProfile{
+				VnetCIDR:       "10.0.0.0/8",
+				DefaultCIDR:    "10.0.0.0/24",
+				ManagementCIDR: "10.0.2.0/24",
+			},
 		},
 	}
 }

--- a/pkg/util/cmp/cmp.go
+++ b/pkg/util/cmp/cmp.go
@@ -1,6 +1,7 @@
 package cmp
 
 import (
+	"crypto/rsa"
 	"crypto/x509"
 
 	gocmp "github.com/google/go-cmp/cmp"
@@ -12,6 +13,8 @@ func Diff(x, y interface{}, opts ...gocmp.Option) string {
 	// FIXME: Remove x509CertComparer after upgrading to a Go version that includes https://github.com/golang/go/issues/28743
 	opts = append(opts, gocmp.Comparer(x509CertComparer))
 
+	opts = append(opts, gocmp.Comparer(rsaPrivateKeyComparer))
+
 	return gocmp.Diff(x, y, opts...)
 }
 
@@ -21,4 +24,16 @@ func x509CertComparer(x, y *x509.Certificate) bool {
 	}
 
 	return x.Equal(y)
+}
+
+func rsaPrivateKeyComparer(x, y *rsa.PrivateKey) bool {
+	if x == nil || y == nil {
+		return x == y
+	}
+
+	if x.D.Cmp(y.D) == 0 ||
+		x.PublicKey.N.Cmp(y.PublicKey.N) == 0 {
+		return true
+	}
+	return false
 }

--- a/pkg/util/cmp/cmp.go
+++ b/pkg/util/cmp/cmp.go
@@ -8,13 +8,11 @@ import (
 
 // Diff is a wrapper for github.com/google/go-cmp/cmp.Diff with extra options
 func Diff(x, y interface{}, opts ...gocmp.Option) string {
-	newOpts := append(
-		opts,
-		// FIXME: Remove x509CertComparer after upgrading to a Go version that includes https://github.com/golang/go/issues/28743
-		gocmp.Comparer(x509CertComparer),
-	)
 
-	return gocmp.Diff(x, y, newOpts...)
+	// FIXME: Remove x509CertComparer after upgrading to a Go version that includes https://github.com/golang/go/issues/28743
+	opts = append(opts, gocmp.Comparer(x509CertComparer))
+
+	return gocmp.Diff(x, y, opts...)
 }
 
 func x509CertComparer(x, y *x509.Certificate) bool {

--- a/pkg/util/cmp/cmp_test.go
+++ b/pkg/util/cmp/cmp_test.go
@@ -1,8 +1,12 @@
 package cmp
 
 import (
+	"crypto/rsa"
 	"crypto/x509"
 	"testing"
+
+	"github.com/openshift/openshift-azure/pkg/util/tls"
+	testtls "github.com/openshift/openshift-azure/test/util/tls"
 )
 
 func TestX509CertComparer(t *testing.T) {
@@ -45,6 +49,41 @@ func TestX509CertComparer(t *testing.T) {
 
 	for _, test := range tests {
 		got := x509CertComparer(test.x, test.y)
+		if got != test.expect {
+			t.Errorf("%s: expected %#v got %#v", test.name, test.expect, got)
+		}
+	}
+}
+
+func TestRsaPrivateKeyComparer(t *testing.T) {
+	pk, _ := tls.NewPrivateKey()
+	tests := []struct {
+		name   string
+		x, y   *rsa.PrivateKey
+		expect bool
+	}{
+		{
+			name:   "both nil",
+			x:      nil,
+			y:      nil,
+			expect: true,
+		},
+		{
+			name:   "compare 2 rsa keys - match",
+			x:      testtls.DummyPrivateKey,
+			y:      testtls.DummyPrivateKey,
+			expect: true,
+		},
+		{
+			name:   "compare 2 rsa keys - missmatch",
+			x:      testtls.DummyPrivateKey,
+			y:      pk,
+			expect: false,
+		},
+	}
+
+	for _, test := range tests {
+		got := rsaPrivateKeyComparer(test.x, test.y)
 		if got != test.expect {
 			t.Errorf("%s: expected %#v got %#v", test.name, test.expect, got)
 		}


### PR DESCRIPTION
```release-note
Adds management subnet
Adds an internal load balancer
Extends API to configure vnet configuration to prepare for expressRoute and vnet
```


TODO: 
- [ ] Add callback function to `createOrUpdate` to provision the PLS/PE
- [ ] Change internal type/config to have placeholders for PE DNS/IP
- [ ] Make plugin kubeconfig avare of the above and use round tripper to call API via External Loadbalanancer OR PE
- [ ] Unit tests for new functions
