### PR TITLE
fix and extend e-mail matching in customer-admin-controller

### DIFF
--- a/pkg/controllers/customeradmin/group_mapping_test.go
+++ b/pkg/controllers/customeradmin/group_mapping_test.go
@@ -309,6 +309,38 @@ func TestFromMSGraphGroup(t *testing.T) {
 				Users: []string{"user@home.com"},
 			},
 		},
+		{
+			name:          "domain case can match",
+			kubeGroupName: osaCustomerAdmins,
+			want1:         true,
+			msGroupMembers: []graphrbac.User{
+				{
+					Mail: to.StringPtr("user@Home.com"),
+				},
+			},
+			want: &v1.Group{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name: osaCustomerAdmins,
+				},
+				Users: []string{"user@home.com"},
+			},
+		},
+		{
+			name:          "user case can't match",
+			kubeGroupName: osaCustomerAdmins,
+			want1:         true,
+			msGroupMembers: []graphrbac.User{
+				{
+					Mail: to.StringPtr("User@home.com"),
+				},
+			},
+			want: &v1.Group{
+				ObjectMeta: meta_v1.ObjectMeta{
+					Name: osaCustomerAdmins,
+				},
+				Users: []string{"User@home.com"},
+			},
+		},
 	}
 
 	for _, tt := range tests {


### PR DESCRIPTION
```release-note
Resolve customer-admin group memberships issue when case of AAD mail domain differs from case of AAD login
```
