### PR TITLE
Updates imports to use specific versions

### DIFF
--- a/hack/setup-management/main.go
+++ b/hack/setup-management/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"io/ioutil"
 
-	"github.com/Azure/azure-sdk-for-go/profiles/latest/network/mgmt/network"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-10-01/network"
 	azresources "github.com/Azure/azure-sdk-for-go/services/resources/mgmt/2018-05-01/resources"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/kelseyhightower/envconfig"

--- a/pkg/util/azureclient/fake/compute/virtualmachinescalesetvms.go
+++ b/pkg/util/azureclient/fake/compute/virtualmachinescalesetvms.go
@@ -4,8 +4,7 @@ import (
 	"context"
 	"fmt"
 
-	"github.com/Azure/azure-sdk-for-go/profiles/latest/compute/mgmt/compute"
-	azcompute "github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
+	"github.com/Azure/azure-sdk-for-go/services/compute/mgmt/2018-10-01/compute"
 	"github.com/Azure/go-autorest/autorest/to"
 	"github.com/sirupsen/logrus"
 )
@@ -13,8 +12,8 @@ import (
 type ComputeRP struct {
 	Log   *logrus.Entry
 	Calls []string
-	Vms   map[string][]azcompute.VirtualMachineScaleSetVM
-	Ssc   []azcompute.VirtualMachineScaleSet
+	Vms   map[string][]compute.VirtualMachineScaleSetVM
+	Ssc   []compute.VirtualMachineScaleSet
 }
 
 type FakeVirtualMachineScaleSetVMsClient struct {
@@ -51,7 +50,7 @@ func (v *FakeVirtualMachineScaleSetVMsClient) Delete(ctx context.Context, resour
 }
 
 // List Fakes base method
-func (v *FakeVirtualMachineScaleSetVMsClient) List(ctx context.Context, resourceGroupName, VMScaleSetName, filter, selectParameter, expand string) ([]azcompute.VirtualMachineScaleSetVM, error) {
+func (v *FakeVirtualMachineScaleSetVMsClient) List(ctx context.Context, resourceGroupName, VMScaleSetName, filter, selectParameter, expand string) ([]compute.VirtualMachineScaleSetVM, error) {
 	v.rp.Calls = append(v.rp.Calls, "VirtualMachineScaleSetVMsClient:List:"+VMScaleSetName)
 	return v.rp.Vms[VMScaleSetName], nil
 }
@@ -79,7 +78,7 @@ func (v *FakeVirtualMachineScaleSetVMsClient) Restart(ctx context.Context, resou
 }
 
 // RunCommand Fakes base method
-func (v *FakeVirtualMachineScaleSetVMsClient) RunCommand(ctx context.Context, resourceGroupName string, VMScaleSetName string, instanceID string, parameters azcompute.RunCommandInput) error {
+func (v *FakeVirtualMachineScaleSetVMsClient) RunCommand(ctx context.Context, resourceGroupName string, VMScaleSetName string, instanceID string, parameters compute.RunCommandInput) error {
 	v.rp.Calls = append(v.rp.Calls, "VirtualMachineScaleSetVMsClient:RunCommand:"+VMScaleSetName+":"+instanceID)
 	return nil
 }

--- a/pkg/util/azureclient/network/privatelink/privateendpoint.go
+++ b/pkg/util/azureclient/network/privatelink/privateendpoint.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/Azure/azure-sdk-for-go/profiles/latest/network/mgmt/network"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-10-01/network"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
 )

--- a/pkg/util/azureclient/network/privatelink/privatelinkservice.go
+++ b/pkg/util/azureclient/network/privatelink/privatelinkservice.go
@@ -4,7 +4,7 @@ import (
 	"context"
 	"net/http"
 
-	"github.com/Azure/azure-sdk-for-go/profiles/latest/network/mgmt/network"
+	"github.com/Azure/azure-sdk-for-go/services/network/mgmt/2018-10-01/network"
 	"github.com/Azure/go-autorest/autorest"
 	"github.com/Azure/go-autorest/autorest/azure"
 )


### PR DESCRIPTION
Let's use explicit versions in our imports instead of `latest` alias. It will make SDK upgrades more predictable.

```release-note
NONE
```
