### PR TITLE
[release-v14] Freeze v14.0 hashes, bump plugin config to 14.1

### DIFF
--- a/pkg/arm/arm.go
+++ b/pkg/arm/arm.go
@@ -37,7 +37,7 @@ func New(ctx context.Context, log *logrus.Entry, cs *api.OpenShiftManagedCluster
 		return v12.New(ctx, log, cs, testConfig), nil
 	case "v13.0", "v13.1":
 		return v13.New(ctx, log, cs, testConfig), nil
-	case "v14.0":
+	case "v14.0", "v14.1":
 		return v14.New(ctx, log, cs, testConfig), nil
 	}
 

--- a/pkg/cluster/hash_test.go
+++ b/pkg/cluster/hash_test.go
@@ -117,6 +117,23 @@ func TestHashScaleSetStability(t *testing.T) {
 				expectedHash: "959b10157d2864150339914d0e5ddee5dc7d7e1e6d2318f0ef9e5325cc6b09df",
 			},
 		},
+		"v14.0": {
+			{
+				role: api.AgentPoolProfileRoleMaster,
+				// this value should not change
+				expectedHash: "752cc90913885e480132837ef71e915933a80fc9933767b7594867fb3848be9a",
+			},
+			{
+				role: api.AgentPoolProfileRoleInfra,
+				// this value should not change
+				expectedHash: "99f4eb33af2723947783a6db1c3b9fb9d36d1989b4f4f658d776efec072779f1",
+			},
+			{
+				role: api.AgentPoolProfileRoleCompute,
+				// this value should not change
+				expectedHash: "959b10157d2864150339914d0e5ddee5dc7d7e1e6d2318f0ef9e5325cc6b09df",
+			},
+		},
 	}
 
 	// check we're testing all versions in our pluginconfig
