### PR TITLE
Adds CI notifications into vmimage-validate

### DIFF
--- a/hack/tests/ci-prepare.sh
+++ b/hack/tests/ci-prepare.sh
@@ -62,6 +62,17 @@ delete() {
   make delete
 }
 
+ci_notify() {
+  # We create notifications in CI and only for periodic jobs. This will open an issue
+  # with a link to a failed CI build.
+  if [[ -e /var/run/secrets/kubernetes.io ]] && [ "${JOB_TYPE}" == "periodic" ]; then
+    if [ $PHASE == "build_complete" ]; then
+      ARGS="-success"
+    fi
+    go run ./hack/ci-notify/main.go -job-name "${JOB_NAME}" -comment "Phase: $1" $ARGS
+  fi
+}
+
 if [[ ! -e /var/run/secrets/kubernetes.io ]]; then
     reset_xtrace
     return

--- a/hack/vmimage-validate.sh
+++ b/hack/vmimage-validate.sh
@@ -3,10 +3,12 @@
 cleanup() {
   set +e
 
+  ci_notify $PHASE
   az group delete -g "${BUILD_RESOURCE_GROUP}" --yes --no-wait
 }
 
 trap cleanup EXIT
+PHASE=image_validation
 
 . hack/tests/ci-prepare.sh
 
@@ -45,3 +47,4 @@ if [ -s "${ARTIFACTS:-/tmp}/yum_updateinfo_list_security" ]; then
   >&2 cat /tmp/yum_updateinfo_list_security
   exit 1
 fi
+PHASE=build_complete

--- a/hack/vmimage.sh
+++ b/hack/vmimage.sh
@@ -3,13 +3,7 @@
 cleanup() {
   set +e
 
-  if [[ -e /var/run/secrets/kubernetes.io ]] && [ "${JOB_TYPE}" == "periodic" ]; then
-    if [ $PHASE == "build_complete" ]; then
-      ARGS="-success"
-    fi
-    go run ./hack/ci-notify/main.go -job-name "${JOB_NAME}" -comment "Phase: ${PHASE}" $ARGS
-  fi
-
+  ci_notify $PHASE
   generate_artifacts
   delete
 }


### PR DESCRIPTION
So we can run it as a periodic job and get feedback from CIin form of a GitHub issue.

```release-note
NONE
```

/test vmimage