### PR TITLE
Testing private cluster rotation

### DIFF
--- a/cmd/createorupdate/createorupdate.go
+++ b/cmd/createorupdate/createorupdate.go
@@ -285,11 +285,13 @@ func (c Client) Create(ctx context.Context) (string, error) {
 
 	// If no MANIFEST has been provided and this is a cluster
 	// creation, default to the test manifest.
-	if !shared.IsUpdate() && c.conf.Manifest == "" {
-		c.conf.Manifest = "test/manifests/fakerp/create.yaml"
-	} else {
-		// If this is a cluster upgrade, reuse the existing manifest.
-		c.conf.Manifest = "_data/manifest.yaml"
+	if c.conf.Manifest == "" {
+		if !shared.IsUpdate() {
+			c.conf.Manifest = "test/manifests/fakerp/create.yaml"
+		} else {
+			// If this is a cluster upgrade, reuse the existing manifest.
+			c.conf.Manifest = "_data/manifest.yaml"
+		}
 	}
 
 	var consoleURL string

--- a/hack/upgrade.sh
+++ b/hack/upgrade.sh
@@ -20,6 +20,10 @@ if [[ -z "${MANIFEST}${ADMIN_MANIFEST}" ]]; then
     echo ""
 fi
 
+if [[ -n "$API_VERSION" ]]; then
+    API_VERSION="-api-version=$API_VERSION"
+fi
+
 if [[ -n "$TEST_IN_PRODUCTION" ]]; then
     TEST_IN_PRODUCTION="-use-prod=true"
 else
@@ -34,4 +38,4 @@ if [[ -n "$ADMIN_MANIFEST" ]]; then
     ADMIN_MANIFEST="-admin-manifest=$ADMIN_MANIFEST"
 fi
 
-go run cmd/createorupdate/createorupdate.go ${TEST_IN_PRODUCTION:-} ${ADMIN_MANIFEST:-}
+go run cmd/createorupdate/createorupdate.go ${API_VERSION:-} ${TEST_IN_PRODUCTION:-} ${ADMIN_MANIFEST:-}

--- a/test/manifests/fakerp/refresh-cluster.yaml
+++ b/test/manifests/fakerp/refresh-cluster.yaml
@@ -1,0 +1,3 @@
+# MANIFEST=test/manifests/fakerp/refresh-cluster.yaml API_VERSION=2019-10-27-preview hack/upgrade.sh
+properties:
+  refreshCluster: true


### PR DESCRIPTION
```release-note
NONE
```
Some changes in scripts/fakerp to make testing private cluster refresh easier
