### PR TITLE
The init() in cmd/proxy is causing unit tests to fail

### DIFF
--- a/cmd/proxy/main.go
+++ b/cmd/proxy/main.go
@@ -28,7 +28,7 @@ var (
 	log *logrus.Entry
 )
 
-func init() {
+func initGlobals() {
 	flag.Parse()
 	logger := logrus.New()
 	logger.Formatter = &logrus.TextFormatter{FullTimestamp: true}
@@ -138,6 +138,7 @@ func handleTunneling(w http.ResponseWriter, r *http.Request) {
 }
 
 func main() {
+	initGlobals()
 	err := run()
 	if err != nil {
 		panic(err)


### PR DESCRIPTION
```release-note
NONE
```

Firstly, I have updated to Fedora 31 and have 
```
go version
go1.13.3 linux/amd64
```

The error I get is:
```
flag provided but not defined: -test.testlogfile
Usage of /tmp/go-build178558260/b625/proxy.test:
  -cacert string
    	path to ca file (default "secrets/proxy-ca.pem")
  -cert string
    	path to pem file (default "secrets/proxy-server.pem")
  -key string
    	path to key file (default "secrets/proxy-server.key")
  -subnet string
    	allowed proxy connect subnet (default "172.30.10.0/24")
FAIL	github.com/openshift/openshift-azure/cmd/proxy	0.032s
```