### PR TITLE
Fix content_test.go after openshift/api update

### DIFF
--- a/pkg/sync/v9/content_test.go
+++ b/pkg/sync/v9/content_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func init() {
-	err := imagev1.AddToSchemeInCoreGroup(scheme.Scheme)
+	err := imagev1.DeprecatedInstallWithoutGroup(scheme.Scheme)
 	if err != nil {
 		panic(err)
 	}


### PR DESCRIPTION
```release-note
NONE
```

Now make verify will catch these compile errors earlier.