### PR TITLE
fixing RG in the metrics-bridge

### DIFF
--- a/pkg/sync/v9/sync_test.go
+++ b/pkg/sync/v9/sync_test.go
@@ -74,6 +74,7 @@ func TestReadDB(t *testing.T) {
 
 	var cs api.OpenShiftManagedCluster
 	populate.Walk(&cs, prepare)
+	cs.ID = "subscriptions/foo/resourceGroups/bar/providers/baz/qux/quz"
 	cs.Config.ImageVersion = "311.123.456"
 	cs.Config.Images.Console = "foo:v3.11.22"
 	cs.Config.Images.PrometheusOperator = ":"

--- a/pkg/sync/v9/translate.go
+++ b/pkg/sync/v9/translate.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"strings"
 
+	"github.com/Azure/go-autorest/autorest/azure"
 	"github.com/ghodss/yaml"
 	"k8s.io/apimachinery/pkg/apis/meta/v1/unstructured"
 	"k8s.io/apimachinery/pkg/runtime/schema"
@@ -247,7 +248,10 @@ var translations = map[string][]struct {
 		{
 			Path:       jsonpath.MustCompile("$.data.'config.yaml'"),
 			NestedPath: jsonpath.MustCompile("$.resourceGroupName"),
-			Template:   "{{ .ContainerService.Properties.AzProfile.ResourceGroup }}",
+			F: func(cs *api.OpenShiftManagedCluster, o interface{}) (interface{}, error) {
+				res, err := azure.ParseResourceID(cs.ID)
+				return res.ResourceGroup, err
+			},
 		},
 		{
 			Path:       jsonpath.MustCompile("$.data.'config.yaml'"),


### PR DESCRIPTION
populating the resourceGroupName in metrics-bridge config with the customer's resourceGroup name instead of the managed resourceGroup. 

```release-note
NONE
```
