### PR TITLE
Increase supported compute cluster size to 100

### DIFF
--- a/pkg/api/validate/validators.go
+++ b/pkg/api/validate/validators.go
@@ -305,7 +305,7 @@ func validateAgentPoolProfile(app *api.AgentPoolProfile, np *api.NetworkProfile)
 		if !rxAgentPoolProfileName.MatchString(app.Name) {
 			errs = append(errs, fmt.Errorf("invalid properties.agentPoolProfiles[%q].name %q", app.Name, app.Name))
 		}
-		if app.Count < 1 || app.Count > 30 {
+		if app.Count < 1 || app.Count > 100 {
 			errs = append(errs, fmt.Errorf("invalid properties.agentPoolProfiles[%q].count %d", app.Name, app.Count))
 		}
 

--- a/pkg/api/validate/validators_test.go
+++ b/pkg/api/validate/validators_test.go
@@ -167,6 +167,17 @@ func TestValidate(t *testing.T) {
 			f:            func(oc *api.OpenShiftManagedCluster) { oc.Name = "cluster name" },
 			expectedErrs: []error{errors.New(`invalid name "cluster name"`)},
 		},
+		"valid compute count": {
+			f: func(oc *api.OpenShiftManagedCluster) {
+				oc.Properties.AgentPoolProfiles[2].Count = 100
+			},
+		},
+		"invalid compute count": {
+			f: func(oc *api.OpenShiftManagedCluster) {
+				oc.Properties.AgentPoolProfiles[2].Count = 1000
+			},
+			expectedErrs: []error{errors.New(`invalid properties.agentPoolProfiles["mycompute"].count 1000`)},
+		},
 		"openshift config invalid api fqdn": {
 			f: func(oc *api.OpenShiftManagedCluster) {
 				oc.Properties.FQDN = ""


### PR DESCRIPTION
```release-note
Intended as a soft launch support larger cluster creation based on previous performance tests now that the timeout issues for cluster creation of this size have been mitigated

Feature launch requires more extensive test plan and documentation updates
```
