### PR TITLE
Update container versions for v8 release

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+## v8.0
+
+- Bugfix: Regression fix in group sync for guest users ([#1910](https://github.com/openshift/openshift-azure/pull/1910), [@mjudeikis](https://github.com/mjudeikis), 05/09/2019)
+- Microsoft: when using logrus.SetReportCaller() you can now use the following to convert absolute file names in logs to relative ones. ([#1895](https://github.com/openshift/openshift-azure/pull/1895), [@asalkeld](https://github.com/asalkeld), 28/08/2019)
+    logrus.SetFormatter(&logrus.TextFormatter{
+        FullTimestamp:    true,
+        CallerPrettyfier: utillog.RelativeFilePathPrettier,
+    })
+- Enabling boot diagnostics means serial console logs are available as
+well as serial console access. ([#1875](https://github.com/openshift/openshift-azure/pull/1875), [@thekad](https://github.com/thekad), 26/08/2019)
+- Allow the following to be set using the admin API: ([#1876](https://github.com/openshift/openshift-azure/pull/1876), [@asalkeld](https://github.com/asalkeld), 23/08/2019)
+    - SSHSourceAddressPrefixes
+    - SecurityPatchPackages
+    - ComponentLogLevel
+- Microsoft: renamed api from 2019-08-31 to 2019-09-30-preview as requested. ([#1874](https://github.com/openshift/openshift-azure/pull/1874), [@asalkeld](https://github.com/asalkeld), 22/08/2019)
+- Disable DisableOutboundSNAT for VMSS ([#1854](https://github.com/openshift/openshift-azure/pull/1854), [@mjudeikis](https://github.com/mjudeikis), 16/08/2019)
+- Delay VM reboot after security updates to prevent possible race with Kubelet's startup. ([#1833](https://github.com/openshift/openshift-azure/pull/1833), [@charlesakalugwu](https://github.com/charlesakalugwu), 16/08/2019)
+- Send logs to a customer's log analytics workspace ([#1812](https://github.com/openshift/openshift-azure/pull/1812), [@asalkeld](https://github.com/asalkeld), 15/08/2019)

--- a/pluginconfig/pluginconfig-311.yaml
+++ b/pluginconfig/pluginconfig-311.yaml
@@ -62,40 +62,40 @@ versions:
     imageSku: osa_311
     imageVersion: 311.129.20190810
     images:
-      alertManager: registry.access.redhat.com/openshift3/prometheus-alertmanager:v3.11.135
-      ansibleServiceBroker: registry.access.redhat.com/openshift3/ose-ansible-service-broker:v3.11.135
-      clusterMonitoringOperator: registry.access.redhat.com/openshift3/ose-cluster-monitoring-operator:v3.11.135
-      configReloader: registry.access.redhat.com/openshift3/ose-configmap-reloader:v3.11.135
-      console: registry.access.redhat.com/openshift3/ose-console:v3.11.135
-      controlPlane: registry.access.redhat.com/openshift3/ose-control-plane:v3.11.135
-      grafana: registry.access.redhat.com/openshift3/grafana:v3.11.135
-      kubeRbacProxy: registry.access.redhat.com/openshift3/ose-kube-rbac-proxy:v3.11.135
-      kubeStateMetrics: registry.access.redhat.com/openshift3/ose-kube-state-metrics:v3.11.135
-      node: registry.access.redhat.com/openshift3/ose-node:v3.11.135
-      nodeExporter: registry.access.redhat.com/openshift3/prometheus-node-exporter:v3.11.135
-      oAuthProxy: registry.access.redhat.com/openshift3/oauth-proxy:v3.11.135
-      prometheus: registry.access.redhat.com/openshift3/prometheus:v3.11.135
-      prometheusConfigReloader: registry.access.redhat.com/openshift3/ose-prometheus-config-reloader:v3.11.135
-      prometheusOperator: registry.access.redhat.com/openshift3/ose-prometheus-operator:v3.11.135
-      registry: registry.access.redhat.com/openshift3/ose-docker-registry:v3.11.135
-      registryConsole: registry.access.redhat.com/openshift3/registry-console:v3.11.135
-      router: registry.access.redhat.com/openshift3/ose-haproxy-router:v3.11.135
-      serviceCatalog: registry.access.redhat.com/openshift3/ose-service-catalog:v3.11.135
-      templateServiceBroker: registry.access.redhat.com/openshift3/ose-template-service-broker:v3.11.135
-      webConsole: registry.access.redhat.com/openshift3/ose-web-console:v3.11.135
-      format: registry.access.redhat.com/openshift3/ose-${component}:v3.11.135
+      alertManager: registry.access.redhat.com/openshift3/prometheus-alertmanager:v3.11.129
+      ansibleServiceBroker: registry.access.redhat.com/openshift3/ose-ansible-service-broker:v3.11.129
+      clusterMonitoringOperator: registry.access.redhat.com/openshift3/ose-cluster-monitoring-operator:v3.11.129
+      configReloader: registry.access.redhat.com/openshift3/ose-configmap-reloader:v3.11.129
+      console: registry.access.redhat.com/openshift3/ose-console:v3.11.129
+      controlPlane: registry.access.redhat.com/openshift3/ose-control-plane:v3.11.129
+      grafana: registry.access.redhat.com/openshift3/grafana:v3.11.129
+      kubeRbacProxy: registry.access.redhat.com/openshift3/ose-kube-rbac-proxy:v3.11.129
+      kubeStateMetrics: registry.access.redhat.com/openshift3/ose-kube-state-metrics:v3.11.129
+      node: registry.access.redhat.com/openshift3/ose-node:v3.11.129
+      nodeExporter: registry.access.redhat.com/openshift3/prometheus-node-exporter:v3.11.129
+      oAuthProxy: registry.access.redhat.com/openshift3/oauth-proxy:v3.11.129
+      prometheus: registry.access.redhat.com/openshift3/prometheus:v3.11.129
+      prometheusConfigReloader: registry.access.redhat.com/openshift3/ose-prometheus-config-reloader:v3.11.129
+      prometheusOperator: registry.access.redhat.com/openshift3/ose-prometheus-operator:v3.11.129
+      registry: registry.access.redhat.com/openshift3/ose-docker-registry:v3.11.129
+      registryConsole: registry.access.redhat.com/openshift3/registry-console:v3.11.129
+      router: registry.access.redhat.com/openshift3/ose-haproxy-router:v3.11.129
+      serviceCatalog: registry.access.redhat.com/openshift3/ose-service-catalog:v3.11.129
+      templateServiceBroker: registry.access.redhat.com/openshift3/ose-template-service-broker:v3.11.129
+      webConsole: registry.access.redhat.com/openshift3/ose-web-console:v3.11.129
+      format: registry.access.redhat.com/openshift3/ose-${component}:v3.11.129
       httpd: registry.access.redhat.com/rhscl/httpd-24-rhel7:2.4-103
       masterEtcd: registry.access.redhat.com/rhel7/etcd:3.2.26-14
       genevaLogging: osarpint.azurecr.io/acs/mdsd:master.20190228.1
       genevaStatsd: osarpint.azurecr.io/acs/mdm:git-a909a2e76
       genevaTDAgent: osarpint.azurecr.io/acs/td-agent:master.20190228.1
-      azureControllers: quay.io/openshift-on-azure/azure:latest
-      canary: quay.io/openshift-on-azure/azure:latest
-      etcdBackup: quay.io/openshift-on-azure/azure:latest
-      metricsBridge: quay.io/openshift-on-azure/azure:latest
-      startup: quay.io/openshift-on-azure/azure:latest
-      sync: quay.io/openshift-on-azure/azure:latest
-      tlsProxy: quay.io/openshift-on-azure/azure:latest
+      azureControllers: quay.io/openshift-on-azure/azure:v8.0
+      canary: quay.io/openshift-on-azure/azure:v8.0
+      etcdBackup: quay.io/openshift-on-azure/azure:v8.0
+      metricsBridge: quay.io/openshift-on-azure/azure:v8.0
+      startup: quay.io/openshift-on-azure/azure:v8.0
+      sync: quay.io/openshift-on-azure/azure:v8.0
+      tlsProxy: quay.io/openshift-on-azure/azure:v8.0
       logAnalyticsAgent: mcr.microsoft.com/azuremonitor/containerinsights/ciprod:ciprod07092019
 ## certificates, used to authenticate to external systems
 ## Red Hat CDN client certificates


### PR DESCRIPTION
```release-note
NONE
```

OpenShift container versions need to match the VM image. We determined we don't need to do a VM image update this sprint, and since the newest one doesn't match the container images we tested against, reverting back to 129 for now.