### PR TITLE
Remove /fakerp when running make clean

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,7 +15,7 @@ secrets:
 	@oc extract -n azure secret/cluster-secrets-azure --to=secrets >/dev/null
 
 clean:
-	rm -f coverage.out azure releasenotes testinsights
+	rm -f coverage.out azure releasenotes testinsights fakerp
 
 generate:
 	@[[ -e /var/run/secrets/kubernetes.io ]] || go generate ./...


### PR DESCRIPTION
```release-note
NONE
```
Given we ignore fakerp in .gitignore I thought we should also clean it when make clean is run.

