### PR TITLE
scale up debug: log the status of the scaleset and the activitylogs

### DIFF
--- a/pkg/util/azureclient/compute/virtualmachinescalesets.go
+++ b/pkg/util/azureclient/compute/virtualmachinescalesets.go
@@ -17,6 +17,7 @@ import (
 // VirtualMachineScaleSetsClient is a minimal interface for azure VirtualMachineScaleSetsClient
 type VirtualMachineScaleSetsClient interface {
 	Get(ctx context.Context, resourceGroupName string, VMScaleSetName string) (result compute.VirtualMachineScaleSet, err error)
+	GetInstanceView(ctx context.Context, resourceGroupName string, VMScaleSetName string) (result compute.VirtualMachineScaleSetInstanceView, err error)
 	VirtualMachineScaleSetsClientAddons
 }
 

--- a/pkg/util/azureclient/fake/compute/virtualmachinescalesets.go
+++ b/pkg/util/azureclient/fake/compute/virtualmachinescalesets.go
@@ -97,6 +97,11 @@ func (s *FakeVirtualMachineScaleSetsClient) Get(ctx context.Context, resourceGro
 	return compute.VirtualMachineScaleSet{}, nil
 }
 
+// GetInstanceView return instance status
+func (s *FakeVirtualMachineScaleSetsClient) GetInstanceView(ctx context.Context, resourceGroupName string, VMScaleSetName string) (result compute.VirtualMachineScaleSetInstanceView, err error) {
+	return compute.VirtualMachineScaleSetInstanceView{}, nil
+}
+
 // List Fakes base method
 func (s *FakeVirtualMachineScaleSetsClient) List(ctx context.Context, resourceGroup string) ([]compute.VirtualMachineScaleSet, error) {
 	s.rp.Calls = append(s.rp.Calls, "VirtualMachineScaleSetsClient:List")

--- a/pkg/util/mocks/mock_azureclient/mock_compute/compute.go
+++ b/pkg/util/mocks/mock_azureclient/mock_compute/compute.go
@@ -161,6 +161,21 @@ func (mr *MockVirtualMachineScaleSetsClientMockRecorder) Get(arg0, arg1, arg2 in
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockVirtualMachineScaleSetsClient)(nil).Get), arg0, arg1, arg2)
 }
 
+// GetInstanceView mocks base method
+func (m *MockVirtualMachineScaleSetsClient) GetInstanceView(arg0 context.Context, arg1, arg2 string) (compute.VirtualMachineScaleSetInstanceView, error) {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetInstanceView", arg0, arg1, arg2)
+	ret0, _ := ret[0].(compute.VirtualMachineScaleSetInstanceView)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetInstanceView indicates an expected call of GetInstanceView
+func (mr *MockVirtualMachineScaleSetsClientMockRecorder) GetInstanceView(arg0, arg1, arg2 interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetInstanceView", reflect.TypeOf((*MockVirtualMachineScaleSetsClient)(nil).GetInstanceView), arg0, arg1, arg2)
+}
+
 // List mocks base method
 func (m *MockVirtualMachineScaleSetsClient) List(arg0 context.Context, arg1 string) ([]compute.VirtualMachineScaleSet, error) {
 	m.ctrl.T.Helper()


### PR DESCRIPTION
Add some diagnostics for the scale up flake: https://github.com/openshift/openshift-azure/issues/1410

```release-note
NONE
```
