### PR TITLE
revert f66053121e8fd74acb6b40c0837471c3de5083f3 - it is a case study of premature optimisation

### DIFF
--- a/pkg/sync/v13/sync.go
+++ b/pkg/sync/v13/sync.go
@@ -14,13 +14,11 @@ import (
 	"os"
 	"sort"
 	"strings"
-	concurrency "sync"
 	"sync/atomic"
 	"time"
 
 	"github.com/ghodss/yaml"
 	"github.com/sirupsen/logrus"
-	"golang.org/x/sync/errgroup"
 	kapiextensions "k8s.io/apiextensions-apiserver/pkg/client/clientset/clientset"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
@@ -74,35 +72,27 @@ func unmarshal(b []byte) (unstructured.Unstructured, error) {
 func (s *sync) readDB() error {
 	s.db = map[string]unstructured.Unstructured{}
 
-	var g errgroup.Group
 	for _, asset := range AssetNames() {
-		asset := asset // https://golang.org/doc/faq#closures_and_goroutines
-		g.Go(func() error {
-			b, err := Asset(asset)
-			if err != nil {
-				return err
-			}
+		b, err := Asset(asset)
+		if err != nil {
+			return err
+		}
 
-			o, err := unmarshal(b)
-			if err != nil {
-				return err
-			}
+		o, err := unmarshal(b)
+		if err != nil {
+			return err
+		}
 
-			o, err = translateAsset(o, s.cs)
-			if err != nil {
-				return err
-			}
-			s.dbLock.Lock()
-			defer s.dbLock.Unlock()
+		o, err = translateAsset(o, s.cs)
+		if err != nil {
+			return err
+		}
 
-			s.db[keyFunc(o.GroupVersionKind().GroupKind(), o.GetNamespace(), o.GetName())] = o
-			return nil
-		})
+		s.db[keyFunc(o.GroupVersionKind().GroupKind(), o.GetNamespace(), o.GetName())] = o
 	}
-	if err := g.Wait(); err != nil {
-		return err
-	}
+
 	s.syncWorkloadsConfig()
+
 	return nil
 }
 
@@ -486,11 +476,10 @@ func (s *sync) PrintDB() error {
 type sync struct {
 	log *logrus.Entry
 
-	kc     kubernetes.Interface
-	cs     *api.OpenShiftManagedCluster
-	dbLock concurrency.Mutex
-	db     map[string]unstructured.Unstructured
-	ready  atomic.Value
+	kc    kubernetes.Interface
+	cs    *api.OpenShiftManagedCluster
+	db    map[string]unstructured.Unstructured
+	ready atomic.Value
 
 	restconfig *rest.Config
 	ac         *kaggregator.Clientset


### PR DESCRIPTION
```release-note
NONE
```

cf https://github.com/openshift/openshift-azure/pull/1687