### PR TITLE
Support multiple AAD reply urls per AAD App

### DIFF
--- a/pkg/util/aadapp/aadapp.go
+++ b/pkg/util/aadapp/aadapp.go
@@ -40,12 +40,17 @@ func GetServicePrincipalObjectIDFromAppID(ctx context.Context, spc graphrbac.Ser
 	return *sp.Values()[0].ObjectID, nil
 }
 
-// UpdateAADApp updates the ReplyURLs in an AAD app.
-func UpdateAADApp(ctx context.Context, appClient graphrbac.ApplicationsClient, appObjID string, callbackURL string) error {
+// UpdateAADApp updates the ReplyURLs for an AAD app.
+func UpdateAADApp(ctx context.Context, appClient graphrbac.ApplicationsClient, appObjID string, callbackURLs []string) error {
+	size := len(callbackURLs)
+	homepage := "http://localhost/"
+	if size > 0 {
+		homepage = callbackURLs[size-1]
+	}
 	_, err := appClient.Patch(ctx, appObjID, azgraphrbac.ApplicationUpdateParameters{
-		Homepage:       to.StringPtr(callbackURL),
-		ReplyUrls:      &[]string{callbackURL},
-		IdentifierUris: &[]string{callbackURL},
+		Homepage:       to.StringPtr(homepage),
+		ReplyUrls:      &callbackURLs,
+		IdentifierUris: &callbackURLs,
 	})
 	return err
 }

--- a/pkg/util/azureclient/graphrbac/applications.go
+++ b/pkg/util/azureclient/graphrbac/applications.go
@@ -18,6 +18,7 @@ import (
 type ApplicationsClient interface {
 	Create(ctx context.Context, parameters graphrbac.ApplicationCreateParameters) (result graphrbac.Application, err error)
 	Delete(ctx context.Context, applicationObjectID string) (result autorest.Response, err error)
+	Get(ctx context.Context, applicationObjectID string) (result graphrbac.Application, err error)
 	List(ctx context.Context, filter string) (result graphrbac.ApplicationListResultPage, err error)
 	Patch(ctx context.Context, applicationObjectID string, parameters graphrbac.ApplicationUpdateParameters) (result autorest.Response, err error)
 }

--- a/pkg/util/mocks/mock_azureclient/mock_graphrbac/graphrbac.go
+++ b/pkg/util/mocks/mock_azureclient/mock_graphrbac/graphrbac.go
@@ -66,6 +66,21 @@ func (mr *MockApplicationsClientMockRecorder) Delete(arg0, arg1 interface{}) *go
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Delete", reflect.TypeOf((*MockApplicationsClient)(nil).Delete), arg0, arg1)
 }
 
+// Get mocks base method
+func (m *MockApplicationsClient) Get(arg0 context.Context, arg1 string) (graphrbac.Application, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "Get", arg0, arg1)
+	ret0, _ := ret[0].(graphrbac.Application)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Get indicates an expected call of Get
+func (mr *MockApplicationsClientMockRecorder) Get(arg0, arg1 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockApplicationsClient)(nil).Get), arg0, arg1)
+}
+
 // List mocks base method
 func (m *MockApplicationsClient) List(arg0 context.Context, arg1 string) (graphrbac.ApplicationListResultPage, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
It is currently impossible to create 2 or more fakerp clusters and be able to log into any of the clusters apart from the latest one. This is because our fakerp cluster creation logic updates the reply urls of the AAD app to contain only the reply url of the last-created cluster. 

To reproduce the issue one can run the following series of steps
```
source ./env
export RESOURCEGROUP=charles-foo
make create
xdg-open https://openshift.${RESOURCEGROUP}.osadev.cloud
mv _data _data-${RESOURCEGROUP}
export RESOURCEGROUP=charles-bar
make create
xdg-open https://openshift.${RESOURCEGROUP}.osadev.cloud
```
After those steps, you are no longer able to login to `https://openshift.charles-foo.osadev.cloud` without updating the list of reply urls via the portal or cli

I want to be able to create multiple fakerp clusters all bound to my lone AAD app and be able to log into all of them without having to update the reply url in the portal or manually manage the list of reply urls for all my clusters (multiple urls are supported). This PR attempts to fix this problem.

![reply](https://user-images.githubusercontent.com/5978370/64727619-8708bf80-d4d9-11e9-9de9-ebfd69551792.png)

```release-note
NONE
```

/cc @kwoodson @mjudeikis @m1kola 