### PR TITLE
Adds privateApiServer field into the admin API

### DIFF
--- a/pkg/api/admin/converterfrominternal.go
+++ b/pkg/api/admin/converterfrominternal.go
@@ -34,6 +34,7 @@ func FromInternal(cs *api.OpenShiftManagedCluster) *OpenShiftManagedCluster {
 		ClusterVersion:    &cs.Properties.ClusterVersion,
 		PublicHostname:    &cs.Properties.PublicHostname,
 		FQDN:              &cs.Properties.FQDN,
+		PrivateAPIServer:  cs.Properties.PrivateAPIServer,
 	}
 	// This is intentionally reversed as far as pointers go.
 	if cs.Properties.RefreshCluster != nil {

--- a/pkg/api/admin/convertertointernal.go
+++ b/pkg/api/admin/convertertointernal.go
@@ -90,6 +90,7 @@ func mergePropertiesAdmin(oc *OpenShiftManagedCluster, cs *api.OpenShiftManagedC
 	if oc.Properties.FQDN != nil {
 		cs.Properties.FQDN = *oc.Properties.FQDN
 	}
+
 	// always set this at it's a per/request action, not a configuration
 	cs.Properties.RefreshCluster = &oc.Properties.RefreshCluster
 

--- a/pkg/api/admin/convertertointernal_test.go
+++ b/pkg/api/admin/convertertointernal_test.go
@@ -321,6 +321,10 @@ func TestRoundTrip(t *testing.T) {
 		t.Error(err)
 	}
 	end := FromInternal(internal)
+
+	// Read-only: ignore in comparison
+	start.Properties.PrivateAPIServer = false
+
 	if !reflect.DeepEqual(start, end) {
 		t.Errorf("unexpected diff %s", cmp.Diff(start, end))
 	}

--- a/pkg/api/admin/types.go
+++ b/pkg/api/admin/types.go
@@ -47,6 +47,9 @@ type Properties struct {
 	// FQDN (out): Auto-allocated internal FQDN for OpenShift API server.
 	FQDN *string `json:"fqdn,omitempty"`
 
+	// PrivateAPIServer: Specifies if API server is public or private
+	PrivateAPIServer bool `json:"privateApiServer,omitempty"`
+
 	// NetworkProfile (in): Configuration for OpenShift networking.
 	NetworkProfile *NetworkProfile `json:"networkProfile,omitempty"`
 

--- a/pkg/api/admin/types_test.go
+++ b/pkg/api/admin/types_test.go
@@ -30,6 +30,7 @@ var marshalled = []byte(`{
 		"clusterVersion": "Properties.ClusterVersion",
 		"publicHostname": "Properties.PublicHostname",
 		"fqdn": "Properties.FQDN",
+		"privateApiServer": true,
 		"networkProfile": {
 			"vnetCidr": "Properties.NetworkProfile.VnetCIDR",
 			"managementSubnetCidr": "Properties.NetworkProfile.ManagementSubnetCIDR",
@@ -362,7 +363,6 @@ func TestAPIParity(t *testing.T) {
 		regexp.MustCompile(`^\.Properties\.NetworkProfile\.InternalLoadBalancerFrontendIPID$`),
 		regexp.MustCompile(`^\.Properties\.NetworkProfile\.Nameservers$`),
 		regexp.MustCompile(`^\.Properties\.MonitorProfile\.Workspace(ID|Key)`),
-		regexp.MustCompile(`^\.Properties\.PrivateAPIServer`),
 		regexp.MustCompile(`^\.Properties\.AzProfile\.`),
 		regexp.MustCompile(`^\.Properties\.(Master|Worker)ServicePrincipalProfile\.`),
 		regexp.MustCompile(`^\.Properties\.APICertProfile\.`),


### PR DESCRIPTION
Addming the `privateApiServer` field into the admin API makes debugging easier for an SRE: it is more obvious that the cluster has a private api enabled.

```release-note
NONE
```

/cc @mjudeikis 