### PR TITLE
Pin image location in vmimage test

### DIFF
--- a/hack/vmimage-validate.sh
+++ b/hack/vmimage-validate.sh
@@ -15,6 +15,8 @@ PHASE=image_validation
 BUILD_RESOURCE_GROUP="vmimage-$(date +%Y%m%d%H%M)"
 IMAGE_RESOURCEGROUP="${IMAGE_RESOURCEGROUP:-images}"
 IMAGE_STORAGEACCOUNT="${IMAGE_STORAGEACCOUNT:-openshiftimages}"
+AZURE_REGION="${AZURE_REGION:-eastus}"
+AZURE_REGIONS="${AZURE_REGION}"
 
 if [ -z "$IMAGE_RESOURCENAME" ] ;
 then
@@ -27,7 +29,7 @@ then
   CMD_VMIMAGE_ARGS="-imageSku $IMAGE_SKU -imageVersion $IMAGE_VERSION"
 else
   echo "Validating: ${IMAGE_RESOURCENAME} image in ${IMAGE_RESOURCEGROUP} resource group"
-  CMD_VMIMAGE_ARGS="-imageResourceGroup ${IMAGE_RESOURCEGROUP} -image ${IMAGE_RESOURCENAME} -imageStorageAccount ${IMAGE_STORAGEACCOUNT}"
+  CMD_VMIMAGE_ARGS="-imageResourceGroup ${IMAGE_RESOURCEGROUP} -image ${IMAGE_RESOURCENAME} -imageStorageAccount ${IMAGE_STORAGEACCOUNT} -location ${AZURE_REGION}"
 fi
 
 

--- a/hack/vmimage.sh
+++ b/hack/vmimage.sh
@@ -23,10 +23,12 @@ fi
 export IMAGE_RESOURCEGROUP="${IMAGE_RESOURCEGROUP:-images}"
 export IMAGE_RESOURCENAME="${IMAGE_RESOURCENAME:-rhel7-3.11-$(TZ=Etc/UTC date +%Y%m%d%H%M)}"
 export IMAGE_STORAGEACCOUNT="${IMAGE_STORAGEACCOUNT:-openshiftimages}"
+export AZURE_REGION="${AZURE_REGION:-eastus}"
+export AZURE_REGIONS="${AZURE_REGION}"
 
 [[ -e /var/run/secrets/kubernetes.io ]] || go generate ./...
 PHASE=image_build
-go run -ldflags "-X main.gitCommit=$GITCOMMIT" ./cmd/vmimage -imageResourceGroup "$IMAGE_RESOURCEGROUP" -image "$IMAGE_RESOURCENAME" -imageStorageAccount "$IMAGE_STORAGEACCOUNT"
+go run -ldflags "-X main.gitCommit=$GITCOMMIT" ./cmd/vmimage -imageResourceGroup "$IMAGE_RESOURCEGROUP" -image "$IMAGE_RESOURCENAME" -imageStorageAccount "$IMAGE_STORAGEACCOUNT" -location "$AZURE_REGION"
 
 if [[ -z "$RESOURCEGROUP" ]]; then
   export RESOURCEGROUP="${IMAGE_RESOURCENAME//./}-e2e"


### PR DESCRIPTION
```release-note 
NONE
```

Frequent failures of [periodic vmimage build test](https://prow.svc.ci.openshift.org/job-history/origin-ci-test/logs/periodic-ci-azure-vmimage) are due to mismatch between the region where image is stored and region where it is attempted to be used for validation. This PR sets `AZURE_REGION` and `AZURE_REGIONS` env variables to solve this issue.

In this test image is always created in `eastus`: https://github.com/openshift/openshift-azure/blob/e4245e59119cab8cfa8458c3f7557368ee62a525/cmd/vmimage/vmimage.go#L29. We don't pass location argument when running this command so the default value is used

After image is built, `vmimage.sh` calls `create.sh`, which invokes fakerp: https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/logs/periodic-ci-azure-vmimage/189#1:build-log.txt%3A4942, e.g:

```sh
./hack/create.sh ci-vmimage-ufxlut
time="2019-10-27T23:18:10Z" level=info msg="starting the fake resource provider" func="main.main()" file="cmd/fakerp/main.go:25"
time="2019-10-27T23:18:10Z" level=info msg="validating external plugin api data models" func="pkg/plugin.(*plugin).ValidatePluginTemplate()" file="pkg/plugin/plugin.go:96"
time="2019-10-27T23:18:10Z" level=info msg="starting server on localhost:8080" func="pkg/fakerp.(*Server).Run()" file="pkg/fakerp/server.go:78"
time="2019-10-27T23:18:12Z" level=info msg="using region westeurope"
```

this log shows a region different from `eastus` is being used.

It is important to make sure that region we want to use for image test is part of the `AZURE_REGIONS` in order to avoid failing on this check: https://github.com/openshift/openshift-azure/blob/e4245e59119cab8cfa8458c3f7557368ee62a525/pkg/fakerp/client/config.go#L64
Right now `eastus` *is* part of the array in ci, but setting this value explicitly will allow us to switch region easier if we need to do so for whatever reason. Maybe it is a good idea to set them as env variables in job manifest: https://github.com/openshift/release/blob/be7107dac580d0a89daff86784f836da01f78de8/ci-operator/jobs/openshift/openshift-azure/openshift-openshift-azure-master-periodics.yaml#L147-L183

`image-validate` is another periodic job that is affected by this PR. It is currently implicitly using the right region as a default value or from `AZURE_REGION` if it is set.
https://prow.svc.ci.openshift.org/view/gcs/origin-ci-test/logs/periodic-ci-azure-vmimage-validate-osa311-latest/35#1:build-log.txt%3A29

related issues: https://github.com/openshift/openshift-azure/issues/2041
https://github.com/openshift/openshift-azure/issues/2033

/cc @ehashman 