### PR TITLE
Fix Template() usage so bugs are not hidden

### DIFF
--- a/pkg/arm/v14/resources.go
+++ b/pkg/arm/v14/resources.go
@@ -486,21 +486,31 @@ func vmss(cs *api.OpenShiftManagedCluster, app *api.AgentPoolProfile, backupBlob
 
 	var script string
 	if app.Role == api.AgentPoolProfileRoleMaster {
-		b, err := template.Template("master-startup.sh", string(masterStartup), nil, map[string]interface{}{
-			"Config":         &cs.Config,
-			"BackupBlobName": backupBlob,
-			"Derived":        derived,
-		})
+		b, err := template.Template("master-startup.sh", string(masterStartup), nil,
+			struct {
+				Config         *api.Config
+				BackupBlobName string
+				Derived        *derivedType
+			}{
+				Config:         &cs.Config,
+				BackupBlobName: backupBlob,
+				Derived:        derived,
+			})
 		if err != nil {
 			return nil, err
 		}
 		script = base64.StdEncoding.EncodeToString(b)
 	} else {
-		b, err := template.Template("node-startup.sh", string(nodeStartup), nil, map[string]interface{}{
-			"Config":  &cs.Config,
-			"Role":    app.Role,
-			"Derived": derived,
-		})
+		b, err := template.Template("node-startup.sh", string(nodeStartup), nil,
+			struct {
+				Config  *api.Config
+				Role    api.AgentPoolProfileRole
+				Derived *derivedType
+			}{
+				Config:  &cs.Config,
+				Role:    app.Role,
+				Derived: derived,
+			})
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/fakerp/container_insights.go
+++ b/pkg/fakerp/container_insights.go
@@ -36,13 +36,20 @@ func createOrUpdateContainerInsights(ctx context.Context, log *logrus.Entry, cs 
 		return err
 	}
 
-	b, err := utiltemplate.Template("azuremonitor-containerSolution.json", string(tmpl), nil, map[string]interface{}{
-		"Location":            cs.Location,
-		"SubscriptionID":      cs.Properties.AzProfile.SubscriptionID,
-		"ResourceGroup":       rg,
-		"WorkspaceResourceID": cs.Properties.MonitorProfile.WorkspaceResourceID,
-		"WorkspaceName":       workspaceName,
-	})
+	b, err := utiltemplate.Template("azuremonitor-containerSolution.json", string(tmpl), nil,
+		struct {
+			Location            string
+			SubscriptionID      string
+			ResourceGroup       string
+			WorkspaceResourceID string
+			WorkspaceName       string
+		}{
+			Location:            cs.Location,
+			SubscriptionID:      cs.Properties.AzProfile.SubscriptionID,
+			ResourceGroup:       rg,
+			WorkspaceResourceID: cs.Properties.MonitorProfile.WorkspaceResourceID,
+			WorkspaceName:       workspaceName,
+		})
 	if err != nil {
 		return err
 	}

--- a/pkg/startup/v14/startup.go
+++ b/pkg/startup/v14/startup.go
@@ -215,13 +215,20 @@ func (s *startup) writeFiles(role api.AgentPoolProfileRole, w writers.Writer, ho
 		b, err := template.Template(filepath, tmpl,
 			map[string]interface{}{
 				"Deref": func(pi *int) int { return *pi },
-			}, map[string]interface{}{
-				"ContainerService": s.cs,
-				"Config":           &s.cs.Config,
-				"Derived":          derived,
-				"Role":             role,
-				"Hostname":         hostname,
-				"DomainName":       domainname,
+			}, struct {
+				ContainerService *api.OpenShiftManagedCluster
+				Config           *api.Config
+				Derived          *derivedType
+				Role             api.AgentPoolProfileRole
+				Hostname         string
+				DomainName       string
+			}{
+				ContainerService: s.cs,
+				Config:           &s.cs.Config,
+				Derived:          derived,
+				Role:             role,
+				Hostname:         hostname,
+				DomainName:       domainname,
 			})
 		if err != nil {
 			return err

--- a/pkg/vmimage/vmimage.go
+++ b/pkg/vmimage/vmimage.go
@@ -55,21 +55,32 @@ func (builder *Builder) generateTemplate() (map[string]interface{}, error) {
 	var script []byte
 	var err error
 	if !builder.Validate {
-		script, err = template.Template("script.sh", string(MustAsset("script.sh")), nil, map[string]interface{}{
-			"Archive":      MustAsset("archive.tgz"),
-			"Builder":      builder,
-			"ClientID":     os.Getenv("AZURE_CLIENT_ID"),
-			"ClientSecret": os.Getenv("AZURE_CLIENT_SECRET"),
-			"TenantID":     os.Getenv("AZURE_TENANT_ID"),
-		})
+		script, err = template.Template("script.sh", string(MustAsset("script.sh")), nil,
+			struct {
+				Archive      []byte
+				Builder      *Builder
+				ClientID     string
+				ClientSecret string
+				TenantID     string
+			}{
+				Archive:      MustAsset("archive.tgz"),
+				Builder:      builder,
+				ClientID:     os.Getenv("AZURE_CLIENT_ID"),
+				ClientSecret: os.Getenv("AZURE_CLIENT_SECRET"),
+				TenantID:     os.Getenv("AZURE_TENANT_ID"),
+			})
 		if err != nil {
 			return nil, err
 		}
 	} else {
-		script, err = template.Template("validate.sh", string(MustAsset("validate.sh")), nil, map[string]interface{}{
-			"Archive": MustAsset("archive.tgz"),
-			"Builder": builder,
-		})
+		script, err = template.Template("validate.sh", string(MustAsset("validate.sh")), nil,
+			struct {
+				Archive []byte
+				Builder *Builder
+			}{
+				Archive: MustAsset("archive.tgz"),
+				Builder: builder,
+			})
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
```release-note
NONE
```
This is because the template function will return interface{} on a non-existing
value instead of an error. With struct we get the error correctly.
This has hidden an error in the startup assets.