### PR TITLE
[release-v19] Prep v19.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,8 @@
+## v19.1
+
+- If SecurityPatchPackages is not set, do not validate its corresponding certificate ([#2324](https://github.com/openshift/openshift-azure/pull/2324), [@ehashman](https://github.com/ehashman), 20/07/2020)
+- Update OMSAgent with July hotfix ([#2323](https://github.com/openshift/openshift-azure/pull/2323), [@ehashman](https://github.com/ehashman), 17/07/2020)
+
 ## v19.0
 
 - Upgrade OpenShift to [3.11.232](https://docs.openshift.com/container-platform/3.11/release_notes/ocp_3_11_release_notes.html#ocp-3-11-232) ([#2316](https://github.com/openshift/openshift-azure/pull/2316), [@ehashman](https://github.com/ehashman), 08/07/2020)

--- a/pkg/arm/arm.go
+++ b/pkg/arm/arm.go
@@ -40,7 +40,7 @@ func New(ctx context.Context, log *logrus.Entry, cs *api.OpenShiftManagedCluster
 		return v17.New(ctx, log, cs, testConfig), nil
 	case "v18.0":
 		return v18.New(ctx, log, cs, testConfig), nil
-	case "v19.0":
+	case "v19.0", "v19.1":
 		return v19.New(ctx, log, cs, testConfig), nil
 	}
 

--- a/pkg/config/config.go
+++ b/pkg/config/config.go
@@ -37,7 +37,7 @@ func New(cs *api.OpenShiftManagedCluster) (Interface, error) {
 		return v17.New(cs), nil
 	case "v18.0":
 		return v18.New(cs), nil
-	case "v19.0":
+	case "v19.0", "v19.1":
 		return v19.New(cs), nil
 	}
 

--- a/pkg/startup/startup.go
+++ b/pkg/startup/startup.go
@@ -42,7 +42,7 @@ func New(log *logrus.Entry, cs *api.OpenShiftManagedCluster, testConfig api.Test
 		return v17.New(log, cs, testConfig), nil
 	case "v18.0":
 		return v18.New(log, cs, testConfig), nil
-	case "v19.0":
+	case "v19.0", "v19.1":
 		return v19.New(log, cs, testConfig), nil
 	}
 

--- a/pkg/sync/sync.go
+++ b/pkg/sync/sync.go
@@ -35,7 +35,7 @@ func New(log *logrus.Entry, cs *api.OpenShiftManagedCluster, initClients bool) (
 		return v17.New(log, cs, initClients)
 	case "v18.0":
 		return v18.New(log, cs, initClients)
-	case "v19.0":
+	case "v19.0", "v19.1":
 		return v19.New(log, cs, initClients)
 	}
 
@@ -58,7 +58,7 @@ func AssetNames(cs *api.OpenShiftManagedCluster) ([]string, error) {
 		return v17.AssetNames(), nil
 	case "v18.0":
 		return v18.AssetNames(), nil
-	case "v19.0":
+	case "v19.0", "v19.1":
 		return v19.AssetNames(), nil
 	}
 
@@ -77,7 +77,7 @@ func Asset(cs *api.OpenShiftManagedCluster, name string) ([]byte, error) {
 		return v17.Asset(name)
 	case "v18.0":
 		return v18.Asset(name)
-	case "v19.0":
+	case "v19.0", "v19.1":
 		return v19.Asset(name)
 	}
 

--- a/pluginconfig/pluginconfig-311.yaml
+++ b/pluginconfig/pluginconfig-311.yaml
@@ -179,14 +179,14 @@ versions:
       genevaTDAgent: osarpint.azurecr.io/acs/td-agent:master.20190228.1
       logAnalyticsAgent: mcr.microsoft.com/azuremonitor/containerinsights/ciprod:ciprod07152020
       metricsServer: registry.access.redhat.com/openshift3/ose-metrics-server:v3.11.232
-      azureControllers: osarpint.azurecr.io/openshift-on-azure/azure:v19.0.1
-      aroAdmissionController: osarpint.azurecr.io/openshift-on-azure/azure:v19.0.1
-      canary: osarpint.azurecr.io/openshift-on-azure/azure:v19.0.1
-      etcdBackup: osarpint.azurecr.io/openshift-on-azure/azure:v19.0.1
-      metricsBridge: osarpint.azurecr.io/openshift-on-azure/azure:v19.0.1
-      startup: osarpint.azurecr.io/openshift-on-azure/azure:v19.0.1
-      sync: osarpint.azurecr.io/openshift-on-azure/azure:v19.0.1
-      tlsProxy: osarpint.azurecr.io/openshift-on-azure/azure:v19.0.1
+      azureControllers: osarpint.azurecr.io/openshift-on-azure/azure:v19.1
+      aroAdmissionController: osarpint.azurecr.io/openshift-on-azure/azure:v19.1
+      canary: osarpint.azurecr.io/openshift-on-azure/azure:v19.1
+      etcdBackup: osarpint.azurecr.io/openshift-on-azure/azure:v19.1
+      metricsBridge: osarpint.azurecr.io/openshift-on-azure/azure:v19.1
+      startup: osarpint.azurecr.io/openshift-on-azure/azure:v19.1
+      sync: osarpint.azurecr.io/openshift-on-azure/azure:v19.1
+      tlsProxy: osarpint.azurecr.io/openshift-on-azure/azure:v19.1
 ## certificates, used to authenticate to external systems
 ## Red Hat CDN client certificates
 #packageRepository:

--- a/pluginconfig/pluginconfig-311.yaml
+++ b/pluginconfig/pluginconfig-311.yaml
@@ -2,7 +2,7 @@
 ## Plugin config template.
 ## This template file is manually curated for the particular OSA version
 ##
-pluginVersion: v19.0
+pluginVersion: v19.1
 ## List of RPM packages that fix security issues
 securityPatchPackages: []
 ## Openshift component logging levels
@@ -144,7 +144,7 @@ versions:
       startup: osarpint.azurecr.io/openshift-on-azure/azure:v17.0
       sync: osarpint.azurecr.io/openshift-on-azure/azure:v17.0
       tlsProxy: osarpint.azurecr.io/openshift-on-azure/azure:v17.0
-  v19.0:
+  v19.1:
     imageOffer: osa
     imagePublisher: redhat
     imageSku: osa_311


### PR DESCRIPTION
```release-note
NONE
```

Needs to be merged after #2324 and #2322 and a v19.1 container image gets built so I can just update the pluginconfig.

I'm being a teeny bit fast and loose with the pluginconfig changes because v19.0 is never going to get deployed to production.

/hold