### PR TITLE
Add ImagePullSecret back into older worker cs

### DIFF
--- a/pkg/startup/startup.go
+++ b/pkg/startup/startup.go
@@ -25,6 +25,7 @@ import (
 type Interface interface {
 	WriteFiles(ctx context.Context) error
 	Hash(role api.AgentPoolProfileRole) ([]byte, error)
+	GetWorkerCs() *api.OpenShiftManagedCluster
 }
 
 // New returns a new startup Interface according to the cluster version running

--- a/pkg/startup/v10/startup.go
+++ b/pkg/startup/v10/startup.go
@@ -39,6 +39,56 @@ func New(log *logrus.Entry, cs *api.OpenShiftManagedCluster, testConfig api.Test
 	return &startup{log: log, cs: cs, testConfig: testConfig}
 }
 
+func (s *startup) GetWorkerCs() *api.OpenShiftManagedCluster {
+	workerCS := &api.OpenShiftManagedCluster{
+		ID:   s.cs.ID,
+		Name: s.cs.Name,
+		Properties: api.Properties{
+			WorkerServicePrincipalProfile: api.ServicePrincipalProfile{
+				ClientID: s.cs.Properties.WorkerServicePrincipalProfile.ClientID,
+				Secret:   s.cs.Properties.WorkerServicePrincipalProfile.Secret,
+			},
+			AzProfile: api.AzProfile{
+				TenantID:       s.cs.Properties.AzProfile.TenantID,
+				SubscriptionID: s.cs.Properties.AzProfile.SubscriptionID,
+				ResourceGroup:  s.cs.Properties.AzProfile.ResourceGroup,
+			},
+		},
+		Location: s.cs.Location,
+		Config: api.Config{
+			PluginVersion: s.cs.Config.PluginVersion,
+			ComponentLogLevel: api.ComponentLogLevel{
+				Node: s.cs.Config.ComponentLogLevel.Node,
+			},
+			Certificates: api.CertificateConfig{
+				Ca: api.CertKeyPair{
+					Cert: s.cs.Config.Certificates.Ca.Cert,
+				},
+				GenevaLogging: s.cs.Config.Certificates.GenevaLogging,
+				NodeBootstrap: s.cs.Config.Certificates.NodeBootstrap,
+			},
+			Images: api.ImageConfig{
+				Format: s.cs.Config.Images.Format,
+				Node:   s.cs.Config.Images.Node,
+			},
+			NodeBootstrapKubeconfig:              s.cs.Config.NodeBootstrapKubeconfig,
+			SDNKubeconfig:                        s.cs.Config.SDNKubeconfig,
+			GenevaLoggingAccount:                 s.cs.Config.GenevaLoggingAccount,
+			GenevaLoggingNamespace:               s.cs.Config.GenevaLoggingNamespace,
+			GenevaLoggingControlPlaneEnvironment: s.cs.Config.GenevaLoggingControlPlaneEnvironment,
+			GenevaLoggingControlPlaneAccount:     s.cs.Config.GenevaLoggingControlPlaneAccount,
+			GenevaLoggingControlPlaneRegion:      s.cs.Config.GenevaLoggingControlPlaneRegion,
+		},
+	}
+	for _, app := range s.cs.Properties.AgentPoolProfiles {
+		workerCS.Properties.AgentPoolProfiles = append(workerCS.Properties.AgentPoolProfiles, api.AgentPoolProfile{
+			Role:   app.Role,
+			VMSize: app.VMSize,
+		})
+	}
+	return workerCS
+}
+
 func (s *startup) WriteFiles(ctx context.Context) error {
 	hostname, err := os.Hostname()
 	if err != nil {

--- a/pkg/startup/v11/startup.go
+++ b/pkg/startup/v11/startup.go
@@ -39,6 +39,56 @@ func New(log *logrus.Entry, cs *api.OpenShiftManagedCluster, testConfig api.Test
 	return &startup{log: log, cs: cs, testConfig: testConfig}
 }
 
+func (s *startup) GetWorkerCs() *api.OpenShiftManagedCluster {
+	workerCS := &api.OpenShiftManagedCluster{
+		ID:   s.cs.ID,
+		Name: s.cs.Name,
+		Properties: api.Properties{
+			WorkerServicePrincipalProfile: api.ServicePrincipalProfile{
+				ClientID: s.cs.Properties.WorkerServicePrincipalProfile.ClientID,
+				Secret:   s.cs.Properties.WorkerServicePrincipalProfile.Secret,
+			},
+			AzProfile: api.AzProfile{
+				TenantID:       s.cs.Properties.AzProfile.TenantID,
+				SubscriptionID: s.cs.Properties.AzProfile.SubscriptionID,
+				ResourceGroup:  s.cs.Properties.AzProfile.ResourceGroup,
+			},
+		},
+		Location: s.cs.Location,
+		Config: api.Config{
+			PluginVersion: s.cs.Config.PluginVersion,
+			ComponentLogLevel: api.ComponentLogLevel{
+				Node: s.cs.Config.ComponentLogLevel.Node,
+			},
+			Certificates: api.CertificateConfig{
+				Ca: api.CertKeyPair{
+					Cert: s.cs.Config.Certificates.Ca.Cert,
+				},
+				GenevaLogging: s.cs.Config.Certificates.GenevaLogging,
+				NodeBootstrap: s.cs.Config.Certificates.NodeBootstrap,
+			},
+			Images: api.ImageConfig{
+				Format: s.cs.Config.Images.Format,
+				Node:   s.cs.Config.Images.Node,
+			},
+			NodeBootstrapKubeconfig:              s.cs.Config.NodeBootstrapKubeconfig,
+			SDNKubeconfig:                        s.cs.Config.SDNKubeconfig,
+			GenevaLoggingAccount:                 s.cs.Config.GenevaLoggingAccount,
+			GenevaLoggingNamespace:               s.cs.Config.GenevaLoggingNamespace,
+			GenevaLoggingControlPlaneEnvironment: s.cs.Config.GenevaLoggingControlPlaneEnvironment,
+			GenevaLoggingControlPlaneAccount:     s.cs.Config.GenevaLoggingControlPlaneAccount,
+			GenevaLoggingControlPlaneRegion:      s.cs.Config.GenevaLoggingControlPlaneRegion,
+		},
+	}
+	for _, app := range s.cs.Properties.AgentPoolProfiles {
+		workerCS.Properties.AgentPoolProfiles = append(workerCS.Properties.AgentPoolProfiles, api.AgentPoolProfile{
+			Role:   app.Role,
+			VMSize: app.VMSize,
+		})
+	}
+	return workerCS
+}
+
 func (s *startup) WriteFiles(ctx context.Context) error {
 	hostname, err := os.Hostname()
 	if err != nil {

--- a/pkg/startup/v12/startup.go
+++ b/pkg/startup/v12/startup.go
@@ -39,6 +39,56 @@ func New(log *logrus.Entry, cs *api.OpenShiftManagedCluster, testConfig api.Test
 	return &startup{log: log, cs: cs, testConfig: testConfig}
 }
 
+func (s *startup) GetWorkerCs() *api.OpenShiftManagedCluster {
+	workerCS := &api.OpenShiftManagedCluster{
+		ID:   s.cs.ID,
+		Name: s.cs.Name,
+		Properties: api.Properties{
+			WorkerServicePrincipalProfile: api.ServicePrincipalProfile{
+				ClientID: s.cs.Properties.WorkerServicePrincipalProfile.ClientID,
+				Secret:   s.cs.Properties.WorkerServicePrincipalProfile.Secret,
+			},
+			AzProfile: api.AzProfile{
+				TenantID:       s.cs.Properties.AzProfile.TenantID,
+				SubscriptionID: s.cs.Properties.AzProfile.SubscriptionID,
+				ResourceGroup:  s.cs.Properties.AzProfile.ResourceGroup,
+			},
+		},
+		Location: s.cs.Location,
+		Config: api.Config{
+			PluginVersion: s.cs.Config.PluginVersion,
+			ComponentLogLevel: api.ComponentLogLevel{
+				Node: s.cs.Config.ComponentLogLevel.Node,
+			},
+			Certificates: api.CertificateConfig{
+				Ca: api.CertKeyPair{
+					Cert: s.cs.Config.Certificates.Ca.Cert,
+				},
+				GenevaLogging: s.cs.Config.Certificates.GenevaLogging,
+				NodeBootstrap: s.cs.Config.Certificates.NodeBootstrap,
+			},
+			Images: api.ImageConfig{
+				Format: s.cs.Config.Images.Format,
+				Node:   s.cs.Config.Images.Node,
+			},
+			NodeBootstrapKubeconfig:              s.cs.Config.NodeBootstrapKubeconfig,
+			SDNKubeconfig:                        s.cs.Config.SDNKubeconfig,
+			GenevaLoggingAccount:                 s.cs.Config.GenevaLoggingAccount,
+			GenevaLoggingNamespace:               s.cs.Config.GenevaLoggingNamespace,
+			GenevaLoggingControlPlaneEnvironment: s.cs.Config.GenevaLoggingControlPlaneEnvironment,
+			GenevaLoggingControlPlaneAccount:     s.cs.Config.GenevaLoggingControlPlaneAccount,
+			GenevaLoggingControlPlaneRegion:      s.cs.Config.GenevaLoggingControlPlaneRegion,
+		},
+	}
+	for _, app := range s.cs.Properties.AgentPoolProfiles {
+		workerCS.Properties.AgentPoolProfiles = append(workerCS.Properties.AgentPoolProfiles, api.AgentPoolProfile{
+			Role:   app.Role,
+			VMSize: app.VMSize,
+		})
+	}
+	return workerCS
+}
+
 func (s *startup) WriteFiles(ctx context.Context) error {
 	hostname, err := os.Hostname()
 	if err != nil {

--- a/pkg/startup/v7/startup.go
+++ b/pkg/startup/v7/startup.go
@@ -38,6 +38,56 @@ type startup struct {
 func New(log *logrus.Entry, cs *api.OpenShiftManagedCluster, testConfig api.TestConfig) *startup {
 	return &startup{log: log, cs: cs, testConfig: testConfig}
 }
+func (s *startup) GetWorkerCs() *api.OpenShiftManagedCluster {
+	workerCS := &api.OpenShiftManagedCluster{
+		ID:   s.cs.ID,
+		Name: s.cs.Name,
+		Properties: api.Properties{
+			WorkerServicePrincipalProfile: api.ServicePrincipalProfile{
+				ClientID: s.cs.Properties.WorkerServicePrincipalProfile.ClientID,
+				Secret:   s.cs.Properties.WorkerServicePrincipalProfile.Secret,
+			},
+			AzProfile: api.AzProfile{
+				TenantID:       s.cs.Properties.AzProfile.TenantID,
+				SubscriptionID: s.cs.Properties.AzProfile.SubscriptionID,
+				ResourceGroup:  s.cs.Properties.AzProfile.ResourceGroup,
+			},
+		},
+		Location: s.cs.Location,
+		Config: api.Config{
+			PluginVersion: s.cs.Config.PluginVersion,
+			ComponentLogLevel: api.ComponentLogLevel{
+				Node: s.cs.Config.ComponentLogLevel.Node,
+			},
+			Certificates: api.CertificateConfig{
+				Ca: api.CertKeyPair{
+					Cert: s.cs.Config.Certificates.Ca.Cert,
+				},
+				GenevaLogging: s.cs.Config.Certificates.GenevaLogging,
+				NodeBootstrap: s.cs.Config.Certificates.NodeBootstrap,
+			},
+			Images: api.ImageConfig{
+				Format:          s.cs.Config.Images.Format,
+				Node:            s.cs.Config.Images.Node,
+				ImagePullSecret: s.cs.Config.Images.ImagePullSecret,
+			},
+			NodeBootstrapKubeconfig:              s.cs.Config.NodeBootstrapKubeconfig,
+			SDNKubeconfig:                        s.cs.Config.SDNKubeconfig,
+			GenevaLoggingAccount:                 s.cs.Config.GenevaLoggingAccount,
+			GenevaLoggingNamespace:               s.cs.Config.GenevaLoggingNamespace,
+			GenevaLoggingControlPlaneEnvironment: s.cs.Config.GenevaLoggingControlPlaneEnvironment,
+			GenevaLoggingControlPlaneAccount:     s.cs.Config.GenevaLoggingControlPlaneAccount,
+			GenevaLoggingControlPlaneRegion:      s.cs.Config.GenevaLoggingControlPlaneRegion,
+		},
+	}
+	for _, app := range s.cs.Properties.AgentPoolProfiles {
+		workerCS.Properties.AgentPoolProfiles = append(workerCS.Properties.AgentPoolProfiles, api.AgentPoolProfile{
+			Role:   app.Role,
+			VMSize: app.VMSize,
+		})
+	}
+	return workerCS
+}
 
 func (s *startup) WriteFiles(ctx context.Context) error {
 	hostname, err := os.Hostname()

--- a/pkg/startup/v71/startup.go
+++ b/pkg/startup/v71/startup.go
@@ -39,6 +39,57 @@ func New(log *logrus.Entry, cs *api.OpenShiftManagedCluster, testConfig api.Test
 	return &startup{log: log, cs: cs, testConfig: testConfig}
 }
 
+func (s *startup) GetWorkerCs() *api.OpenShiftManagedCluster {
+	workerCS := &api.OpenShiftManagedCluster{
+		ID:   s.cs.ID,
+		Name: s.cs.Name,
+		Properties: api.Properties{
+			WorkerServicePrincipalProfile: api.ServicePrincipalProfile{
+				ClientID: s.cs.Properties.WorkerServicePrincipalProfile.ClientID,
+				Secret:   s.cs.Properties.WorkerServicePrincipalProfile.Secret,
+			},
+			AzProfile: api.AzProfile{
+				TenantID:       s.cs.Properties.AzProfile.TenantID,
+				SubscriptionID: s.cs.Properties.AzProfile.SubscriptionID,
+				ResourceGroup:  s.cs.Properties.AzProfile.ResourceGroup,
+			},
+		},
+		Location: s.cs.Location,
+		Config: api.Config{
+			PluginVersion: s.cs.Config.PluginVersion,
+			ComponentLogLevel: api.ComponentLogLevel{
+				Node: s.cs.Config.ComponentLogLevel.Node,
+			},
+			Certificates: api.CertificateConfig{
+				Ca: api.CertKeyPair{
+					Cert: s.cs.Config.Certificates.Ca.Cert,
+				},
+				GenevaLogging: s.cs.Config.Certificates.GenevaLogging,
+				NodeBootstrap: s.cs.Config.Certificates.NodeBootstrap,
+			},
+			Images: api.ImageConfig{
+				Format:          s.cs.Config.Images.Format,
+				Node:            s.cs.Config.Images.Node,
+				ImagePullSecret: s.cs.Config.Images.ImagePullSecret,
+			},
+			NodeBootstrapKubeconfig:              s.cs.Config.NodeBootstrapKubeconfig,
+			SDNKubeconfig:                        s.cs.Config.SDNKubeconfig,
+			GenevaLoggingAccount:                 s.cs.Config.GenevaLoggingAccount,
+			GenevaLoggingNamespace:               s.cs.Config.GenevaLoggingNamespace,
+			GenevaLoggingControlPlaneEnvironment: s.cs.Config.GenevaLoggingControlPlaneEnvironment,
+			GenevaLoggingControlPlaneAccount:     s.cs.Config.GenevaLoggingControlPlaneAccount,
+			GenevaLoggingControlPlaneRegion:      s.cs.Config.GenevaLoggingControlPlaneRegion,
+		},
+	}
+	for _, app := range s.cs.Properties.AgentPoolProfiles {
+		workerCS.Properties.AgentPoolProfiles = append(workerCS.Properties.AgentPoolProfiles, api.AgentPoolProfile{
+			Role:   app.Role,
+			VMSize: app.VMSize,
+		})
+	}
+	return workerCS
+}
+
 func (s *startup) WriteFiles(ctx context.Context) error {
 	hostname, err := os.Hostname()
 	if err != nil {

--- a/pkg/startup/v9/startup.go
+++ b/pkg/startup/v9/startup.go
@@ -38,6 +38,56 @@ type startup struct {
 func New(log *logrus.Entry, cs *api.OpenShiftManagedCluster, testConfig api.TestConfig) *startup {
 	return &startup{log: log, cs: cs, testConfig: testConfig}
 }
+func (s *startup) GetWorkerCs() *api.OpenShiftManagedCluster {
+	workerCS := &api.OpenShiftManagedCluster{
+		ID:   s.cs.ID,
+		Name: s.cs.Name,
+		Properties: api.Properties{
+			WorkerServicePrincipalProfile: api.ServicePrincipalProfile{
+				ClientID: s.cs.Properties.WorkerServicePrincipalProfile.ClientID,
+				Secret:   s.cs.Properties.WorkerServicePrincipalProfile.Secret,
+			},
+			AzProfile: api.AzProfile{
+				TenantID:       s.cs.Properties.AzProfile.TenantID,
+				SubscriptionID: s.cs.Properties.AzProfile.SubscriptionID,
+				ResourceGroup:  s.cs.Properties.AzProfile.ResourceGroup,
+			},
+		},
+		Location: s.cs.Location,
+		Config: api.Config{
+			PluginVersion: s.cs.Config.PluginVersion,
+			ComponentLogLevel: api.ComponentLogLevel{
+				Node: s.cs.Config.ComponentLogLevel.Node,
+			},
+			Certificates: api.CertificateConfig{
+				Ca: api.CertKeyPair{
+					Cert: s.cs.Config.Certificates.Ca.Cert,
+				},
+				GenevaLogging: s.cs.Config.Certificates.GenevaLogging,
+				NodeBootstrap: s.cs.Config.Certificates.NodeBootstrap,
+			},
+			Images: api.ImageConfig{
+				Format:          s.cs.Config.Images.Format,
+				Node:            s.cs.Config.Images.Node,
+				ImagePullSecret: s.cs.Config.Images.ImagePullSecret,
+			},
+			NodeBootstrapKubeconfig:              s.cs.Config.NodeBootstrapKubeconfig,
+			SDNKubeconfig:                        s.cs.Config.SDNKubeconfig,
+			GenevaLoggingAccount:                 s.cs.Config.GenevaLoggingAccount,
+			GenevaLoggingNamespace:               s.cs.Config.GenevaLoggingNamespace,
+			GenevaLoggingControlPlaneEnvironment: s.cs.Config.GenevaLoggingControlPlaneEnvironment,
+			GenevaLoggingControlPlaneAccount:     s.cs.Config.GenevaLoggingControlPlaneAccount,
+			GenevaLoggingControlPlaneRegion:      s.cs.Config.GenevaLoggingControlPlaneRegion,
+		},
+	}
+	for _, app := range s.cs.Properties.AgentPoolProfiles {
+		workerCS.Properties.AgentPoolProfiles = append(workerCS.Properties.AgentPoolProfiles, api.AgentPoolProfile{
+			Role:   app.Role,
+			VMSize: app.VMSize,
+		})
+	}
+	return workerCS
+}
 
 func (s *startup) WriteFiles(ctx context.Context) error {
 	hostname, err := os.Hostname()

--- a/pkg/util/mocks/mock_startup/startup.go
+++ b/pkg/util/mocks/mock_startup/startup.go
@@ -64,3 +64,17 @@ func (mr *MockInterfaceMockRecorder) Hash(role interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Hash", reflect.TypeOf((*MockInterface)(nil).Hash), role)
 }
+
+// GetWorkerCs mocks base method
+func (m *MockInterface) GetWorkerCs() *api.OpenShiftManagedCluster {
+	m.ctrl.T.Helper()
+	ret := m.ctrl.Call(m, "GetWorkerCs")
+	ret0, _ := ret[0].(*api.OpenShiftManagedCluster)
+	return ret0
+}
+
+// GetWorkerCs indicates an expected call of GetWorkerCs
+func (mr *MockInterfaceMockRecorder) GetWorkerCs() *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetWorkerCs", reflect.TypeOf((*MockInterface)(nil).GetWorkerCs))
+}


### PR DESCRIPTION
This was removed in v10, but older clusters still need it. This part of the code
is heavily depended on by versioned code, but has not been versioned. This has
lead to a bug when scaling older clusters. https://github.com/openshift/openshift-azure/issues/1515

```release-note
NONE
```
/cc @jim-minter 
