### PR TITLE
Remove PeerVnetID from 2019-10-27-preview API

### DIFF
--- a/pkg/api/2019-10-27-preview/converterfrominternal.go
+++ b/pkg/api/2019-10-27-preview/converterfrominternal.go
@@ -40,7 +40,6 @@ func FromInternal(cs *api.OpenShiftManagedCluster) *OpenShiftManagedCluster {
 		VnetID:               &cs.Properties.NetworkProfile.VnetID,
 		VnetCIDR:             &cs.Properties.NetworkProfile.VnetCIDR,
 		ManagementSubnetCIDR: cs.Properties.NetworkProfile.ManagementSubnetCIDR,
-		PeerVnetID:           cs.Properties.NetworkProfile.PeerVnetID,
 	}
 	oc.Properties.MonitorProfile = &MonitorProfile{
 		Enabled:             &cs.Properties.MonitorProfile.Enabled,

--- a/pkg/api/2019-10-27-preview/convertertointernal.go
+++ b/pkg/api/2019-10-27-preview/convertertointernal.go
@@ -103,7 +103,6 @@ func mergeProperties(oc *OpenShiftManagedCluster, cs *api.OpenShiftManagedCluste
 		if oc.Properties.NetworkProfile.VnetCIDR != nil {
 			cs.Properties.NetworkProfile.VnetCIDR = *oc.Properties.NetworkProfile.VnetCIDR
 		}
-		cs.Properties.NetworkProfile.PeerVnetID = oc.Properties.NetworkProfile.PeerVnetID
 		// reverse conversion check. If internal fiels is not set - only than we set it
 		if cs.Properties.NetworkProfile.ManagementSubnetCIDR == nil {
 			cs.Properties.NetworkProfile.ManagementSubnetCIDR = oc.Properties.NetworkProfile.ManagementSubnetCIDR

--- a/pkg/api/2019-10-27-preview/types.go
+++ b/pkg/api/2019-10-27-preview/types.go
@@ -103,14 +103,6 @@ type NetworkProfile struct {
 
 	// VnetID (out): the ID of the Vnet created for the OSA cluster
 	VnetID *string `json:"vnetId,omitempty"`
-
-	// PeerVnetID (in, optional): ID of a Vnet with which the OSA cluster Vnet should be peered.
-	// If specified, this should match
-	// `^/subscriptions/[^/]+
-	//   /resourceGroups/[^/]+
-	//   /providers/Microsoft.Network
-	//   /virtualNetworks/[^/]+$`
-	PeerVnetID *string `json:"peerVnetId,omitempty"`
 }
 
 // RouterProfile represents an OpenShift router.

--- a/pkg/api/2019-10-27-preview/types_test.go
+++ b/pkg/api/2019-10-27-preview/types_test.go
@@ -30,8 +30,7 @@ var marshalled = []byte(`{
 		"networkProfile": {
 			"vnetCidr": "Properties.NetworkProfile.VnetCIDR",
 			"managementSubnetCidr": "Properties.NetworkProfile.ManagementSubnetCIDR",
-			"vnetId": "Properties.NetworkProfile.VnetID",
-			"peerVnetId": "Properties.NetworkProfile.PeerVnetID"
+			"vnetId": "Properties.NetworkProfile.VnetID"
 		},
 		"routerProfiles": [
 			{
@@ -211,6 +210,7 @@ func TestAPIParity(t *testing.T) {
 
 	notInExternal := []*regexp.Regexp{
 		regexp.MustCompile(`^\.Properties\.NetworkProfile\.PrivateEndpoint$`),
+		regexp.MustCompile(`^\.Properties\.NetworkProfile\.PeerVnetID$`),
 		regexp.MustCompile(`^\.Properties\.NetworkProfile\.ManagementSubnetID$`),
 		regexp.MustCompile(`^\.Properties\.NetworkProfile\.InternalLoadBalancerFrontendIPID$`),
 		regexp.MustCompile(`^\.Properties\.MasterServicePrincipalProfile`),


### PR DESCRIPTION
```release-note
Remove  PeerVnetID from 2019-10-27-preview API
```

Note microsoft will store the api that a cluster is created with and not allow a cluster to be updated
with an older version.
