### PR TITLE
return after deployment errors

### DIFF
--- a/pkg/fakerp/fakerp.go
+++ b/pkg/fakerp/fakerp.go
@@ -102,6 +102,7 @@ func GetDeployer(log *logrus.Entry, cs *api.OpenShiftManagedCluster, conf *clien
 		if err != nil {
 			log.Warnf("deployment failed: %#v", err)
 			debugDeployerError(ctx, log, cs, testConfig)
+			return nil, err
 		}
 
 		// we check if PE exists and get IP
@@ -134,6 +135,7 @@ func GetDeployer(log *logrus.Entry, cs *api.OpenShiftManagedCluster, conf *clien
 				if err != nil {
 					log.Warnf("deployment failed: %#v", err)
 					debugDeployerError(ctx, log, cs, testConfig)
+					return nil, err
 				}
 
 				log.Info("applying PE deployment")
@@ -157,6 +159,7 @@ func GetDeployer(log *logrus.Entry, cs *api.OpenShiftManagedCluster, conf *clien
 				if err != nil {
 					log.Warnf("deployment failed: %#v", err)
 					debugDeployerError(ctx, log, cs, testConfig)
+					return nil, err
 				}
 			}
 			if cs.Properties.PrivateAPIServer {


### PR DESCRIPTION
```release-note
NONE
```
With the roundtripper PR we seemed to have lost the return after a failed deploy.
