### PR TITLE
Fix multiple aad urls single-cluster case

### DIFF
--- a/pkg/util/aadapp/aadapp.go
+++ b/pkg/util/aadapp/aadapp.go
@@ -41,16 +41,11 @@ func GetServicePrincipalObjectIDFromAppID(ctx context.Context, spc graphrbac.Ser
 }
 
 // UpdateAADApp updates the ReplyURLs for an AAD app.
-func UpdateAADApp(ctx context.Context, appClient graphrbac.ApplicationsClient, appObjID string, callbackURLs []string) error {
-	size := len(callbackURLs)
-	homepage := "http://localhost/"
-	if size > 0 {
-		homepage = callbackURLs[size-1]
-	}
+func UpdateAADApp(ctx context.Context, appClient graphrbac.ApplicationsClient, appObjID, clusterUrl string, replyUrls []string) error {
 	_, err := appClient.Patch(ctx, appObjID, azgraphrbac.ApplicationUpdateParameters{
-		Homepage:       to.StringPtr(homepage),
-		ReplyUrls:      &callbackURLs,
-		IdentifierUris: &callbackURLs,
+		Homepage:       to.StringPtr(clusterUrl),
+		ReplyUrls:      &replyUrls,
+		IdentifierUris: to.StringSlicePtr([]string{clusterUrl}),
 	})
 	return err
 }


### PR DESCRIPTION
This is a follow-up to #1937. The patch api doesn't accept an empty slice for `identifiersUri` and therefore blows up in the case that a single cluster is linked to an AAD app, the cluster is deleted and the cluster is attempted to be unlinked from the AAD app.  This PR fixes that problem.

```release-note
NONE
```

/cc @mjudeikis @kwoodson 
