### PR TITLE
Disable gosec checks

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -72,7 +72,6 @@ verify:
 	./hack/verify/validate-codecov.sh
 	go run ./hack/validate-imports/validate-imports.go cmd hack pkg test
 	go run ./hack/verify/validate_pluginconfig.go
-	./hack/verify/validate-sec.sh
 
 testinsights:
 	go build -ldflags ${LDFLAGS} ./cmd/$@


### PR DESCRIPTION
Upstream changes in gosec keep breaking validation on builds. Since this
repo is in maintenance mode, I'd like to disable the checks.

```release-note
NONE
```
