### PR TITLE
Adding ability to skip ci based on files

### DIFF
--- a/hack/skipci/codecov_dummy_test.go
+++ b/hack/skipci/codecov_dummy_test.go
@@ -1,0 +1,12 @@
+package main
+
+import (
+	"testing"
+)
+
+// This file exists because this package has no unit tests.  Codecov does not
+// report packages with no unit tests as 0% coverage, incorrectly inflating our
+// coverage statistics.  When unit tests are added to this package, this file
+// can be removed.
+
+func TestDummyCodeCov(t *testing.T) {}

--- a/hack/skipci/codecov_dummy_test.go
+++ b/hack/skipci/codecov_dummy_test.go
@@ -4,9 +4,68 @@ import (
 	"testing"
 )
 
-// This file exists because this package has no unit tests.  Codecov does not
-// report packages with no unit tests as 0% coverage, incorrectly inflating our
-// coverage statistics.  When unit tests are added to this package, this file
-// can be removed.
+func TestDummyCodeCov(t *testing.T) {
+	tests := []struct {
+		name   string
+		cf     commitFile
+		status bool
+	}{
+		{
+			name: "markdown",
+			cf: commitFile{
+				extension: ".md",
+				directory: "docs",
+				filename:  "test",
+				original:  "docs/test.md",
+			},
+			status: true,
+		},
+		{
+			name: "asciidoc",
+			cf: commitFile{
+				extension: ".asciidoc",
+				directory: "pkg/arm",
+				filename:  "test",
+				original:  "docs/test.asciidoc",
+			},
+			status: true,
+		},
+		{
+			name: "gofile",
+			cf: commitFile{
+				extension: ".go",
+				directory: "pkg/startup",
+				filename:  "startup",
+				original:  "pkg/startup/startup.go",
+			},
+			status: false,
+		},
+		{
+			name: "shellfile1",
+			cf: commitFile{
+				extension: ".sh",
+				directory: "hack/test",
+				filename:  "create",
+				original:  "hack/test/create.sh",
+			},
+			status: false,
+		},
+		{
+			name: "owners",
+			cf: commitFile{
+				extension: "",
+				directory: "",
+				filename:  "OWNERS",
+				original:  "OWNERS",
+			},
+			status: true,
+		},
+	}
 
-func TestDummyCodeCov(t *testing.T) {}
+	for _, tt := range tests {
+		result := whiteListed(tt.cf, false)
+		if result != tt.status {
+			t.Errorf("%s test failed.  expected %v got=%v", tt.name, tt.status, result)
+		}
+	}
+}

