### PR TITLE
[WIP] Validate that VM and container versions of OCP match in pluginconfig

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,6 +72,7 @@ verify:
 	./hack/verify/validate-codecov.sh
 	go run ./hack/validate-imports/validate-imports.go cmd hack pkg test
 	./hack/verify/validate-sec.sh
+	./hack/verify/validate-ocp-version.py
 
 testinsights:
 	go build -ldflags ${LDFLAGS} ./cmd/$@

--- a/hack/verify/validate-ocp-version.py
+++ b/hack/verify/validate-ocp-version.py
@@ -1,0 +1,25 @@
+#!/usr/bin/python3
+
+import re
+import sys
+import yaml
+
+PLUGIN_CONFIG = 'pluginconfig/pluginconfig-311.yaml'
+
+
+def main():
+    config = yaml.load(open(PLUGIN_CONFIG, 'r'))
+    tag_re = re.compile(r':v3\.11\.(\d+)')
+
+    for version in config['versions'].values():
+        vm_version = version['imageVersion']
+        vm_ocp_version = vm_version.split('.')[1]
+        for container_version in version['images'].values():
+            tag = tag_re.search(container_version)
+            if 'registry.access.redhat.com/openshift3' in container_version and tag and tag[1] != vm_ocp_version:
+                print('VM version {vm} and container tag {ct} do not match'.format(vm=vm_version, ct=container_version))
+                sys.exit(1)
+
+
+if __name__ == '__main__':
+    main()


### PR DESCRIPTION
```release-note
NONE
```

Addresses [AZURE-427](https://jira.coreos.com/browse/AZURE-427).

To test: try changing a container or VM image version in the pluginconfig to not match and see what happens :)