### PR TITLE
Bump OpenShift version to 3.11.188

### DIFF
--- a/pluginconfig/pluginconfig-311.yaml
+++ b/pluginconfig/pluginconfig-311.yaml
@@ -189,37 +189,37 @@ versions:
     imageOffer: osa
     imagePublisher: redhat
     imageSku: osa_311
-    imageVersion: 311.170.20200224
+    imageVersion: 311.188.20200320
     images:
-      alertManager: registry.access.redhat.com/openshift3/prometheus-alertmanager:v3.11.170
-      ansibleServiceBroker: registry.access.redhat.com/openshift3/ose-ansible-service-broker:v3.11.170
-      clusterMonitoringOperator: registry.access.redhat.com/openshift3/ose-cluster-monitoring-operator:v3.11.170
-      configReloader: registry.access.redhat.com/openshift3/ose-configmap-reloader:v3.11.170
-      console: registry.access.redhat.com/openshift3/ose-console:v3.11.170
-      controlPlane: registry.access.redhat.com/openshift3/ose-control-plane:v3.11.170
-      grafana: registry.access.redhat.com/openshift3/grafana:v3.11.170
-      kubeRbacProxy: registry.access.redhat.com/openshift3/ose-kube-rbac-proxy:v3.11.170
-      kubeStateMetrics: registry.access.redhat.com/openshift3/ose-kube-state-metrics:v3.11.170
-      node: registry.access.redhat.com/openshift3/ose-node:v3.11.170
-      nodeExporter: registry.access.redhat.com/openshift3/prometheus-node-exporter:v3.11.170
-      oAuthProxy: registry.access.redhat.com/openshift3/oauth-proxy:v3.11.170
-      prometheus: registry.access.redhat.com/openshift3/prometheus:v3.11.170
-      prometheusConfigReloader: registry.access.redhat.com/openshift3/ose-prometheus-config-reloader:v3.11.170
-      prometheusOperator: registry.access.redhat.com/openshift3/ose-prometheus-operator:v3.11.170
-      registry: registry.access.redhat.com/openshift3/ose-docker-registry:v3.11.170
-      registryConsole: registry.access.redhat.com/openshift3/registry-console:v3.11.170
-      router: registry.access.redhat.com/openshift3/ose-haproxy-router:v3.11.170
-      serviceCatalog: registry.access.redhat.com/openshift3/ose-service-catalog:v3.11.170
-      templateServiceBroker: registry.access.redhat.com/openshift3/ose-template-service-broker:v3.11.170
-      webConsole: registry.access.redhat.com/openshift3/ose-web-console:v3.11.170
-      format: registry.access.redhat.com/openshift3/ose-${component}:v3.11.170
+      alertManager: registry.access.redhat.com/openshift3/prometheus-alertmanager:v3.11.188
+      ansibleServiceBroker: registry.access.redhat.com/openshift3/ose-ansible-service-broker:v3.11.188
+      clusterMonitoringOperator: registry.access.redhat.com/openshift3/ose-cluster-monitoring-operator:v3.11.188
+      configReloader: registry.access.redhat.com/openshift3/ose-configmap-reloader:v3.11.188
+      console: registry.access.redhat.com/openshift3/ose-console:v3.11.188
+      controlPlane: registry.access.redhat.com/openshift3/ose-control-plane:v3.11.188
+      grafana: registry.access.redhat.com/openshift3/grafana:v3.11.188
+      kubeRbacProxy: registry.access.redhat.com/openshift3/ose-kube-rbac-proxy:v3.11.188
+      kubeStateMetrics: registry.access.redhat.com/openshift3/ose-kube-state-metrics:v3.11.188
+      node: registry.access.redhat.com/openshift3/ose-node:v3.11.188
+      nodeExporter: registry.access.redhat.com/openshift3/prometheus-node-exporter:v3.11.188
+      oAuthProxy: registry.access.redhat.com/openshift3/oauth-proxy:v3.11.188
+      prometheus: registry.access.redhat.com/openshift3/prometheus:v3.11.188
+      prometheusConfigReloader: registry.access.redhat.com/openshift3/ose-prometheus-config-reloader:v3.11.188
+      prometheusOperator: registry.access.redhat.com/openshift3/ose-prometheus-operator:v3.11.188
+      registry: registry.access.redhat.com/openshift3/ose-docker-registry:v3.11.188
+      registryConsole: registry.access.redhat.com/openshift3/registry-console:v3.11.188
+      router: registry.access.redhat.com/openshift3/ose-haproxy-router:v3.11.188
+      serviceCatalog: registry.access.redhat.com/openshift3/ose-service-catalog:v3.11.188
+      templateServiceBroker: registry.access.redhat.com/openshift3/ose-template-service-broker:v3.11.188
+      webConsole: registry.access.redhat.com/openshift3/ose-web-console:v3.11.188
+      format: registry.access.redhat.com/openshift3/ose-${component}:v3.11.188
       httpd: registry.access.redhat.com/rhscl/httpd-24-rhel7:2.4-109
-      masterEtcd: registry.access.redhat.com/rhel7/etcd:3.2.26-32
+      masterEtcd: registry.access.redhat.com/rhel7/etcd:3.2.26-36
       genevaLogging: osarpint.azurecr.io/acs/mdsd:master.20190228.1
       genevaStatsd: osarpint.azurecr.io/acs/mdm:git-a909a2e76
       genevaTDAgent: osarpint.azurecr.io/acs/td-agent:master.20190228.1
       logAnalyticsAgent: mcr.microsoft.com/azuremonitor/containerinsights/ciprod:ciprod03022020
-      metricsServer: registry.access.redhat.com/openshift3/ose-metrics-server:v3.11.170
+      metricsServer: registry.access.redhat.com/openshift3/ose-metrics-server:v3.11.188
       azureControllers: quay.io/openshift-on-azure/ci-azure:latest
       aroAdmissionController: quay.io/openshift-on-azure/ci-azure:latest
       canary: quay.io/openshift-on-azure/ci-azure:latest


### PR DESCRIPTION
```release-note
Upgrade to OpenShift [3.11.188](https://docs.openshift.com/container-platform/3.11/release_notes/ocp_3_11_release_notes.html#ocp-3-11-188)
```

/hold

VM image is still publishing.

This will unblock #2237.