### PR TITLE
Ignore second run of sync pod for updates

### DIFF
--- a/test/e2e/specs/fakerp/sync.go
+++ b/test/e2e/specs/fakerp/sync.go
@@ -29,7 +29,7 @@ var _ = Describe("sync pod tests [EveryPR]", func() {
 			if len(runs) > 1 {
 				for i, run := range runs {
 					Expect(run).To(Not(ContainSubstring("level=error")))
-					if i == 0 {
+					if i == 0 || i == 1 {
 						By(fmt.Sprintf("ignoring the run %d/%d as it will have updates", i, len(runs)))
 						continue
 					}


### PR DESCRIPTION
```release-note
NONE
```

Currently, a ton of the e2e tests keep flaking because there's one remaining update during the sync runs that spill over from run 0 to run 1. (See e.g. #1778) I think that ignoring the 0th and 1st run will reduce the number of flakes we see from this.

/cc @jim-minter @asalkeld 

thoughts? 

Fixes. #1778.