### PR TITLE
Improve the validation of setcontainerimage

### DIFF
--- a/test/e2e/specs/fakerp/setcontainerimage.go
+++ b/test/e2e/specs/fakerp/setcontainerimage.go
@@ -91,8 +91,9 @@ var _ = Describe("Change a single image to latest E2E tests [ChangeImage][LongRu
 			Expect(val).To(Equal(after.ScalesetHashes[key]))
 		}
 
-		By("Validating the cluster")
-		errs := sanity.Checker.ValidateCluster(context.Background())
-		Expect(errs).To(BeEmpty())
+		By("Checking that we can still access the console")
+		// Note: wait a bit longer for the console to respond as we are bouncing it (reties=20).
+		err = sanity.Checker.CheckCanAccessConsole(context.Background(), 20)
+		Expect(err).NotTo(HaveOccurred())
 	})
 })


### PR DESCRIPTION
The test changes the image of the console deployment, which should cause
it to restart. we then do "validateCluster" - which is rather excessive, but the most often failure is that console is not available (which should not be suprising).

This PR does the following:
1. make a more focused check
2. wait longer for the console to be available.

```release-note
NONE
```
relates to flake #1438
