### PR TITLE
Pass the privateEndpoint to the customer using FQDN and PublicHostname

### DIFF
--- a/pkg/api/2019-10-27-preview/converterfrominternal.go
+++ b/pkg/api/2019-10-27-preview/converterfrominternal.go
@@ -35,7 +35,10 @@ func FromInternal(cs *api.OpenShiftManagedCluster) *OpenShiftManagedCluster {
 		PublicHostname:    &cs.Properties.PublicHostname,
 		FQDN:              &cs.Properties.FQDN,
 	}
-
+	if cs.Properties.PrivateAPIServer {
+		oc.Properties.FQDN = cs.Properties.NetworkProfile.PrivateEndpoint
+		oc.Properties.PublicHostname = cs.Properties.NetworkProfile.PrivateEndpoint
+	}
 	oc.Properties.NetworkProfile = &NetworkProfile{
 		VnetID:               &cs.Properties.NetworkProfile.VnetID,
 		VnetCIDR:             &cs.Properties.NetworkProfile.VnetCIDR,


### PR DESCRIPTION
```release-note
When using private cluster, the API server's IP address can be obtained from the FQDN and PublicHostname fields.
```

