### PR TITLE
Improves make vmimage-validate locally

### DIFF
--- a/pkg/vmimage/ssh.go
+++ b/pkg/vmimage/ssh.go
@@ -49,7 +49,7 @@ func (builder *Builder) scp(files []string) error {
 		}
 
 		builder.Log.Infof("download %s", file)
-		f, err := os.OpenFile(file, os.O_APPEND|os.O_WRONLY|os.O_CREATE, 0600)
+		f, err := os.OpenFile(file, os.O_TRUNC|os.O_WRONLY|os.O_CREATE, 0600)
 		if err != nil {
 			return err
 		}


### PR DESCRIPTION
Currently scap report and yum log files are not being cleaned up between `make vmimage-validate` runs. It's not an issue in CI, because we run jobs in clean environments, but can cause confusion when run locally because the validation will fail even if the image is valid. It happens because the command checks if files contain data or not.

Example scenario:

* You run validation locally and it fails due to pending security updates
* You fix the issue/update vm image
* You run validation locally again: it fails becasue `yum_updateinfo_list_security` log contains data from previous run

```release-note
NONE
```
