### PR TITLE
Fixes cluster deletion via cmd/createorupdate/createorupdate.go

### DIFF
--- a/cmd/createorupdate/createorupdate.go
+++ b/cmd/createorupdate/createorupdate.go
@@ -235,6 +235,7 @@ func main() {
 
 	if isDelete {
 		client.Delete(ctx)
+		return
 	}
 
 	if *restoreFromBlob != "" {


### PR DESCRIPTION
It seems like cluster deletion via `cmd/createorupdate/createorupdate.go` is currently broken. After deletion, the comand attempts to create a cluster again. For example, `make vmimage` fails on cleanup because cluster creation is happening in a non-existing resource group:

```
INFO[2019-10-17T13:23:02+01:00] deleting cluster
DEBU[2019-10-17T13:23:02+01:00]pkg/fakerp/middleware.go:16 pkg/fakerp.(*Server).logger.func1() starting: DELETE /subscriptions/225e02bc-43d0-43d1-a01a-17e584a4ef69/resourceGroups/mradchuk-tests-1/providers/Microsoft.ContainerService/openShiftManagedClusters/mradchuk-tests-1?api-version=2019-10-27-preview
INFO[2019-10-17T13:23:02+01:00]pkg/fakerp/client/config.go:68 pkg/fakerp/client.newConfig() using region eastus
INFO[2019-10-17T13:23:02+01:00]pkg/fakerp/client/config.go:72 pkg/fakerp/client.newConfig() using management resource group management-eastus
DEBU[2019-10-17T13:23:04+01:00]pkg/fakerp/network.go:52 pkg/fakerp.getPrivateEndpointIP() PE IP Address 172.30.9.4
INFO[2019-10-17T13:23:04+01:00]pkg/fakerp/customer_handlers.go:19 pkg/fakerp.(*Server).handleDelete() creating clients
INFO[2019-10-17T13:23:04+01:00]pkg/fakerp/customer_handlers.go:26 pkg/fakerp.(*Server).handleDelete() deleting service principals
INFO[2019-10-17T13:23:05+01:00]pkg/fakerp/customer_handlers.go:33 pkg/fakerp.(*Server).handleDelete() deleting dns records
DEBU[2019-10-17T13:23:05+01:00]pkg/fakerp/dns.go:142 pkg/fakerp.(*dnsManager).deleteDns() deleting apps dns zone "apps.mradchuk-tests-1.osadev.cloud"
DEBU[2019-10-17T13:23:05+01:00]pkg/fakerp/dns.go:159 pkg/fakerp.(*dnsManager).deleteZone() deleting NS record set "apps" in parent dns zone "mradchuk-tests-1.osadev.cloud"
DEBU[2019-10-17T13:23:11+01:00]pkg/fakerp/dns.go:147 pkg/fakerp.(*dnsManager).deleteDns() deleting cluster root dns zone "mradchuk-tests-1.osadev.cloud"
DEBU[2019-10-17T13:23:11+01:00]pkg/fakerp/dns.go:159 pkg/fakerp.(*dnsManager).deleteZone() deleting NS record set "mradchuk-tests-1" in parent dns zone "osadev.cloud"
DEBU[2019-10-17T13:23:16+01:00]pkg/fakerp/dns.go:152 pkg/fakerp.(*dnsManager).deleteDns() deleting NS record set "mradchuk-tests-1" in global root dns zone "osadev.cloud"
INFO[2019-10-17T13:23:16+01:00]pkg/fakerp/customer_handlers.go:40 pkg/fakerp.(*Server).handleDelete() delete pe resources
INFO[2019-10-17T13:23:17+01:00]pkg/fakerp/customer_handlers.go:47 pkg/fakerp.(*Server).handleDelete() deleting resource group
DEBU[2019-10-17T13:32:11+01:00]pkg/fakerp/middleware.go:18 pkg/fakerp.(*Server).logger.func1() ending:   DELETE /subscriptions/225e02bc-43d0-43d1-a01a-17e584a4ef69/resourceGroups/mradchuk-tests-1/providers/Microsoft.ContainerService/openShiftManagedClusters/mradchuk-tests-1?api-version=2019-10-27-preview
INFO[2019-10-17T13:32:11+01:00] waiting for cluster deletion
INFO[2019-10-17T13:32:11+01:00] deleted cluster
INFO[2019-10-17T13:32:12+01:00] unlinked cluster mradchuk-tests-1 from aad object id d595b672-4868-4a2e-a97a-00b03e329e57
INFO[2019-10-17T13:32:12+01:00] create()
INFO[2019-10-17T13:32:12+01:00] creating/updating cluster
DEBU[2019-10-17T13:32:12+01:00]pkg/fakerp/middleware.go:16 pkg/fakerp.(*Server).logger.func1() starting: PUT /subscriptions/225e02bc-43d0-43d1-a01a-17e584a4ef69/resourceGroups/mradchuk-tests-1/providers/Microsoft.ContainerService/openShiftManagedClusters/mradchuk-tests-1?api-version=2019-10-27-preview
INFO[2019-10-17T13:32:12+01:00]pkg/fakerp/customer_handlers.go:76 pkg/fakerp.(*Server).handlePut() read request and convert to internal
INFO[2019-10-17T13:32:12+01:00]pkg/fakerp/client/config.go:68 pkg/fakerp/client.newConfig() using region westeurope
INFO[2019-10-17T13:32:12+01:00]pkg/fakerp/client/config.go:72 pkg/fakerp/client.newConfig() using management resource group management-westeurope
INFO[2019-10-17T13:32:12+01:00]pkg/fakerp/fakerp.go:184 pkg/fakerp.createOrUpdateWrapper() enrich
INFO[2019-10-17T13:32:12+01:00]pkg/fakerp/fakerp.go:203 pkg/fakerp.createOrUpdateWrapper() setting up service principals
DEBU[2019-10-17T13:32:12+01:00]pkg/fakerp/aad.go:66 pkg/fakerp.(*aadManager).ensureApp() create aad app auto-1571315532-mradchuk-tests-1-master
DEBU[2019-10-17T13:32:23+01:00]pkg/fakerp/util.go:24 pkg/fakerp.(*Server).badRequest() 400 Bad Request: Failed to apply request: authorization.RoleAssignmentsClient#Create: Failure responding to request: StatusCode=404 -- Original Error: autorest/azure: Service returned an error. Status=404 Code="ResourceGroupNotFound" Message="Resource group 'mradchuk-tests-1' could not be found."
DEBU[2019-10-17T13:32:23+01:00]pkg/fakerp/middleware.go:18 pkg/fakerp.(*Server).logger.func1() ending:   PUT /subscriptions/225e02bc-43d0-43d1-a01a-17e584a4ef69/resourceGroups/mradchuk-tests-1/providers/Microsoft.ContainerService/openShiftManagedClusters/mradchuk-tests-1?api-version=2019-10-27-preview
FATA[2019-10-17T13:32:23+01:00] containerservice.OpenShiftManagedClustersClient#CreateOrUpdate: Failure sending request: StatusCode=0 -- Original Error: autorest/azure: error response cannot be parsed: "400 Bad Request: Failed to apply request: authorization.RoleAssignmentsClient#Create: Failure responding to request: StatusCode=404 -- Original Error: autorest/azure: Service returned an error. Status=404 Code=\"ResourceGroupNotFound\" Message=\"Resource group 'mradchuk-tests-1' could not be found.\"\n" error: json: cannot unmarshal number into Go value of type azure.RequestError
exit status 1
make[1]: *** [delete] Error 1
```

```release-note
NONE
```
