### PR TITLE
Avoid VM image build timeout

### DIFF
--- a/pkg/vmimage/resources.go
+++ b/pkg/vmimage/resources.go
@@ -143,7 +143,7 @@ func vm(subscriptionID, resourceGroup, location, sshPublicKey string, plan *comp
 		Plan: plan,
 		VirtualMachineProperties: &compute.VirtualMachineProperties{
 			HardwareProfile: &compute.HardwareProfile{
-				VMSize: compute.VirtualMachineSizeTypesStandardD2sV3,
+				VMSize: compute.VirtualMachineSizeTypesStandardD4sV3,
 			},
 			StorageProfile: &compute.StorageProfile{
 				ImageReference: imageReference,

--- a/pkg/vmimage/vmimage.go
+++ b/pkg/vmimage/vmimage.go
@@ -244,7 +244,7 @@ func (builder *Builder) Run(ctx context.Context) error {
 	go builder.ssh()
 
 	cli := builder.Deployments.Client()
-	cli.PollingDuration = time.Hour
+	cli.PollingDuration = time.Minute * 90
 
 	builder.Log.Infof("waiting for deployment")
 	err = future.WaitForCompletionRef(ctx, cli)


### PR DESCRIPTION
```release-note
NONE
```

I got a successful build out this, but it failed the VM validation due to a token expiry.

/test vmimage