### PR TITLE
Fixes failure to cat yum_updateinfo_list_security log in make vmimage-validate

### DIFF
--- a/hack/vmimage-validate.sh
+++ b/hack/vmimage-validate.sh
@@ -44,7 +44,7 @@ fi
 
 if [ -s "${ARTIFACTS:-/tmp}/yum_updateinfo_list_security" ]; then
   >&2 echo "Found pending security updates:"
-  >&2 cat /tmp/yum_updateinfo_list_security
+  >&2 cat "${ARTIFACTS:-/tmp}/yum_updateinfo_list_security"
   exit 1
 fi
 PHASE=build_complete


### PR DESCRIPTION
This is the reason why `periodic-ci-azure-vmimage-validate-osa311-latest` job currently fails (see https://github.com/openshift/openshift-azure/issues/1961#issuecomment-533894065).

Once the PR merged, the CI should pass sucessfuly if there are no security updates. If there are pending security updates, it will be failing and priting output of `yum updateinfo list security -q` into stderr. For example:

```
RHSA-2019:2829 Important/Sec. kernel-3.10.0-1062.1.2.el7.x86_64
RHSA-2019:2829 Important/Sec. python-perf-3.10.0-1062.1.2.el7.x86_64
```

```release-note
NONE
```
