### PR TITLE
Updates the vm image

### DIFF
--- a/pluginconfig/pluginconfig-311.yaml
+++ b/pluginconfig/pluginconfig-311.yaml
@@ -265,7 +265,7 @@ versions:
     imageOffer: osa
     imagePublisher: redhat
     imageSku: osa_311
-    imageVersion: 311.153.20191018
+    imageVersion: 311.153.20191112
     images:
       alertManager: registry.access.redhat.com/openshift3/prometheus-alertmanager:v3.11.153
       ansibleServiceBroker: registry.access.redhat.com/openshift3/ose-ansible-service-broker:v3.11.153


### PR DESCRIPTION
Updates the VM image to include fix for `RHSA-2019:3197`.

```
./hack/vmimage-cloudpartner.sh rhel7-3.11-201911120949
Disk version: 311.153.20191112
OS VHD URL:   https://openshiftimages.blob.core.windows.net/images/rhel7-3.11-201911120949.vhd?st=2019-11-11T15%3A08Z&se=2019-11-27T15%3A08Z&sp=rl&sv=2018-11-09&sr=c&sig=G6osDBFidQXJfpVmLbgnLGGkGe82hTEJcA2WlmlilzU%3D
```

/hold - image needs to be published first.
/cc @kwoodson @jim-minter could one of you please publish the image?

```release-note
NONE
```
