### PR TITLE
Allow validation of an existing built image

### DIFF
--- a/hack/vmimage.sh
+++ b/hack/vmimage.sh
@@ -21,12 +21,15 @@ else
 fi
 
 export IMAGE_RESOURCEGROUP="${IMAGE_RESOURCEGROUP:-images}"
-export IMAGE_RESOURCENAME="${IMAGE_RESOURCENAME:-rhel7-3.11-$(TZ=Etc/UTC date +%Y%m%d%H%M)}"
 export IMAGE_STORAGEACCOUNT="${IMAGE_STORAGEACCOUNT:-openshiftimages}"
 
 [[ -e /var/run/secrets/kubernetes.io ]] || go generate ./...
-PHASE=image_build
-go run -ldflags "-X main.gitCommit=$GITCOMMIT" ./cmd/vmimage -imageResourceGroup "$IMAGE_RESOURCEGROUP" -image "$IMAGE_RESOURCENAME" -imageStorageAccount "$IMAGE_STORAGEACCOUNT"
+
+if [[ -z "$IMAGE_RESOURCENAME" ]]; then
+  export IMAGE_RESOURCENAME="rhel7-3.11-$(TZ=Etc/UTC date +%Y%m%d%H%M)"
+  PHASE=image_build
+  go run -ldflags "-X main.gitCommit=$GITCOMMIT" ./cmd/vmimage -imageResourceGroup "$IMAGE_RESOURCEGROUP" -image "$IMAGE_RESOURCENAME" -imageStorageAccount "$IMAGE_STORAGEACCOUNT"
+fi
 
 if [[ -z "$RESOURCEGROUP" ]]; then
   export RESOURCEGROUP="${IMAGE_RESOURCENAME//./}-e2e"


### PR DESCRIPTION
```release-note
NONE
```

This lets you export `IMAGE_RESOURCENAME` so you don't need to build a new image if you've done something silly that messed up the test cluster create or e2e, or if your e2e flakes.

Note: you may also need to set `AZURE_REGIONS` to ensure validation happens in the same region the test image was built.