### PR TITLE
Make sure both managementSubnetCIDR and PrivateAPIServer are provided together

### DIFF
--- a/pkg/api/validate/validators.go
+++ b/pkg/api/validate/validators.go
@@ -71,7 +71,7 @@ func validateProperties(p *api.Properties, location string, externalOnly bool) (
 		}
 	}
 
-	errs = append(errs, validateNetworkProfile("properties.networkProfile", &p.NetworkProfile)...)
+	errs = append(errs, validateNetworkProfile("properties.networkProfile", &p.NetworkProfile, p.PrivateAPIServer)...)
 
 	errs = append(errs, validateRouterProfiles("properties.routerProfiles", p.RouterProfiles, location, externalOnly)...)
 
@@ -94,7 +94,7 @@ func validateProperties(p *api.Properties, location string, externalOnly bool) (
 	return
 }
 
-func validateNetworkProfile(path string, np *api.NetworkProfile) (errs []error) {
+func validateNetworkProfile(path string, np *api.NetworkProfile, privateAPIServer bool) (errs []error) {
 	if np == nil {
 		errs = append(errs, fmt.Errorf("%s cannot be nil", path))
 		return
@@ -105,7 +105,9 @@ func validateNetworkProfile(path string, np *api.NetworkProfile) (errs []error) 
 		return
 	}
 
-	// We dont enforce ManagementSubnetCIDR, but if it set - require valid value
+	if privateAPIServer && np.ManagementSubnetCIDR == nil {
+		errs = append(errs, fmt.Errorf("%s.managementSubnetCIDR cannot be nil with privateAPIServer enabled", path))
+	}
 	if np.ManagementSubnetCIDR != nil {
 		if !isValidIPV4CIDR(*np.ManagementSubnetCIDR) {
 			errs = append(errs, fmt.Errorf("invalid %s.managementSubnetCIDR %q", path, *np.ManagementSubnetCIDR))

--- a/pkg/api/validate/validators_test.go
+++ b/pkg/api/validate/validators_test.go
@@ -279,6 +279,13 @@ func TestValidate(t *testing.T) {
 			},
 			expectedErrs: []error{errors.New(`invalid properties.networkProfile.managementSubnetCIDR "foo"`)},
 		},
+		"network profile managementSubnetCIDR - nil - not allowed for private cluster": {
+			f: func(oc *api.OpenShiftManagedCluster) {
+				oc.Properties.NetworkProfile.ManagementSubnetCIDR = nil
+				oc.Properties.PrivateAPIServer = true
+			},
+			expectedErrs: []error{errors.New(`properties.networkProfile.managementSubnetCIDR cannot be nil with privateAPIServer enabled`)},
+		},
 		"network profile managementSubnetCIDR - nil - allowed": {
 			f: func(oc *api.OpenShiftManagedCluster) {
 				oc.Properties.NetworkProfile.ManagementSubnetCIDR = nil

--- a/pkg/fakerp/fakerp.go
+++ b/pkg/fakerp/fakerp.go
@@ -187,14 +187,6 @@ func createOrUpdateWrapper(ctx context.Context, p api.Plugin, log *logrus.Entry,
 		return nil, err
 	}
 
-	// TODO: Remove this when APIVersion support lands into fakeRP
-	// and we have more consistent way to set it
-	// Currently this code part decides if we should deploy
-	// PrivateLinkService and and internal-LB
-	if cs.Properties.NetworkProfile.ManagementSubnetCIDR != nil {
-		cs.Properties.PrivateAPIServer = true
-	}
-
 	clients, err := newClients(ctx, log, cs, testConfig, conf)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
```release-note
NONE
```
Improvement in validation of the above two fields