### PR TITLE
Disable etcd backups on upgrades

### DIFF
--- a/pkg/plugin/plugin.go
+++ b/pkg/plugin/plugin.go
@@ -249,7 +249,8 @@ const (
 
 func (p *plugin) CreateOrUpdate(ctx context.Context, cs *api.OpenShiftManagedCluster, isUpdate bool, deployFn api.DeployFn) *api.PluginError {
 	if isUpdate {
-		return p.createOrUpdateExt(ctx, cs, updateTypeNormal, deployFn, true)
+		// NOTE(ehashman): disable backups on updates, they regularly fail
+		return p.createOrUpdateExt(ctx, cs, updateTypeNormal, deployFn, false)
 	}
 	return p.createOrUpdateExt(ctx, cs, updateTypeCreate, deployFn, false)
 }

--- a/pkg/plugin/plugin_test.go
+++ b/pkg/plugin/plugin_test.go
@@ -80,7 +80,8 @@ func TestCreateOrUpdate(t *testing.T) {
 			clusterUpgrader := mock_cluster.NewMockUpgrader(gmc)
 			if tt.isUpdate {
 				var c *gomock.Call
-				clusterUpgrader.EXPECT().BackupCluster(nil, gomock.Any())
+				// NOTE(ehashman): disable backups before updates
+				// clusterUpgrader.EXPECT().BackupCluster(nil, gomock.Any())
 				expectUpdate(cs, clusterUpgrader, &c)
 			} else {
 				c := clusterUpgrader.EXPECT().CreateOrUpdateConfigStorageAccount(nil).Return(nil)
@@ -243,7 +244,8 @@ func TestForceUpdate(t *testing.T) {
 	clusterUpgrader := mock_cluster.NewMockUpgrader(gmc)
 
 	c := clusterUpgrader.EXPECT().ResetUpdateBlob().Return(nil)
-	c = clusterUpgrader.EXPECT().BackupCluster(nil, gomock.Any()).After(c)
+	// NOTE(ehashman): disable backups before updates
+	// c = clusterUpgrader.EXPECT().BackupCluster(nil, gomock.Any()).After(c)
 	expectUpdate(cs, clusterUpgrader, &c)
 
 	p := &plugin{


### PR DESCRIPTION
```release-note
Internal fix: no longer perform etcd-backup on upgrade
```

MS has been disabling this by commenting out:

https://github.com/openshift/openshift-azure/blob/c70152ea551524eb7470c19519d01a1d7035ea8d/pkg/plugin/plugin.go#L287-L293

To avoid leaving a dangling `backupEtcd` argument and an associated refactor to clean it up, I instead located everywhere that `createOrUpdateExt` is called and ensured that `backupEtcd` is always set to false. But I'm not attached to this solution, I could also just remove the code above.

Hopefully this will unblock upgrades on private clusters.

/cc @jim-minter 