### PR TITLE
don't allow upper-case domain names

### DIFF
--- a/pkg/api/validate/types.go
+++ b/pkg/api/validate/types.go
@@ -132,8 +132,12 @@ func isValidLocation(l string) bool {
 	return rxLocation.MatchString(l)
 }
 
-func isValidHostname(h string) bool {
-	return len(h) <= 255 && rxRfc1123.MatchString(h)
+func isValidLowerCaseHostname(h string) bool {
+	// OpenShift master will not start if (for example) routingConfig.subdomain
+	// or servingInfo.namedCertificates.names have upper case characters.  I
+	// don't believe that's RFC1123 compliant, hence adding the strings.ToLower
+	// check and not changing the regex
+	return len(h) <= 255 && rxRfc1123.MatchString(h) && strings.ToLower(h) == h
 }
 
 func isValidCloudAppHostname(h, location string) bool {

--- a/pkg/api/validate/validators.go
+++ b/pkg/api/validate/validators.go
@@ -68,7 +68,7 @@ func validateProperties(p *api.Properties, location string, externalOnly bool) (
 		} else {
 			// TODO: consider ensuring that PublicSubdomain is of the form
 			// openshift.<random>.<location>.azmosa.io
-			if !isValidHostname(p.PublicHostname) {
+			if !isValidLowerCaseHostname(p.PublicHostname) {
 				errs = append(errs, fmt.Errorf("invalid properties.publicHostname %q", p.PublicHostname))
 			}
 
@@ -223,7 +223,7 @@ func validateRouterProfile(path string, rp *api.RouterProfile, location string, 
 	if !externalOnly {
 		// TODO: consider ensuring that PublicSubdomain is of the form
 		// apps.<random>.<location>.azmosa.io
-		if !isValidHostname(rp.PublicSubdomain) {
+		if !isValidLowerCaseHostname(rp.PublicSubdomain) {
 			errs = append(errs, fmt.Errorf("invalid %s.publicSubdomain %q", path, rp.PublicSubdomain))
 		}
 

--- a/pkg/api/validate/validators_test.go
+++ b/pkg/api/validate/validators_test.go
@@ -230,6 +230,12 @@ func TestValidate(t *testing.T) {
 			},
 			expectedErrs: []error{errors.New(`invalid properties.publicHostname "bad!"`)},
 		},
+		"openshift config invalid public hostname (upper case)": {
+			f: func(oc *api.OpenShiftManagedCluster) {
+				oc.Properties.PublicHostname = "BAD.DOMAIN"
+			},
+			expectedErrs: []error{errors.New(`invalid properties.publicHostname "BAD.DOMAIN"`)},
+		},
 		"openshift config matching public hostname": {
 			f: func(oc *api.OpenShiftManagedCluster) {
 				oc.Properties.PublicHostname = oc.Properties.FQDN
@@ -348,6 +354,12 @@ func TestValidate(t *testing.T) {
 				oc.Properties.RouterProfiles[0].PublicSubdomain = "()"
 			},
 			expectedErrs: []error{errors.New(`invalid properties.routerProfiles["default"].publicSubdomain "()"`)},
+		},
+		"router invalid public subdomain (upper case)": {
+			f: func(oc *api.OpenShiftManagedCluster) {
+				oc.Properties.RouterProfiles[0].PublicSubdomain = "BAD.DOMAIN"
+			},
+			expectedErrs: []error{errors.New(`invalid properties.routerProfiles["default"].publicSubdomain "BAD.DOMAIN"`)},
 		},
 		"router matching public subdomain": {
 			f: func(oc *api.OpenShiftManagedCluster) {

--- a/pkg/plugin/integration_test.go
+++ b/pkg/plugin/integration_test.go
@@ -75,7 +75,7 @@ func getFakeDeployer(log *logrus.Entry, cs *api.OpenShiftManagedCluster, az *fak
 }
 
 func enrichCs(cs *api.OpenShiftManagedCluster) error {
-	rg := "testRG"
+	rg := "testrg"
 	dnsDomain := "cloudapp.azure.com"
 	tenantID := uuid.NewV4().String()
 	clientID := uuid.NewV4().String()


### PR DESCRIPTION
```release-note
MSFT: update plugin validator to reject upper-case domain names for public hostname and router.
```
