### PR TITLE
[release-v19] Disable SecurityPatchPackages certificate when feature isn't in use

### DIFF
--- a/pkg/api/validate/plugin.go
+++ b/pkg/api/validate/plugin.go
@@ -47,7 +47,7 @@ func (v *PluginAPIValidator) Validate(c *pluginapi.Config) (errs []error) {
 		errs = append(errs, fmt.Errorf("missing versions key %q", c.PluginVersion))
 	}
 
-	errs = append(errs, validateCertificateConfig(&c.Certificates)...)
+	errs = append(errs, validateCertificateConfig(c, &c.Certificates)...)
 
 	if c.GenevaLoggingSector == "" {
 		errs = append(errs, fmt.Errorf("invalid genevaLoggingSector %q", c.GenevaLoggingSector))
@@ -302,7 +302,7 @@ func validateImageConfig(path, version string, i *pluginapi.ImageConfig) (errs [
 	return
 }
 
-func validateCertificateConfig(c *pluginapi.CertificateConfig) (errs []error) {
+func validateCertificateConfig(config *pluginapi.Config, c *pluginapi.CertificateConfig) (errs []error) {
 	if c == nil {
 		errs = append(errs, fmt.Errorf("certificateConfig cannot be nil"))
 		return
@@ -312,7 +312,9 @@ func validateCertificateConfig(c *pluginapi.CertificateConfig) (errs []error) {
 
 	errs = append(errs, validateCertKeyPair("certificates.genevaMetrics", &c.GenevaMetrics)...)
 
-	errs = append(errs, validateCertKeyPair("certificates.packageRepository", &c.PackageRepository)...)
+	if len(config.SecurityPatchPackages) > 0 {
+		errs = append(errs, validateCertKeyPair("certificates.packageRepository", &c.PackageRepository)...)
+	}
 
 	return
 }

--- a/pkg/api/validate/plugin_test.go
+++ b/pkg/api/validate/plugin_test.go
@@ -90,3 +90,83 @@ func TestPluginTemplateValidate(t *testing.T) {
 		}
 	}
 }
+
+func TestPluginTemplateValidateNoSecurityPatchPackages(t *testing.T) {
+	expectedErrs :=
+		[]error{
+			errors.New(`invalid pluginVersion ""`),
+			errors.New(`invalid versions[""]`),
+			errors.New(`invalid versions[""].imageOffer ""`),
+			errors.New(`invalid versions[""].imagePublisher ""`),
+			errors.New(`invalid versions[""].imageSKU ""`),
+			errors.New(`invalid versions[""].imageVersion ""`),
+			errors.New(`invalid versions[""].images.alertManager ""`),
+			errors.New(`invalid versions[""].images.ansibleServiceBroker ""`),
+			errors.New(`invalid versions[""].images.clusterMonitoringOperator ""`),
+			errors.New(`invalid versions[""].images.configReloader ""`),
+			errors.New(`invalid versions[""].images.console ""`),
+			errors.New(`invalid versions[""].images.controlPlane ""`),
+			errors.New(`invalid versions[""].images.grafana ""`),
+			errors.New(`invalid versions[""].images.kubeRbacProxy ""`),
+			errors.New(`invalid versions[""].images.kubeStateMetrics ""`),
+			errors.New(`invalid versions[""].images.node ""`),
+			errors.New(`invalid versions[""].images.nodeExporter ""`),
+			errors.New(`invalid versions[""].images.oAuthProxy ""`),
+			errors.New(`invalid versions[""].images.prometheus ""`),
+			errors.New(`invalid versions[""].images.prometheusConfigReloader ""`),
+			errors.New(`invalid versions[""].images.prometheusOperator ""`),
+			errors.New(`invalid versions[""].images.registry ""`),
+			errors.New(`invalid versions[""].images.registryConsole ""`),
+			errors.New(`invalid versions[""].images.router ""`),
+			errors.New(`invalid versions[""].images.serviceCatalog ""`),
+			errors.New(`invalid versions[""].images.templateServiceBroker ""`),
+			errors.New(`invalid versions[""].images.webConsole ""`),
+			errors.New(`invalid versions[""].images.format ""`),
+			errors.New(`invalid versions[""].images.httpd ""`),
+			errors.New(`invalid versions[""].images.masterEtcd ""`),
+			errors.New(`invalid versions[""].images.genevaLogging ""`),
+			errors.New(`invalid versions[""].images.genevaStatsd ""`),
+			errors.New(`invalid versions[""].images.genevaTDAgent ""`),
+			errors.New(`invalid versions[""].images.logAnalyticsAgent ""`),
+			errors.New(`invalid versions[""].images.azureControllers ""`),
+			errors.New(`invalid versions[""].images.canary ""`),
+			errors.New(`invalid versions[""].images.etcdBackup ""`),
+			errors.New(`invalid versions[""].images.metricsBridge ""`),
+			errors.New(`invalid versions[""].images.startup ""`),
+			errors.New(`invalid versions[""].images.sync ""`),
+			errors.New(`invalid versions[""].images.tlsProxy ""`),
+			errors.New(`invalid certificates.genevaLogging.key`),
+			errors.New(`invalid certificates.genevaLogging.cert`),
+			errors.New(`invalid certificates.genevaMetrics.key`),
+			errors.New(`invalid certificates.genevaMetrics.cert`),
+			errors.New(`invalid genevaLoggingSector ""`),
+			errors.New(`invalid genevaLoggingAccount ""`),
+			errors.New(`invalid genevaLoggingNamespace ""`),
+			errors.New(`invalid genevaLoggingControlPlaneAccount ""`),
+			errors.New(`invalid genevaLoggingControlPlaneEnvironment ""`),
+			errors.New(`invalid genevaLoggingControlPlaneRegion ""`),
+			errors.New(`invalid genevaMetricsAccount ""`),
+			errors.New(`invalid genevaMetricsEndpoint ""`),
+			errors.New(`invalid genevaImagePullSecret ""`),
+			errors.New(`invalid imagePullSecret ""`),
+		}
+
+	template := pluginapi.Config{
+		Versions: map[string]pluginapi.VersionConfig{
+			"": {},
+		},
+		SecurityPatchPackages: nil,
+	}
+	v := PluginAPIValidator{}
+	errs := v.Validate(&template)
+	if !reflect.DeepEqual(errs, expectedErrs) {
+		t.Errorf("expected errors:")
+		for _, err := range expectedErrs {
+			t.Errorf("\t%v", err)
+		}
+		t.Error("received errors:")
+		for _, err := range errs {
+			t.Errorf("\t%v", err)
+		}
+	}
+}


### PR DESCRIPTION
```release-note
If SecurityPatchPackages is not set, do not validate its corresponding certificate
```

@jim-minter note that I extremely lazily added a unit test case here because I did not think it was worth doing a refactor.