### PR TITLE
make config struct invisible for update

### DIFF
--- a/pkg/api/validate/api.go
+++ b/pkg/api/validate/api.go
@@ -92,6 +92,8 @@ func (v *APIValidator) validateUpdateContainerService(cs, oldCs *api.OpenShiftMa
 			csCopy.Properties.AuthProfile.IdentityProviders[0].Provider.(*api.AADIdentityProvider).Secret = "<hidden 1>"
 			old.Properties.AuthProfile.IdentityProviders[0].Provider.(*api.AADIdentityProvider).Secret = "<hidden 2>"
 		}
+		csCopy.Config = api.Config{}
+		old.Config = api.Config{}
 		errs = append(errs, fmt.Errorf("invalid change %s", cmp.Diff(csCopy, old)))
 	}
 

--- a/pkg/api/validate/api_test.go
+++ b/pkg/api/validate/api_test.go
@@ -55,6 +55,16 @@ func TestAPIValidateUpdate(t *testing.T) {
 				oc.Properties.ProvisioningState = api.Creating // the RP is responsible for checking this
 			},
 		},
+		"config structure is not exposed if changed": {
+			f: func(oc *api.OpenShiftManagedCluster) {
+				oc.Config.EtcdMetricsPassword = "test"
+			},
+			expectedErrs: []*regexp.Regexp{
+				// when config struct changed we should print ONLY error
+				// No diff output should be printed from the struct
+				regexp.MustCompile(`invalid change $`),
+			},
+		},
 	}
 
 	for name, test := range tests {

--- a/pkg/api/validate/validators_test.go
+++ b/pkg/api/validate/validators_test.go
@@ -71,7 +71,8 @@ properties:
   workerServicePrincipalProfile:
     clientID: 00000000-0000-0000-0000-000000000000
     secret: secret
-`)
+  config:
+    etcdMetricsPassword: password`)
 
 func TestValidate(t *testing.T) {
 	tests := map[string]struct {


### PR DESCRIPTION
```release-note
hide config from update return errors
```
