### PR TITLE
Allowing annotation openshift.io/reconcile-protect=true instead of a label

### DIFF
--- a/pkg/entrypoint/admissioncontroller/scc.go
+++ b/pkg/entrypoint/admissioncontroller/scc.go
@@ -58,7 +58,7 @@ func (ac *admissionController) validateSCCRequest(req *admission.AdmissionReques
 	}
 	scc.Users = template.Users
 
-	delete(scc.Labels, "openshift.io/reconcile-protect")
+	delete(scc.Annotations, "openshift.io/reconcile-protect")
 
 	scc.SelfLink = template.SelfLink
 	scc.UID = template.UID
@@ -68,7 +68,7 @@ func (ac *admissionController) validateSCCRequest(req *admission.AdmissionReques
 
 	// TODO: should do this field-wise
 	if !reflect.DeepEqual(scc, template) {
-		errs = append(errs, field.Invalid(field.NewPath(""), "", fmt.Sprint("may not modify fields other than users, groups and label labels.openshift.io/reconcile-protect")))
+		errs = append(errs, field.Invalid(field.NewPath(""), "", fmt.Sprint("may not modify fields other than users, groups and annotation openshift.io/reconcile-protect")))
 	}
 
 	return errors.NewAggregate(errs), nil

--- a/pkg/entrypoint/admissioncontroller/scc_test.go
+++ b/pkg/entrypoint/admissioncontroller/scc_test.go
@@ -85,7 +85,7 @@ func TestSCC(t *testing.T) {
 			name: "add user to privileged scc allowed",
 			request: func() *admission.AdmissionReview {
 				scc := sccs["privileged"].DeepCopy()
-				scc.Labels["openshift.io/reconcile-protect"] = "true"
+				scc.Annotations["openshift.io/reconcile-protect"] = "true"
 				scc.Users = append(scc.Users, "testuser")
 
 				return &admission.AdmissionReview{
@@ -100,7 +100,7 @@ func TestSCC(t *testing.T) {
 			name: "remove user from privileged scc not allowed",
 			request: func() *admission.AdmissionReview {
 				scc := sccs["privileged"].DeepCopy()
-				scc.Labels["openshift.io/reconcile-protect"] = "true"
+				scc.Annotations["openshift.io/reconcile-protect"] = "true"
 				scc.Users = scc.Users[1:]
 
 				return &admission.AdmissionReview{
@@ -116,7 +116,7 @@ func TestSCC(t *testing.T) {
 			name: "add group to privileged scc allowed",
 			request: func() *admission.AdmissionReview {
 				scc := sccs["privileged"].DeepCopy()
-				scc.Labels["openshift.io/reconcile-protect"] = "true"
+				scc.Annotations["openshift.io/reconcile-protect"] = "true"
 				scc.Groups = append(scc.Groups, "testgroup")
 
 				return &admission.AdmissionReview{
@@ -131,7 +131,7 @@ func TestSCC(t *testing.T) {
 			name: "remove group from privileged scc not allowed",
 			request: func() *admission.AdmissionReview {
 				scc := sccs["privileged"].DeepCopy()
-				scc.Labels["openshift.io/reconcile-protect"] = "true"
+				scc.Annotations["openshift.io/reconcile-protect"] = "true"
 				scc.Groups = scc.Groups[1:]
 
 				return &admission.AdmissionReview{
@@ -156,7 +156,7 @@ func TestSCC(t *testing.T) {
 					},
 				}
 			},
-			wantMessage: `[]: Invalid value: "": may not modify fields other than users, groups and label labels.openshift.io/reconcile-protect`,
+			wantMessage: `[]: Invalid value: "": may not modify fields other than users, groups and annotation openshift.io/reconcile-protect`,
 		},
 	} {
 		t.Run(tt.name, func(t *testing.T) {


### PR DESCRIPTION
```release-note
Fixes bug which prevented adding reconcile-protect annotation to SCCs
```