@@ -229,6 +246,10 @@ func TestHashSyncPodStability(t *testing.T) {
 		"v13.1": {
 			// this value should not change
 			expectedHash: "803aadaf2f66d5766118ff70a36d9e15382483d6adef729cc80177a4a41062fa",
+		},
+		"v14.0": {
+			// this value should not change
+			expectedHash: "4dd641611a5f33ecdae8be029f1911827636999c11997d20db3f935badeb1129",
 		},
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -34,7 +34,7 @@ func New(cs *api.OpenShiftManagedCluster) (Interface, error) {
 		return v12.New(cs), nil
 	case "v13.0", "v13.1":
 		return v13.New(cs), nil
-	case "v14.0":
+	case "v14.0", "v14.1":
 		return v14.New(cs), nil
 	}
 

--- a/pkg/startup/startup.go
+++ b/pkg/startup/startup.go
@@ -38,7 +38,7 @@ func New(log *logrus.Entry, cs *api.OpenShiftManagedCluster, testConfig api.Test
 		return v12.New(log, cs, testConfig), nil
 	case "v13.0", "v13.1":
 		return v13.New(log, cs, testConfig), nil
-	case "v14.0":
+	case "v14.0", "v14.1":
 		return v14.New(log, cs, testConfig), nil
 	}
 

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -32,7 +32,7 @@ func New(log *logrus.Entry, cs *api.OpenShiftManagedCluster, initClients bool) (
 		return v12.New(log, cs, initClients)
 	case "v13.0", "v13.1":
 		return v13.New(log, cs, initClients)
-	case "v14.0":
+	case "v14.0", "v14.1":
 		return v14.New(log, cs, initClients)
 	}
 
@@ -47,7 +47,7 @@ func AssetNames(cs *api.OpenShiftManagedCluster) ([]string, error) {
 	switch cs.Config.PluginVersion {
 	case "v13.0", "v13.1":
 		return v13.AssetNames(), nil
-	case "v14.0":
+	case "v14.0", "v14.1":
 		return v14.AssetNames(), nil
 	}
 
@@ -58,7 +58,7 @@ func Asset(cs *api.OpenShiftManagedCluster, name string) ([]byte, error) {
 	switch cs.Config.PluginVersion {
 	case "v13.0", "v13.1":
 		return v13.Asset(name)
-	case "v14.0":
+	case "v14.0", "v14.1":
 		return v14.Asset(name)
 	}
 

--- a/pluginconfig/pluginconfig-311.yaml
+++ b/pluginconfig/pluginconfig-311.yaml
@@ -2,7 +2,7 @@
 ## Plugin config template.
 ## This template file is manually curated for the particular OSA version
 ##
-pluginVersion: v14.0
+pluginVersion: v14.1
 ## List of RPM packages that fix security issues
 securityPatchPackages: []
 ## Openshift component logging levels
@@ -223,6 +223,49 @@ versions:
       sync: osarpint.azurecr.io/openshift-on-azure/azure:v13.1
       tlsProxy: osarpint.azurecr.io/openshift-on-azure/azure:v13.1
   v14.0:
+    imageOffer: osa
+    imagePublisher: redhat
+    imageSku: osa_311
+    imageVersion: 311.157.20191217
+    images:
+      alertManager: registry.access.redhat.com/openshift3/prometheus-alertmanager:v3.11.157
+      ansibleServiceBroker: registry.access.redhat.com/openshift3/ose-ansible-service-broker:v3.11.157
+      clusterMonitoringOperator: registry.access.redhat.com/openshift3/ose-cluster-monitoring-operator:v3.11.157
+      configReloader: registry.access.redhat.com/openshift3/ose-configmap-reloader:v3.11.157
+      console: registry.access.redhat.com/openshift3/ose-console:v3.11.157
+      controlPlane: registry.access.redhat.com/openshift3/ose-control-plane:v3.11.157
+      grafana: registry.access.redhat.com/openshift3/grafana:v3.11.157
+      kubeRbacProxy: registry.access.redhat.com/openshift3/ose-kube-rbac-proxy:v3.11.157
+      kubeStateMetrics: registry.access.redhat.com/openshift3/ose-kube-state-metrics:v3.11.157
+      node: registry.access.redhat.com/openshift3/ose-node:v3.11.157
+      nodeExporter: registry.access.redhat.com/openshift3/prometheus-node-exporter:v3.11.157
+      oAuthProxy: registry.access.redhat.com/openshift3/oauth-proxy:v3.11.157
+      prometheus: registry.access.redhat.com/openshift3/prometheus:v3.11.157
+      prometheusConfigReloader: registry.access.redhat.com/openshift3/ose-prometheus-config-reloader:v3.11.157
+      prometheusOperator: registry.access.redhat.com/openshift3/ose-prometheus-operator:v3.11.157
+      registry: registry.access.redhat.com/openshift3/ose-docker-registry:v3.11.157
+      registryConsole: registry.access.redhat.com/openshift3/registry-console:v3.11.157
+      router: registry.access.redhat.com/openshift3/ose-haproxy-router:v3.11.157
+      serviceCatalog: registry.access.redhat.com/openshift3/ose-service-catalog:v3.11.157
+      templateServiceBroker: registry.access.redhat.com/openshift3/ose-template-service-broker:v3.11.157
+      webConsole: registry.access.redhat.com/openshift3/ose-web-console:v3.11.157
+      format: registry.access.redhat.com/openshift3/ose-${component}:v3.11.157
+      httpd: registry.access.redhat.com/rhscl/httpd-24-rhel7:2.4-108
+      masterEtcd: registry.access.redhat.com/rhel7/etcd:3.2.26-22
+      genevaLogging: osarpint.azurecr.io/acs/mdsd:master.20190228.1
+      genevaStatsd: osarpint.azurecr.io/acs/mdm:git-a909a2e76
+      genevaTDAgent: osarpint.azurecr.io/acs/td-agent:master.20190228.1
+      logAnalyticsAgent: mcr.microsoft.com/azuremonitor/containerinsights/ciprod:ciprod11012019
+      metricsServer: registry.access.redhat.com/openshift3/ose-metrics-server:v3.11.157
+      azureControllers: osarpint.azurecr.io/openshift-on-azure/azure:v14.0
+      aroAdmissionController: osarpint.azurecr.io/openshift-on-azure/azure:v14.0
+      canary: osarpint.azurecr.io/openshift-on-azure/azure:v14.0
+      etcdBackup: osarpint.azurecr.io/openshift-on-azure/azure:v14.0
+      metricsBridge: osarpint.azurecr.io/openshift-on-azure/azure:v14.0
+      startup: osarpint.azurecr.io/openshift-on-azure/azure:v14.0
+      sync: osarpint.azurecr.io/openshift-on-azure/azure:v14.0
+      tlsProxy: osarpint.azurecr.io/openshift-on-azure/azure:v14.0
+  v14.1:
     imageOffer: osa
     imagePublisher: redhat
     imageSku: osa_311


### PR DESCRIPTION
We might not do a 14.1 point release but this was the easiest way to get the correct hashes for master.

```release-note
NONE
```