--- a/hack/skipci/main.go
+++ b/hack/skipci/main.go
@@ -1,0 +1,118 @@
+package main
+
+/*
+
+A list of available environment variables can be found here:
+
+https://github.com/kubernetes/test-infra/blob/a9f967cb1235916fb5a4eca661fa083413211242/prow/jobs.md#job-environment-variables
+
+For periodics:
+- JOB_NAME
+- JOB_TYPE
+- JOB_SPEC
+- BUILD_ID
+- PROW_JOB_ID
+
+*/
+
+import (
+	"flag"
+	"fmt"
+	"os"
+	"os/exec"
+	"path"
+	"strings"
+)
+
+var (
+	commit = flag.String("commit", "HEAD~1..HEAD", "commit to compare against. defaults to n-1")
+	debug  = flag.Bool("debug", false, "whether to print debug statements")
+)
+
+type commitFile struct {
+	extension string
+	directory string
+	filename  string
+	original  string
+}
+
+var (
+	whiteListDirectories = []string{
+		"docs/",
+		"hack/skipci",
+	}
+
+	whiteListFileExt = []string{
+		".md",
+		".asciidoc",
+	}
+)
+
+func whiteListed(f commitFile, debug bool) bool {
+	for _, wld := range whiteListDirectories {
+		if strings.Contains(f.directory, wld) {
+			if debug {
+				fmt.Printf("matched dir (%s) on whitelist dir (%s) with (%s)\n", f.original, f.directory, wld)
+			}
+			return true
+		}
+	}
+	for _, wle := range whiteListFileExt {
+		if strings.HasSuffix(f.extension, wle) {
+			if debug {
+				fmt.Printf("matched file (%s) on whitelist file extension (%s) with (%s)\n", f.original, f.extension, wle)
+			}
+			return true
+		}
+	}
+
+	return false
+}
+
+func getCommitFiles(commit string) ([]commitFile, error) {
+	cmd := "git"
+	args := []string{"diff-tree", "--no-commit-id", "--name-only", "-r", commit}
+	c := exec.Command(cmd, args...)
+	cmdOut, err := c.Output()
+	if err != nil {
+		fmt.Fprintln(os.Stderr, err)
+		return nil, err
+	}
+	files := []commitFile{}
+	for _, f := range strings.Split(string(cmdOut), "\n") {
+		if f != "" {
+			files = append(files, commitFile{
+				filename:  path.Base(f),
+				extension: path.Ext(f),
+				directory: path.Dir(f),
+				original:  f,
+			})
+		}
+	}
+
+	return files, nil
+}
+
+func main() {
+	flag.Parse()
+	fmt.Printf("testing commit: %s\n", *commit)
+	// algorithm:
+	// find all files in recent commits
+	// first determine if they are in a directory that is test worthy
+	// second determine if they have a file extension that can be ignored
+	// any other tests we can think of?
+	files, err := getCommitFiles(*commit)
+	if err != nil {
+		panic(err)
+	}
+
+	for _, f := range files {
+		fmt.Printf("File: %s\n", f.original)
+		if !whiteListed(f, *debug) {
+			// found a file that requires testing
+			// TODO: further classify what testing we should perform
+			os.Exit(1)
+		}
+	}
+	os.Exit(0)
+}

--- a/hack/tests/ci-prepare.sh
+++ b/hack/tests/ci-prepare.sh
@@ -62,10 +62,23 @@ delete() {
   make delete
 }
 
+check_skip_ci() {
+    if [ ${SKIP_CI:-1} -eq 0 ]; then
+      # No need to run CI
+      exit
+    fi
+}
+
 if [[ ! -e /var/run/secrets/kubernetes.io ]]; then
     reset_xtrace
     return
 fi
+
+set +e
+# check the latest commit
+go run hack/skipci/main.go
+export SKIP_CI=$?
+set -e
 
 export NO_WAIT=true
 export RESOURCEGROUP_TTL=4h

--- a/hack/tests/create.sh
+++ b/hack/tests/create.sh
@@ -10,6 +10,8 @@ cleanup() {
 
 . hack/tests/ci-prepare.sh
 
+check_skip_ci
+
 start_monitoring
 set_build_images
 

--- a/hack/tests/e2e-create.sh
+++ b/hack/tests/e2e-create.sh
@@ -12,6 +12,8 @@ trap cleanup EXIT
 
 . hack/tests/ci-prepare.sh
 
+check_skip_ci
+
 start_monitoring
 set_build_images
 

--- a/hack/tests/e2e-scaleupdown-previous.sh
+++ b/hack/tests/e2e-scaleupdown-previous.sh
@@ -21,6 +21,8 @@ trap cleanup EXIT
 
 . hack/tests/ci-prepare.sh
 
+check_skip_ci
+
 T="$(mktemp -d)"
 start_monitoring $T/src/github.com/openshift/openshift-azure/_data/containerservice.yaml
 

--- a/hack/tests/e2e-upgrade.sh
+++ b/hack/tests/e2e-upgrade.sh
@@ -21,6 +21,8 @@ trap cleanup EXIT
 
 . hack/tests/ci-prepare.sh
 
+check_skip_ci
+
 T="$(mktemp -d)"
 start_monitoring $T/src/github.com/openshift/openshift-azure/_data/containerservice.yaml
 


### PR DESCRIPTION
A quick script to determine the incoming changes and skip ci tests if matched.  This is a proof of concept and would like feedback.

```release-notes:
None
```